### PR TITLE
Fixing reading WEBPACK_DEV_URL from config

### DIFF
--- a/webpack/dev-config.js
+++ b/webpack/dev-config.js
@@ -6,7 +6,7 @@ const vars = require('postcss-simple-vars');
 const autoprefixer = require('autoprefixer');
 
 const conf = require('../src/server/configure.js');
-const WEBPACK_DEV_URL = conf.get('SERVER:WEBPACK_DEV_URL');
+const WEBPACK_DEV_URL = conf.get('WEBPACK_DEV_URL');
 
 const sharedVars = require('../src/common/style/variables');
 


### PR DESCRIPTION
WEBPACK_DEV_URL was returned as false resulting in invalid assets URLs.