### PR TITLE
GitHub repository input component

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "expect": "^1.20.2",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
+    "flux-standard-action": "^1.0.0",
     "images-require-hook": "^1.0.3",
     "mocha": "^3.1.2",
     "nock": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "normalize.css": "^5.0.0",
     "oauth": "^0.9.14",
     "qs": "^6.3.0",
+    "parse-github-url": "^0.3.2",
     "raven": "^0.12.3",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -42,11 +42,8 @@ export function verifyGitHubRepository(repository) {
         payload: gitHubRepo.repo
       });
 
-      return fetch(`https://api.github.com/repos/${repo}`)
+      return fetch(`https://api.github.com/repos/${repo}/contents/snapcraft.yaml`)
         .then(checkStatus)
-        // TODO:
-        //.then(response => response.json())
-        // use json.clone_url from response instead of building our own?
         .then(() => dispatch(verifyGitHubRepositorySuccess(`https://github.com/${repo}.git`)))
         .catch(error => dispatch(verifyGitHubRepositoryError(error)));
     } else {

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -1,44 +1,14 @@
 import 'isomorphic-fetch';
-import parseGitHubUrl from 'parse-github-url';
 
-export const CHANGE_REPOSITORY_INPUT = 'CHANGE_REPOSITORY_INPUT';
-export const UPDATE_STATUS_MESSAGE = 'UPDATE_STATUS_MESSAGE';
 export const SET_GITHUB_REPOSITORY = 'SET_GITHUB_REPOSITORY';
 export const VERIFY_GITHUB_REPOSITORY = 'VERIFY_GITHUB_REPOSITORY';
 export const VERIFY_GITHUB_REPOSITORY_SUCCESS = 'VERIFY_GITHUB_REPOSITORY_SUCCESS';
 export const VERIFY_GITHUB_REPOSITORY_ERROR = 'VERIFY_GITHUB_REPOSITORY_ERROR';
 
-export function updateInputValue(value) {
-  return (dispatch) => {
-    dispatch(changeRepositoryInput(value));
-    dispatch(validateGitHubRepository(value));
-  };
-}
-
-export function changeRepositoryInput(value) {
-  return {
-    type: CHANGE_REPOSITORY_INPUT,
-    payload: value
-  };
-}
-
-export function setGitHubRepository(repository) {
+export function setGitHubRepository(value) {
   return {
     type: SET_GITHUB_REPOSITORY,
-    payload: repository
-  };
-}
-
-export function validateGitHubRepository(repository) {
-  return (dispatch) => {
-    const gitHubRepo = parseGitHubUrl(repository);
-    const repo = gitHubRepo ? gitHubRepo.repo : null;
-
-    dispatch(setGitHubRepository(repo));
-
-    if (!repo) {
-      dispatch(verifyGitHubRepositoryError(new Error('Invalid repository URL.')));
-    }
+    payload: value
   };
 }
 

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -1,0 +1,72 @@
+import 'isomorphic-fetch';
+import parseGitHubUrl from 'parse-github-url';
+
+export const CHANGE_REPOSITORY_INPUT = 'CHANGE_REPOSITORY_INPUT';
+export const UPDATE_STATUS_MESSAGE = 'UPDATE_STATUS_MESSAGE';
+export const VERIFY_GITHUB_REPOSITORY = 'VERIFY_GITHUB_REPOSITORY';
+export const VERIFY_GITHUB_REPOSITORY_SUCCESS = 'VERIFY_GITHUB_REPOSITORY_SUCCESS';
+export const VERIFY_GITHUB_REPOSITORY_ERROR = 'VERIFY_GITHUB_REPOSITORY_ERROR';
+
+export function changeRepositoryInput(value) {
+  return {
+    type: CHANGE_REPOSITORY_INPUT,
+    payload: value
+  };
+}
+
+export function updateStatusMessage(message) {
+  return {
+    type: UPDATE_STATUS_MESSAGE,
+    payload: message
+  };
+}
+
+function checkStatus(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  } else {
+    const error = new Error(response.statusText);
+    error.response = response;
+    throw error;
+  }
+}
+
+export function verifyGitHubRepository(repository) {
+  return (dispatch) => {
+    const gitHubRepo = parseGitHubUrl(repository);
+    const repo = gitHubRepo ? gitHubRepo.repo : null;
+
+    if (repo) {
+      dispatch({
+        type: VERIFY_GITHUB_REPOSITORY,
+        payload: gitHubRepo.repo
+      });
+
+      return fetch(`https://api.github.com/repos/${repo}`)
+        .then(checkStatus)
+        // TODO:
+        //.then(response => response.json())
+        // use json.clone_url from response instead of building our own?
+        .then(() => dispatch(verifyGitHubRepositorySuccess(`https://github.com/${repo}.git`)))
+        .catch(error => dispatch(verifyGitHubRepositoryError(error)));
+    } else {
+      // TODO: above we return promise, here nothing - inconsistent and harder to test
+      dispatch(verifyGitHubRepositoryError(new Error('Invalid repository URL.')));
+    }
+  };
+}
+
+export function verifyGitHubRepositorySuccess(repositoryUrl) {
+  return {
+    type: VERIFY_GITHUB_REPOSITORY_SUCCESS,
+    payload: repositoryUrl
+  };
+}
+
+export function verifyGitHubRepositoryError(error) {
+  return {
+    type: VERIFY_GITHUB_REPOSITORY_ERROR,
+    payload: error,
+    error: true
+  };
+}

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -30,14 +30,16 @@ export function setGitHubRepository(repository) {
 }
 
 export function validateGitHubRepository(repository) {
-  const gitHubRepo = parseGitHubUrl(repository);
-  const repo = gitHubRepo ? gitHubRepo.repo : null;
+  return (dispatch) => {
+    const gitHubRepo = parseGitHubUrl(repository);
+    const repo = gitHubRepo ? gitHubRepo.repo : null;
 
-  if (repo) {
-    return setGitHubRepository(repo);
-  } else {
-    return verifyGitHubRepositoryError(new Error('Invalid repository URL.'));
-  }
+    dispatch(setGitHubRepository(repo));
+
+    if (!repo) {
+      dispatch(verifyGitHubRepositoryError(new Error('Invalid repository URL.')));
+    }
+  };
 }
 
 function checkStatus(response) {

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+
+import parseGitHubUrl from 'parse-github-url';
+
+export class RepositoryInput extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      message: '',
+      repository: null,
+      repositoryInput: ''
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <label>Repository URL:</label>
+        <input type='text' value={this.state.repositoryInput} onChange={this.onInputChange.bind(this)} />
+        <button onClick={this.onButtonClick.bind(this)}>Parse</button>
+        <div>
+          {this.state.message}
+        </div>
+      </div>
+    );
+  }
+
+  onInputChange(event) {
+    this.setState({
+      repositoryInput: event.target.value
+    });
+  }
+
+  onButtonClick() {
+    const gitHubRepo = parseGitHubUrl(this.state.repositoryInput);
+    const repo = gitHubRepo ? gitHubRepo.repo : null;
+    let message;
+
+    if (repo) {
+      let repoUrl = `https://github.com/${repo}.git`;
+      message = <span>Repository: {repo}, URL: <a href={repoUrl}>{repoUrl}</a></span>;
+    } else {
+      message = 'Invalid repository URL';
+    }
+
+    this.setState({
+      message: message
+    });
+  }
+}
+
+export default RepositoryInput;

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -17,14 +17,16 @@ export class RepositoryInput extends Component {
     const input = this.props.repositoryInput;
     let message;
 
-    if (!input.repository) {
-      message = 'Invalid repository URL.';
-    } else if (input.repository && input.isFetching) {
+    if (input.repository && input.isFetching) {
       message = `Verifying ${input.repository} on GitHub...`;
     } else if (input.success && input.repositoryUrl) {
-      message = `Repository ${input.repository} is valid.`;
-    } else if (input.errors) {
-      message = `Repository ${input.repository} is invalid.`;
+      message = `Repository ${input.repository} contains snapcraft project and can be built.`;
+    } else if (input.error) {
+      if (input.repository) {
+        message = `Repository ${input.repository} is doesn't exist, is not public or doesn't contain snapcraft.yaml file.`;
+      } else {
+        message = 'Repository URL or name is invalid.';
+      }
     }
 
     return message;

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -18,14 +18,14 @@ export class RepositoryInput extends Component {
     let message;
 
     if (input.inputValue.length > 2 && !input.repository) {
-      message = 'Repository URL or name is invalid.';
+      message = '❌ Repository URL or name is invalid.';
     } else if (input.repository && input.isFetching) {
-      message = `Verifying ${input.repository} on GitHub...`;
+      message = `🔍 Verifying ${input.repository} on GitHub...`;
     } else if (input.success && input.repositoryUrl) {
-      message = `Repository ${input.repository} contains snapcraft project and can be built.`;
+      message = `✅ Repository ${input.repository} contains snapcraft project and can be built.`;
     } else if (input.error) {
       if (input.repository) {
-        message = `Repository ${input.repository} is doesn't exist, is not public or doesn't contain snapcraft.yaml file.`;
+        message = `❌ Repository ${input.repository} is doesn't exist, is not public or doesn't contain snapcraft.yaml file.`;
       }
     }
 

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -4,7 +4,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import {
-  updateInputValue,
+  setGitHubRepository,
   verifyGitHubRepository
 } from '../../actions/repository-input';
 
@@ -17,15 +17,15 @@ export class RepositoryInput extends Component {
     const input = this.props.repositoryInput;
     let message;
 
-    if (input.repository && input.isFetching) {
+    if (input.inputValue.length > 2 && !input.repository) {
+      message = 'Repository URL or name is invalid.';
+    } else if (input.repository && input.isFetching) {
       message = `Verifying ${input.repository} on GitHub...`;
     } else if (input.success && input.repositoryUrl) {
       message = `Repository ${input.repository} contains snapcraft project and can be built.`;
     } else if (input.error) {
       if (input.repository) {
         message = `Repository ${input.repository} is doesn't exist, is not public or doesn't contain snapcraft.yaml file.`;
-      } else {
-        message = 'Repository URL or name is invalid.';
       }
     }
 
@@ -33,11 +33,13 @@ export class RepositoryInput extends Component {
   }
 
   render() {
+    const isValid = !!this.props.repositoryInput.repository;
+
     return (
       <form onSubmit={this.onSubmit.bind(this)}>
         <label>Repository URL:</label>
         <input type='text' value={this.props.repositoryInput.inputValue} onChange={this.onInputChange.bind(this)} />
-        <button type='submit'>Parse</button>
+        <button type='submit' disabled={!isValid}>Verify</button>
         <div>
           {this.getStatusMessage()}
         </div>
@@ -46,11 +48,15 @@ export class RepositoryInput extends Component {
   }
 
   onInputChange(event) {
-    this.props.dispatch(updateInputValue(event.target.value));
+    this.props.dispatch(setGitHubRepository(event.target.value));
   }
 
   onSubmit(event) {
-    this.props.dispatch(verifyGitHubRepository(this.props.repositoryInput.inputValue));
+    const { repository } = this.props.repositoryInput;
+
+    if (repository) {
+      this.props.dispatch(verifyGitHubRepository(repository));
+    }
     event.preventDefault();
   }
 }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -1,3 +1,5 @@
+import 'isomorphic-fetch';
+
 import React, { Component } from 'react';
 
 import parseGitHubUrl from 'parse-github-url';
@@ -39,7 +41,32 @@ export class RepositoryInput extends Component {
 
     if (repo) {
       let repoUrl = `https://github.com/${repo}.git`;
+      let apiUrl = `https://api.github.com/repos/${repo}`;
+
       message = <span>Repository: {repo}, URL: <a href={repoUrl}>{repoUrl}</a></span>;
+
+      let self = this;
+      fetch(apiUrl)
+        .then((response) => {
+          if (response.status >= 200 && response.status < 300) {
+            return response.json();
+          } else {
+            const error = new Error(response.statusText);
+            error.response = response;
+            throw error;
+          }
+        })
+        .then(() => {
+          self.setState({
+            message: <span>{this.state.message}  [exists on GitHub]</span>
+          });
+        })
+        .catch((errors) => {
+          self.setState({
+            message: `Repository ${repo} doesn't exist (${errors})`
+          });
+        });
+
     } else {
       message = 'Invalid repository URL';
     }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -34,14 +34,14 @@ export class RepositoryInput extends Component {
 
   render() {
     return (
-      <div>
+      <form onSubmit={this.onSubmit.bind(this)}>
         <label>Repository URL:</label>
         <input type='text' value={this.props.repositoryInput.inputValue} onChange={this.onInputChange.bind(this)} />
-        <button onClick={this.onButtonClick.bind(this)}>Parse</button>
+        <button type='submit'>Parse</button>
         <div>
           {this.getStatusMessage()}
         </div>
-      </div>
+      </form>
     );
   }
 
@@ -49,8 +49,9 @@ export class RepositoryInput extends Component {
     this.props.dispatch(updateInputValue(event.target.value));
   }
 
-  onButtonClick() {
+  onSubmit(event) {
     this.props.dispatch(verifyGitHubRepository(this.props.repositoryInput.inputValue));
+    event.preventDefault();
   }
 }
 

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -19,17 +19,11 @@ export class RepositoryInput extends Component {
 
     if (!input.repository) {
       message = 'Invalid repository URL.';
-    }
-
-    if (input.repository && input.isFetching) {
+    } else if (input.repository && input.isFetching) {
       message = `Verifying ${input.repository} on GitHub...`;
-    }
-
-    if (input.success && input.repositoryUrl) {
+    } else if (input.success && input.repositoryUrl) {
       message = `Repository ${input.repository} is valid.`;
-    }
-
-    if (input.errors) {
+    } else if (input.errors) {
       message = `Repository ${input.repository} is invalid.`;
     }
 

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -4,7 +4,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import {
-  changeRepositoryInput,
+  updateInputValue,
   verifyGitHubRepository
 } from '../../actions/repository-input';
 
@@ -44,7 +44,7 @@ export class RepositoryInput extends Component {
   }
 
   onInputChange(event) {
-    this.props.dispatch(changeRepositoryInput(event.target.value));
+    this.props.dispatch(updateInputValue(event.target.value));
   }
 
   onButtonClick() {

--- a/src/common/containers/home.js
+++ b/src/common/containers/home.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Helmet from 'react-helmet';
 
 import HelloWorld from '../components/hello-world';
+import RepositoryInput from '../components/repository-input';
 
 import styles from './container.css';
 
@@ -14,6 +15,7 @@ export default class Home extends Component {
           title='Home'
         />
         <HelloWorld />
+        <RepositoryInput />
       </div>
     );
   }

--- a/src/common/reducers/index.js
+++ b/src/common/reducers/index.js
@@ -1,7 +1,10 @@
 import { routerReducer } from 'react-router-redux';
 import { combineReducers } from 'redux';
 
+import * as repositoryInput from '../reducers/repository-input';
+
 const rootReducer = combineReducers({
+  ...repositoryInput,
   routing: routerReducer
 });
 

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -6,13 +6,15 @@ export function repositoryInput(state = {
   repository: null,
   repositoryUrl: null,
   success: false,
-  errors: false
+  error: false
 }, action) {
   switch(action.type) {
     case ActionTypes.CHANGE_REPOSITORY_INPUT:
       return {
         ...state,
-        inputValue: action.payload
+        inputValue: action.payload,
+        success: false,
+        error: false
       };
     case ActionTypes.SET_GITHUB_REPOSITORY:
       return {
@@ -29,7 +31,7 @@ export function repositoryInput(state = {
         ...state,
         isFetching: false,
         success: true,
-        errors: false,
+        error: false,
         repositoryUrl: action.payload
       };
     case ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR:
@@ -37,7 +39,7 @@ export function repositoryInput(state = {
         ...state,
         isFetching: false,
         success: false,
-        errors: action.payload
+        error: action.payload
       };
     default:
       return state;

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -5,7 +5,6 @@ export function repositoryInput(state = {
   inputValue: '',
   repository: null,
   repositoryUrl: null,
-  statusMessage: '',
   success: false,
   errors: false
 }, action) {
@@ -15,16 +14,15 @@ export function repositoryInput(state = {
         ...state,
         inputValue: action.payload
       };
-    case ActionTypes.UPDATE_STATUS_MESSAGE:
+    case ActionTypes.SET_GITHUB_REPOSITORY:
       return {
         ...state,
-        statusMessage: action.payload
+        repository: action.payload
       };
     case ActionTypes.VERIFY_GITHUB_REPOSITORY:
       return {
         ...state,
-        isFetching: true,
-        repository: action.payload
+        isFetching: true
       };
     case ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS:
       return {

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -1,4 +1,10 @@
 import * as ActionTypes from '../actions/repository-input';
+import parseGitHubUrl from 'parse-github-url';
+
+function parseRepository(input) {
+  const gitHubRepo = parseGitHubUrl(input);
+  return gitHubRepo ? gitHubRepo.repo : null;
+}
 
 export function repositoryInput(state = {
   isFetching: false,
@@ -9,17 +15,13 @@ export function repositoryInput(state = {
   error: false
 }, action) {
   switch(action.type) {
-    case ActionTypes.CHANGE_REPOSITORY_INPUT:
-      return {
-        ...state,
-        inputValue: action.payload,
-        success: false,
-        error: false
-      };
     case ActionTypes.SET_GITHUB_REPOSITORY:
       return {
         ...state,
-        repository: action.payload
+        inputValue: action.payload,
+        repository: parseRepository(action.payload),
+        success: false,
+        error: false
       };
     case ActionTypes.VERIFY_GITHUB_REPOSITORY:
       return {

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -31,6 +31,7 @@ export function repositoryInput(state = {
         ...state,
         isFetching: false,
         success: true,
+        errors: false,
         repositoryUrl: action.payload
       };
     case ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR:

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -1,0 +1,46 @@
+import * as ActionTypes from '../actions/repository-input';
+
+export function repositoryInput(state = {
+  isFetching: false,
+  inputValue: '',
+  repository: null,
+  repositoryUrl: null,
+  statusMessage: '',
+  success: false,
+  errors: false
+}, action) {
+  switch(action.type) {
+    case ActionTypes.CHANGE_REPOSITORY_INPUT:
+      return {
+        ...state,
+        inputValue: action.payload
+      };
+    case ActionTypes.UPDATE_STATUS_MESSAGE:
+      return {
+        ...state,
+        statusMessage: action.payload
+      };
+    case ActionTypes.VERIFY_GITHUB_REPOSITORY:
+      return {
+        ...state,
+        isFetching: true,
+        repository: action.payload
+      };
+    case ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS:
+      return {
+        ...state,
+        isFetching: false,
+        success: true,
+        repositoryUrl: action.payload
+      };
+    case ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR:
+      return {
+        ...state,
+        isFetching: false,
+        success: false,
+        errors: action.payload
+      };
+    default:
+      return state;
+  }
+}

--- a/test/unit/helpers.js
+++ b/test/unit/helpers.js
@@ -1,0 +1,16 @@
+import expect from 'expect';
+
+// Custom assertions
+expect.extend({
+  toHaveActionOfType(expected) {
+    expect.assert(
+      this.actual.filter((action) => {
+        return action.type === expected;
+      }).length > 0,
+      'to have action %s',
+      expected
+    );
+
+    return this;
+  }
+});

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -1,0 +1,1 @@
+import './helpers';

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -98,10 +98,6 @@ describe('repository input actions', () => {
         store.dispatch(action);
         expect(store.getActions()).toInclude(expectedAction);
       });
-
-      it('should create a valid flux standard action', () => {
-        expect(isFSA(action)).toBe(true);
-      });
     });
 
     context('on invalid repository input', () => {
@@ -116,10 +112,6 @@ describe('repository input actions', () => {
         expect(store.getActions()).toHaveActionOfType(
           ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR
         );
-      });
-
-      it('should create a valid flux standard action', () => {
-        expect(isFSA(action)).toBe(true);
       });
     });
   });

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -1,0 +1,182 @@
+import expect from 'expect';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import nock from 'nock';
+import { isFSA } from 'flux-standard-action';
+
+import {
+  changeRepositoryInput,
+  updateStatusMessage,
+  verifyGitHubRepository,
+  verifyGitHubRepositorySuccess,
+  verifyGitHubRepositoryError
+} from '../../../../../src/common/actions/repository-input';
+import * as ActionTypes from '../../../../../src/common/actions/repository-input';
+
+const middlewares = [ thunk ];
+const mockStore = configureMockStore(middlewares);
+
+describe('repository input actions', () => {
+  const initialState = {
+    isFetching: false,
+    inputValue: '',
+    repository: null,
+    repositoryUrl: null,
+    statusMessage: '',
+    success: false,
+    errors: false
+  };
+
+  let store;
+  let action;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+  });
+
+  context('changeRepositoryInput', () => {
+    let payload = 'foo input';
+
+    beforeEach(() => {
+      action = changeRepositoryInput(payload);
+    });
+
+    it('should create an action to change repository input value', () => {
+      const expectedAction = {
+        type: ActionTypes.CHANGE_REPOSITORY_INPUT,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('updateStatusMessage', () => {
+    let payload = 'test status message';
+
+    beforeEach(() => {
+      action = updateStatusMessage(payload);
+    });
+
+    it('should create an action to update status message', () => {
+      const expectedAction = {
+        type: ActionTypes.UPDATE_STATUS_MESSAGE,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('verifyGitHubRepositorySuccess', () => {
+    let payload = 'http://github.com/foo/bar.git';
+
+    beforeEach(() => {
+      action = verifyGitHubRepositorySuccess(payload);
+    });
+
+    it('should create an action to save github repo url on success', () => {
+      const expectedAction = {
+        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('verifyGitHubRepositoryError', () => {
+    let payload = 'Something went wrong!';
+
+    beforeEach(() => {
+      action = verifyGitHubRepositoryError(payload);
+    });
+
+    it('should create an action to store github repo error on failure', () => {
+      const expectedAction = {
+        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR,
+        error: true,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('verifyGitHubRepository', () => {
+    let scope;
+
+    beforeEach(() => {
+      scope = nock('https://api.github.com');
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should save GitHub repo on successful verification', () => {
+      scope.get('/repos/foo/bar')
+        .reply(200, {
+          'id': 123456,
+          'name': 'bar',
+          'full_name': 'foo/bar',
+          'owner': {
+            'login': 'bar',
+          },
+          'clone_url': 'https://github.com/foo/bar.git'
+        });
+
+      return store.dispatch(verifyGitHubRepository('foo/bar'))
+        .then(() => {
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS
+          );
+        });
+    });
+
+    it('should store error on GitHub verification failure', () => {
+      scope.get('/repos/foo/bar')
+        .reply(404, {
+          'message': 'Not Found',
+          'documentation_url': 'https://developer.github.com/v3'
+        });
+
+      return store.dispatch(verifyGitHubRepository('foo/bar'))
+        .then(() => {
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR
+          );
+        });
+    });
+
+    it('should fail on invalid input', () => {
+      store.dispatch(verifyGitHubRepository('invalid input'));
+      expect(store.getActions()).toHaveActionOfType(
+        ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR
+      );
+    });
+
+
+  });
+
+});

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -5,10 +5,7 @@ import nock from 'nock';
 import { isFSA } from 'flux-standard-action';
 
 import {
-  updateInputValue,
-  changeRepositoryInput,
   setGitHubRepository,
-  validateGitHubRepository,
   verifyGitHubRepository,
   verifyGitHubRepositorySuccess,
   verifyGitHubRepositoryError
@@ -26,7 +23,7 @@ describe('repository input actions', () => {
     repositoryUrl: null,
     statusMessage: '',
     success: false,
-    errors: false
+    error: false
   };
 
   let store;
@@ -34,28 +31,6 @@ describe('repository input actions', () => {
 
   beforeEach(() => {
     store = mockStore(initialState);
-  });
-
-  context('changeRepositoryInput', () => {
-    let payload = 'foo input';
-
-    beforeEach(() => {
-      action = changeRepositoryInput(payload);
-    });
-
-    it('should create an action to change repository input value', () => {
-      const expectedAction = {
-        type: ActionTypes.CHANGE_REPOSITORY_INPUT,
-        payload
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('should create a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
   });
 
   context('setGitHubRepository', () => {
@@ -77,64 +52,6 @@ describe('repository input actions', () => {
 
     it('should create a valid flux standard action', () => {
       expect(isFSA(action)).toBe(true);
-    });
-  });
-
-  context('validateGitHubRepository', () => {
-
-    context('on valid repository input', () => {
-      let payload = 'foo/bar';
-
-      beforeEach(() => {
-        action = validateGitHubRepository(payload);
-      });
-
-      it('should save an action to change repository input value', () => {
-        const expectedAction = {
-          type: ActionTypes.SET_GITHUB_REPOSITORY,
-          payload
-        };
-
-        store.dispatch(action);
-        expect(store.getActions()).toInclude(expectedAction);
-      });
-    });
-
-    context('on invalid repository input', () => {
-      let payload = 'foo bar';
-
-      beforeEach(() => {
-        action = validateGitHubRepository(payload);
-      });
-
-      it('should dispatch VERIFY_GITHUB_REPOSITORY_ERROR action', () => {
-        store.dispatch(action);
-        expect(store.getActions()).toHaveActionOfType(
-          ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR
-        );
-      });
-    });
-  });
-
-  context('updateInputValue', () => {
-    let payload = 'foo/bar';
-
-    beforeEach(() => {
-      action = updateInputValue(payload);
-    });
-
-    it('should dispatch CHANGE_REPOSITORY_INPUT action', () => {
-      store.dispatch(action);
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.CHANGE_REPOSITORY_INPUT
-      );
-    });
-
-    it('should dispatch SET_GITHUB_REPOSITORY action', () => {
-      store.dispatch(action);
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.SET_GITHUB_REPOSITORY
-      );
     });
   });
 

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -5,8 +5,10 @@ import nock from 'nock';
 import { isFSA } from 'flux-standard-action';
 
 import {
+  updateInputValue,
   changeRepositoryInput,
-  updateStatusMessage,
+  setGitHubRepository,
+  validateGitHubRepository,
   verifyGitHubRepository,
   verifyGitHubRepositorySuccess,
   verifyGitHubRepositoryError
@@ -56,16 +58,16 @@ describe('repository input actions', () => {
     });
   });
 
-  context('updateStatusMessage', () => {
-    let payload = 'test status message';
+  context('setGitHubRepository', () => {
+    let payload = 'foo/bar';
 
     beforeEach(() => {
-      action = updateStatusMessage(payload);
+      action = setGitHubRepository(payload);
     });
 
-    it('should create an action to update status message', () => {
+    it('should create an action to update repository name', () => {
       const expectedAction = {
-        type: ActionTypes.UPDATE_STATUS_MESSAGE,
+        type: ActionTypes.SET_GITHUB_REPOSITORY,
         payload
       };
 
@@ -75,6 +77,72 @@ describe('repository input actions', () => {
 
     it('should create a valid flux standard action', () => {
       expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('validateGitHubRepository', () => {
+
+    context('on valid repository input', () => {
+      let payload = 'foo/bar';
+
+      beforeEach(() => {
+        action = validateGitHubRepository(payload);
+      });
+
+      it('should save an action to change repository input value', () => {
+        const expectedAction = {
+          type: ActionTypes.SET_GITHUB_REPOSITORY,
+          payload
+        };
+
+        store.dispatch(action);
+        expect(store.getActions()).toInclude(expectedAction);
+      });
+
+      it('should create a valid flux standard action', () => {
+        expect(isFSA(action)).toBe(true);
+      });
+    });
+
+    context('on invalid repository input', () => {
+      let payload = 'foo bar';
+
+      beforeEach(() => {
+        action = validateGitHubRepository(payload);
+      });
+
+      it('should dispatch VERIFY_GITHUB_REPOSITORY_ERROR action', () => {
+        store.dispatch(action);
+        expect(store.getActions()).toHaveActionOfType(
+          ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR
+        );
+      });
+
+      it('should create a valid flux standard action', () => {
+        expect(isFSA(action)).toBe(true);
+      });
+    });
+  });
+
+  context('updateInputValue', () => {
+    let payload = 'foo/bar';
+
+    beforeEach(() => {
+      action = updateInputValue(payload);
+    });
+
+    it('should dispatch CHANGE_REPOSITORY_INPUT action', () => {
+      store.dispatch(action);
+      expect(store.getActions()).toHaveActionOfType(
+        ActionTypes.CHANGE_REPOSITORY_INPUT
+      );
+    });
+
+    it('should dispatch SET_GITHUB_REPOSITORY action', () => {
+      store.dispatch(action);
+      expect(store.getActions()).toHaveActionOfType(
+        ActionTypes.SET_GITHUB_REPOSITORY
+      );
     });
   });
 
@@ -162,14 +230,6 @@ describe('repository input actions', () => {
           );
         });
     });
-
-    it('should fail on invalid input', () => {
-      store.dispatch(verifyGitHubRepository('invalid input'));
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR
-      );
-    });
-
 
   });
 

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -135,15 +135,9 @@ describe('repository input actions', () => {
     });
 
     it('should save GitHub repo on successful verification', () => {
-      scope.get('/repos/foo/bar')
+      scope.get('/repos/foo/bar/contents/snapcraft.yaml')
         .reply(200, {
-          'id': 123456,
-          'name': 'bar',
-          'full_name': 'foo/bar',
-          'owner': {
-            'login': 'bar',
-          },
-          'clone_url': 'https://github.com/foo/bar.git'
+          'name': 'snapcraft.yaml'
         });
 
       return store.dispatch(verifyGitHubRepository('foo/bar'))
@@ -155,7 +149,7 @@ describe('repository input actions', () => {
     });
 
     it('should store error on GitHub verification failure', () => {
-      scope.get('/repos/foo/bar')
+      scope.get('/repos/foo/bar/contents/snapcraft.yaml')
         .reply(404, {
           'message': 'Not Found',
           'documentation_url': 'https://developer.github.com/v3'

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -9,7 +9,6 @@ describe('repositoryInput reducers', () => {
     inputValue: '',
     repository: null,
     repositoryUrl: null,
-    statusMessage: '',
     success: false,
     errors: false
   };
@@ -30,19 +29,19 @@ describe('repositoryInput reducers', () => {
     });
   });
 
-  it('should update status message', () => {
+  it('should save validated repository name', () => {
     const action = {
-      type: ActionTypes.UPDATE_STATUS_MESSAGE,
-      payload: 'dummy message here'
+      type: ActionTypes.SET_GITHUB_REPOSITORY,
+      payload: 'foo/bar'
     };
 
     expect(repositoryInput(initialState, action)).toEqual({
       ...initialState,
-      statusMessage: 'dummy message here'
+      repository: 'foo/bar'
     });
   });
 
-  it('should store and verify repository id (user/name)', () => {
+  it('should store fetching status when repository is verified via GH API', () => {
     const action = {
       type: ActionTypes.VERIFY_GITHUB_REPOSITORY,
       payload: 'dummy/repo'
@@ -50,8 +49,7 @@ describe('repositoryInput reducers', () => {
 
     expect(repositoryInput(initialState, action)).toEqual({
       ...initialState,
-      isFetching: true,
-      repository: 'dummy/repo'
+      isFetching: true
     });
   });
 

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -75,6 +75,21 @@ describe('repositoryInput reducers', () => {
     });
   });
 
+  it('should clean errors on success', () => {
+    const state = {
+      ...initialState,
+      repository: 'dummy/repo',
+      errors: 'Previous error'
+    };
+
+    const action = {
+      type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
+      payload: 'http://github.com/dummy/repo.git'
+    };
+
+    expect(repositoryInput(state, action).errors).toBe(false);
+  });
+
   it('should handle verify repo failure', () => {
     const state = {
       ...initialState,

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -10,101 +10,131 @@ describe('repositoryInput reducers', () => {
     repository: null,
     repositoryUrl: null,
     success: false,
-    errors: false
+    error: false
   };
 
   it('should return the initial state', () => {
     expect(repositoryInput(undefined, {})).toEqual(initialState);
   });
 
-  it('should change repository input value', () => {
-    const action = {
-      type: ActionTypes.CHANGE_REPOSITORY_INPUT,
-      payload: 'foo'
-    };
+  context('CHANGE_REPOSITORY_INPUT', () => {
+    let action;
 
-    expect(repositoryInput(initialState, action)).toEqual({
-      ...initialState,
-      inputValue: 'foo'
+    beforeEach(() => {
+      action = {
+        type: ActionTypes.CHANGE_REPOSITORY_INPUT,
+        payload: 'foo'
+      };
+    });
+
+    it('should change repository input value', () => {
+      expect(repositoryInput(initialState, action)).toEqual({
+        ...initialState,
+        inputValue: 'foo'
+      });
+    });
+
+    it('should reset error status', () => {
+      const state = {
+        error: new Error('Test')
+      };
+
+      expect(repositoryInput(state, action).error).toBe(false);
+    });
+
+    it('should reset error status', () => {
+      const state = {
+        success: true
+      };
+
+      expect(repositoryInput(state, action).success).toBe(false);
     });
   });
 
-  it('should save validated repository name', () => {
-    const action = {
-      type: ActionTypes.SET_GITHUB_REPOSITORY,
-      payload: 'foo/bar'
-    };
+  context('SET_GITHUB_REPOSITORY', () => {
+    it('should save validated repository name', () => {
+      const action = {
+        type: ActionTypes.SET_GITHUB_REPOSITORY,
+        payload: 'foo/bar'
+      };
 
-    expect(repositoryInput(initialState, action)).toEqual({
-      ...initialState,
-      repository: 'foo/bar'
+      expect(repositoryInput(initialState, action)).toEqual({
+        ...initialState,
+        repository: 'foo/bar'
+      });
     });
   });
 
-  it('should store fetching status when repository is verified via GH API', () => {
-    const action = {
-      type: ActionTypes.VERIFY_GITHUB_REPOSITORY,
-      payload: 'dummy/repo'
-    };
+  context('VERIFY_GITHUB_REPOSITORY', () => {
+    it('should store fetching status when repository is verified via GH API', () => {
+      const action = {
+        type: ActionTypes.VERIFY_GITHUB_REPOSITORY,
+        payload: 'dummy/repo'
+      };
 
-    expect(repositoryInput(initialState, action)).toEqual({
-      ...initialState,
-      isFetching: true
+      expect(repositoryInput(initialState, action)).toEqual({
+        ...initialState,
+        isFetching: true
+      });
     });
   });
 
-  it('should handle verify repo success', () => {
-    const state = {
-      ...initialState,
-      repository: 'dummy/repo',
-      isFetching: true
-    };
+  context('VERIFY_GITHUB_REPOSITORY_SUCCESS', () => {
+    it('should handle verify repo success', () => {
+      const state = {
+        ...initialState,
+        repository: 'dummy/repo',
+        isFetching: true
+      };
 
-    const action = {
-      type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
-      payload: 'http://github.com/dummy/repo.git'
-    };
+      const action = {
+        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
+        payload: 'http://github.com/dummy/repo.git'
+      };
 
-    expect(repositoryInput(state, action)).toEqual({
-      ...state,
-      isFetching: false,
-      repositoryUrl: 'http://github.com/dummy/repo.git',
-      success: true
+      expect(repositoryInput(state, action)).toEqual({
+        ...state,
+        isFetching: false,
+        repositoryUrl: 'http://github.com/dummy/repo.git',
+        success: true
+      });
+    });
+
+    it('should clean error', () => {
+      const state = {
+        ...initialState,
+        repository: 'dummy/repo',
+        error: new Error('Previous error')
+      };
+
+      const action = {
+        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
+        payload: 'http://github.com/dummy/repo.git'
+      };
+
+      expect(repositoryInput(state, action).error).toBe(false);
     });
   });
 
-  it('should clean errors on success', () => {
-    const state = {
-      ...initialState,
-      repository: 'dummy/repo',
-      errors: 'Previous error'
-    };
+  context('VERIFY_GITHUB_REPOSITORY_ERROR', () => {
+    it('should handle verify repo failure', () => {
+      const state = {
+        ...initialState,
+        repository: 'dummy/repo',
+        isFetching: true
+      };
 
-    const action = {
-      type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
-      payload: 'http://github.com/dummy/repo.git'
-    };
+      const action = {
+        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR,
+        payload: new Error('Something went wrong!')
+      };
 
-    expect(repositoryInput(state, action).errors).toBe(false);
-  });
-
-  it('should handle verify repo failure', () => {
-    const state = {
-      ...initialState,
-      repository: 'dummy/repo',
-      isFetching: true
-    };
-
-    const action = {
-      type: ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR,
-      payload: { error: 'Something went wrong!' }
-    };
-
-    expect(repositoryInput(state, action)).toEqual({
-      ...state,
-      isFetching: false,
-      success: false,
-      errors: { error: 'Something went wrong!' }
+      expect(repositoryInput(state, action)).toEqual({
+        ...state,
+        isFetching: false,
+        success: false,
+        error: action.payload
+      });
     });
   });
 });

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -17,51 +17,68 @@ describe('repositoryInput reducers', () => {
     expect(repositoryInput(undefined, {})).toEqual(initialState);
   });
 
-  context('CHANGE_REPOSITORY_INPUT', () => {
+  context('SET_GITHUB_REPOSITORY', () => {
     let action;
 
     beforeEach(() => {
       action = {
-        type: ActionTypes.CHANGE_REPOSITORY_INPUT,
-        payload: 'foo'
+        type: ActionTypes.SET_GITHUB_REPOSITORY
       };
     });
 
     it('should change repository input value', () => {
-      expect(repositoryInput(initialState, action)).toEqual({
-        ...initialState,
+      action.payload = 'foo';
+
+      expect(repositoryInput(initialState, action)).toInclude({
         inputValue: 'foo'
+      });
+    });
+
+    it('should save repository name for valid user/repo pair', () => {
+      action.payload = 'foo/bar';
+
+      expect(repositoryInput(initialState, action)).toInclude({
+        repository: 'foo/bar'
+      });
+    });
+
+    it('should save repository name for valid repo URL', () => {
+      action.payload = 'http://github.com/foo/bar';
+
+      expect(repositoryInput(initialState, action)).toInclude({
+        repository: 'foo/bar'
+      });
+    });
+
+    it('should clear repository name for invalid input', () => {
+      action.payload = 'foo bar';
+
+      const state = {
+        ...initialState,
+        repository: 'foo/bar'
+      };
+
+      expect(repositoryInput(state, action)).toInclude({
+        repository: null
       });
     });
 
     it('should reset error status', () => {
       const state = {
+        ...initialState,
         error: new Error('Test')
       };
 
       expect(repositoryInput(state, action).error).toBe(false);
     });
 
-    it('should reset error status', () => {
+    it('should reset success status', () => {
       const state = {
+        ...initialState,
         success: true
       };
 
       expect(repositoryInput(state, action).success).toBe(false);
-    });
-  });
-
-  context('SET_GITHUB_REPOSITORY', () => {
-    it('should save validated repository name', () => {
-      const action = {
-        type: ActionTypes.SET_GITHUB_REPOSITORY,
-        payload: 'foo/bar'
-      };
-
-      expect(repositoryInput(initialState, action)).toEqual({
-        ...initialState,
-        repository: 'foo/bar'
-      });
     });
   });
 

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -1,0 +1,97 @@
+import expect from 'expect';
+
+import { repositoryInput } from '../../../../../src/common/reducers/repository-input';
+import * as ActionTypes from '../../../../../src/common/actions/repository-input';
+
+describe('repositoryInput reducers', () => {
+  const initialState = {
+    isFetching: false,
+    inputValue: '',
+    repository: null,
+    repositoryUrl: null,
+    statusMessage: '',
+    success: false,
+    errors: false
+  };
+
+  it('should return the initial state', () => {
+    expect(repositoryInput(undefined, {})).toEqual(initialState);
+  });
+
+  it('should change repository input value', () => {
+    const action = {
+      type: ActionTypes.CHANGE_REPOSITORY_INPUT,
+      payload: 'foo'
+    };
+
+    expect(repositoryInput(initialState, action)).toEqual({
+      ...initialState,
+      inputValue: 'foo'
+    });
+  });
+
+  it('should update status message', () => {
+    const action = {
+      type: ActionTypes.UPDATE_STATUS_MESSAGE,
+      payload: 'dummy message here'
+    };
+
+    expect(repositoryInput(initialState, action)).toEqual({
+      ...initialState,
+      statusMessage: 'dummy message here'
+    });
+  });
+
+  it('should store and verify repository id (user/name)', () => {
+    const action = {
+      type: ActionTypes.VERIFY_GITHUB_REPOSITORY,
+      payload: 'dummy/repo'
+    };
+
+    expect(repositoryInput(initialState, action)).toEqual({
+      ...initialState,
+      isFetching: true,
+      repository: 'dummy/repo'
+    });
+  });
+
+  it('should handle verify repo success', () => {
+    const state = {
+      ...initialState,
+      repository: 'dummy/repo',
+      isFetching: true
+    };
+
+    const action = {
+      type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
+      payload: 'http://github.com/dummy/repo.git'
+    };
+
+    expect(repositoryInput(state, action)).toEqual({
+      ...state,
+      isFetching: false,
+      repositoryUrl: 'http://github.com/dummy/repo.git',
+      success: true
+    });
+  });
+
+  it('should handle verify repo failure', () => {
+    const state = {
+      ...initialState,
+      repository: 'dummy/repo',
+      isFetching: true
+    };
+
+    const action = {
+      type: ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR,
+      payload: { error: 'Something went wrong!' }
+    };
+
+    expect(repositoryInput(state, action)).toEqual({
+      ...state,
+      isFetching: false,
+      success: false,
+      errors: { error: 'Something went wrong!' }
+    });
+  });
+});


### PR DESCRIPTION
### DONE: 

- [x] add simple component
- [x] basic input parsing (to get user/repo pair and repo URL)
- [x] talk to GH API to verify repo existence
- [x] move component state to redux store
- [x] connect store to component, remove component state
- [x] tests of the component

- [x] talk to GH API to verify snapcraft.yaml existence (can be one step with checking repo on GH?)

### TODO (postponed to separate branch)
- better styles / reuse form components from MU
