### PR TITLE
Make development configuration charm-friendly

### DIFF
--- a/charm/reactive/snap-build.py
+++ b/charm/reactive/snap-build.py
@@ -37,6 +37,7 @@ def configure(cache):
                 'memcache_session_secret': memcache_session_secret,
                 'sentry_dsn': sentry_dsn,
             })
+        check_call(['systemctl', 'daemon-reload'])
         check_port('ols.{}.express'.format(service_name()), port())
         set_state('service.configured')
         hookenv.status_set('active', 'systemd unit configured')

--- a/environments/development.env
+++ b/environments/development.env
@@ -1,6 +1,6 @@
 HOST=127.0.0.1
-PORT=3000
-BASE_URL=http://localhost:3000
-WEBPACK_DEV_URL=http://localhost:3001
+PORT=8000
+BASE_URL=http://localhost:8000
+WEBPACK_DEV_URL=http://localhost:8001
 NODE_ENV=development
 LP_API_URL=https://api.staging.launchpad.net

--- a/environments/development.env
+++ b/environments/development.env
@@ -1,4 +1,4 @@
-HOST=127.0.0.1
+HOST=0.0.0.0
 PORT=8000
 BASE_URL=http://localhost:8000
 WEBPACK_DEV_URL=http://localhost:8001


### PR DESCRIPTION
Reload systemd configuration after rendering the unit file, as otherwise
systemd isn't guaranteed to do the right thing on restart.

Change the development listen ports to 8000/8001.  This makes it easier
to make the charm work on all environments (since staging and production
will use 8000).

Make the development server listen on 0.0.0.0, as otherwise it's
effectively impossible to deploy a test development server using juju.
It does mean you have to be a bit careful that you have a firewall in
the way if you're standing up a test service somewhere, but that was
surely the case for other reasons anyway.