### PR TITLE
mirroring commit from mu; don't ship production npm deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ $(DIST):
 	mkdir -p $(DISTDIR)
 	npm install || (cat npm-debug.log && exit 1)
 	npm run build
+	npm install --production || (cat npm-debug.log && exit 1)
 	touch $@
 
 $(PAYLOAD): $(CHARM) $(DIST) version-info build-exclude.txt $(SRC) $(SRC)/* $(SRC_PREQS)


### PR DESCRIPTION
This will delete devDeps from node_modules, reducing churn in staging and production branches and preventing shipping unused code in deployments.