### PR TITLE
Make way for non-session users of memcached

### DIFF
--- a/charm/templates/snap-build_systemd.j2
+++ b/charm/templates/snap-build_systemd.j2
@@ -8,8 +8,8 @@ Description=Build snaps from GitHub repositories
 Type=simple
 Environment='SESSION_SECRET={{ session_secret }}'
 Environment='LOGS_PATH={{ logs_path }}'
-Environment='SESSION_MEMCACHED_HOST={{ cache_hosts | join(",") }}'
-Environment='SESSION_MEMCACHED_SECRET={{ memcache_session_secret }}'
+Environment='MEMCACHED_HOST={{ cache_hosts | join(",") }}'
+Environment='MEMCACHED_SESSION_SECRET={{ memcache_session_secret }}'
 Environment='SENTRY_DSN={{ sentry_dsn }}'
 Environment='LP_API_CONSUMER_KEY={{ lp_api_consumer_key }}'
 Environment='LP_API_TOKEN={{ lp_api_token }}'

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,7 +14,7 @@ If true, set secure session cookies.
 
 The host name of the memcached service.
 
-### MEMCACHED\_SERVICE
+### SESSION\_MEMCACHED\_SERVICE
 
 The secret key for encrypting session data stored in memcached.
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "helmet": "^3.1.0",
     "images-require-hook": "^1.0.3",
     "isomorphic-fetch": "^2.2.1",
+    "memcached": "^2.2.2",
     "nconf": "^0.8.4",
     "nconf-yaml": "^1.0.2",
     "normalize.css": "^5.0.0",

--- a/src/server/helpers/session.js
+++ b/src/server/helpers/session.js
@@ -33,11 +33,12 @@ export default function sessionStorageConfig(config) {
     settings.secret = 'dont-use-me-in-production';
   }
 
-  if(config.get('SESSION_MEMCACHED_HOST') && config.get('SESSION_MEMCACHED_SECRET')) {
+  if(config.get('MEMCACHED_HOST') && config.get('MEMCACHED_SESSION_SECRET')) {
     logger.info('Starting with memcached session store');
     settings.store = new MemcachedStore({
-      hosts: config.get('SESSION_MEMCACHED_HOST').split(','),
-      secret: config.get('SESSION_MEMCACHED_SECRET')
+      hosts: config.get('MEMCACHED_HOST').split(','),
+      prefix: 'session:',
+      secret: config.get('MEMCACHED_SESSION_SECRET')
     });
   } else {
     // TODO: Log memory session store

--- a/src/server/helpers/session.js
+++ b/src/server/helpers/session.js
@@ -34,7 +34,7 @@ export default function sessionStorageConfig(config) {
   }
 
   if(config.get('MEMCACHED_HOST') && config.get('MEMCACHED_SESSION_SECRET')) {
-    logger.info('Starting with memcached session store');
+    logger.info('Starting with memcached store');
     settings.store = new MemcachedStore({
       hosts: config.get('MEMCACHED_HOST').split(','),
       prefix: 'session:',

--- a/test/unit/src/server/helpers/t_session.js
+++ b/test/unit/src/server/helpers/t_session.js
@@ -30,8 +30,8 @@ describe('The session helper', () => {
       let config;
 
       beforeEach(() => {
-        mockConfig.get.withArgs('SESSION_MEMCACHED_HOST').returns('127.0.0.1:8000');
-        mockConfig.get.withArgs('SESSION_MEMCACHED_SECRET').returns('secret');
+        mockConfig.get.withArgs('MEMCACHED_HOST').returns('127.0.0.1:8000');
+        mockConfig.get.withArgs('MEMCACHED_SESSION_SECRET').returns('secret');
         config = sessionStorageConfig(mockConfig);
       });
 
@@ -44,8 +44,8 @@ describe('The session helper', () => {
       let config;
 
       beforeEach(() => {
-        mockConfig.get.withArgs('SESSION_MEMCACHED_HOST').returns(null);
-        mockConfig.get.withArgs('SESSION_MEMCACHED_SECRET').returns(null);
+        mockConfig.get.withArgs('MEMCACHED_HOST').returns(null);
+        mockConfig.get.withArgs('MEMCACHED_SESSION_SECRET').returns(null);
         config = sessionStorageConfig(mockConfig);
       });
 
@@ -70,8 +70,8 @@ describe('The session helper', () => {
 
     context('when session secret config is not set', () => {
       beforeEach(() => {
-        mockConfig.get.withArgs('SESSION_MEMCACHED_HOST').returns(null);
-        mockConfig.get.withArgs('SESSION_MEMCACHED_SECRET').returns(null);
+        mockConfig.get.withArgs('MEMCACHED_HOST').returns(null);
+        mockConfig.get.withArgs('MEMCACHED_SESSION_SECRET').returns(null);
         mockConfig.get.withArgs('SESSION_SECRET').returns(null);
       });
 


### PR DESCRIPTION
We're likely to want to use memcached for other things, such as caching
the GitHub repository URL -> Launchpad snap URL lookup.  Rename some
environment variables to be less session-specific, and add a "session:"
prefix to session-related keys.