### PR TITLE
Register babel-polyfill in a couple more places

### DIFF
--- a/src/server/dev-server.js
+++ b/src/server/dev-server.js
@@ -1,4 +1,5 @@
 require('babel-register');
+require('babel-polyfill');
 require('css-modules-require-hook/preset');
 const clearRequireCache = require('./helpers/hot-load').clearRequireCache;
 const chokidar = require('chokidar');

--- a/src/server/dev-server.js
+++ b/src/server/dev-server.js
@@ -1,5 +1,3 @@
-require('babel-register');
-require('babel-polyfill');
 require('css-modules-require-hook/preset');
 const clearRequireCache = require('./helpers/hot-load').clearRequireCache;
 const chokidar = require('chokidar');

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,3 +1,4 @@
+require('babel-polyfill');
 require('css-modules-require-hook/preset');
 require('images-require-hook')('.svg', '/static/icons');
 

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -1,4 +1,5 @@
 require('babel-register');
+require('babel-polyfill');
 const Express = require('express');
 const webpack = require('webpack');
 const url = require('url');


### PR DESCRIPTION
Since src/server/launchpad/resources.js needs this now, we need to make
sure that it's registered in server startup paths.