### PR TITLE
Use transform-runtime instead of babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
   "plugins": [
     "react-hot-loader/babel",
     "transform-object-rest-spread",
-    "transform-es2015-destructuring"
+    "transform-es2015-destructuring",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build": "./scripts/build.sh",
     "lint": "eslint -c .eslintrc.js '**/*.js'",
     "test": "nyc npm run test:unit && npm run test:routes && npm run lint",
-    "test:unit": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha --recursive --require babel-core/register --compilers js:babel-register ./test/unit/setup.js ./test/unit/t_*.js ./test/unit/**/*",
-    "test:routes": "HTTP_PROXY= HTTPS_PROXY= mocha --recursive --require babel-core/register --compilers js:babel-register ./test/routes/setup.js ./test/routes/**/*"
+    "test:unit": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha --recursive --compilers js:babel-register ./test/unit/setup.js ./test/unit/t_*.js ./test/unit/**/*",
+    "test:routes": "HTTP_PROXY= HTTPS_PROXY= mocha --recursive --compilers js:babel-register ./test/routes/setup.js ./test/routes/**/*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build": "./scripts/build.sh",
     "lint": "eslint -c .eslintrc.js '**/*.js'",
     "test": "nyc npm run test:unit && npm run test:routes && npm run lint",
-    "test:unit": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/unit/setup.js ./test/unit/t_*.js ./test/unit/**/*",
-    "test:routes": "HTTP_PROXY= HTTPS_PROXY= mocha --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/routes/setup.js ./test/routes/**/*"
+    "test:unit": "BABEL_DISABLE_CACHE=1 NODE_ENV=TEST mocha --recursive --require babel-core/register --compilers js:babel-register ./test/unit/setup.js ./test/unit/t_*.js ./test/unit/**/*",
+    "test:routes": "HTTP_PROXY= HTTPS_PROXY= mocha --recursive --require babel-core/register --compilers js:babel-register ./test/routes/setup.js ./test/routes/**/*"
   },
   "repository": {
     "type": "git",
@@ -73,7 +73,7 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-es2015-destructuring": "^6.16.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
-    "babel-polyfill": "^6.16.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",

--- a/src/server/dev-server.js
+++ b/src/server/dev-server.js
@@ -1,4 +1,3 @@
-require('babel-register');
 require('css-modules-require-hook/preset');
 const clearRequireCache = require('./helpers/hot-load').clearRequireCache;
 const chokidar = require('chokidar');

--- a/webpack/dev-config.js
+++ b/webpack/dev-config.js
@@ -12,7 +12,6 @@ const sharedVars = require('../src/common/style/variables');
 module.exports = {
   context: path.resolve(__dirname, '..'),
   entry: [
-    'babel-polyfill',
     `webpack-hot-middleware/client?path=${WEBPACK_DEV_URL}/__webpack_hmr`,
     'webpack/hot/only-dev-server',
     'react-hot-loader/patch',


### PR DESCRIPTION
This doesn't pollute the global namespace as much, and doesn't require
every entry point to take care to require babel-polyfill.