### PR TITLE
Shrinkwrap babel-polyfill

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -47,6 +47,14 @@
     "babel-messages": {
       "version": "6.8.0"
     },
+    "babel-polyfill": {
+      "version": "6.16.0",
+      "dependencies": {
+        "core-js": {
+          "version": "2.4.1"
+        }
+      }
+    },
     "babel-runtime": {
       "version": "6.18.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/canonical-ols/build.snapcraft.io-ui#readme",
   "dependencies": {
+    "babel-polyfill": "^6.16.0",
     "body-parser": "^1.15.2",
     "chalk": "^1.1.3",
     "connect-memcached": "^0.2.0",
@@ -73,7 +74,6 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-es2015-destructuring": "^6.16.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
-    "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",


### PR DESCRIPTION
babel-polyfill is needed at run-time, so it must be in dependencies and
shrinkwrapped.