### PR TITLE
Make the launchpad routes visible

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -10,7 +10,7 @@ Unless otherwise stated, routes return JSON responses of this form:
 
 To create a snap:
 
-    POST /launchpad/snaps
+    POST /api/launchpad/snaps
     Cookie: <session cookie>
     Content-Type: application/json
     Accept: application/json
@@ -37,7 +37,7 @@ using `:caveat-id` as the parameter to the Macaroon extension.  If
 successful, the result of this OpenID exchange will be a discharge macaroon,
 which it should then store in Launchpad:
 
-    POST /launchpad/snaps/complete-authorization
+    POST /api/launchpad/snaps/complete-authorization
     Cookie: <session cookie>
     Content-Type: application/json
     Accept: application/json
@@ -51,7 +51,7 @@ On success, this returns 200.
 
 To search for an existing snap:
 
-    GET /launchpad/snaps?repository_url=:url
+    GET /api/launchpad/snaps?repository_url=:url
     Accept: application/json
 
 Successful responses have `status` set to `success` and `code` set to

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -40,6 +40,7 @@ app.use(Express.static(__dirname + '/../public', { maxAge: '365d' }));
 // routes
 app.use('/', routes.login);
 app.use('/api', routes.github);
+app.use('/api', routes.launchpad);
 app.use(routes.login);
 app.use(routes.githubAuth);
 app.use('/', routes.universal);


### PR DESCRIPTION
They're mounted under /api, so adjust the documentation to talk about
/api/launchpad/snaps.