### PR TITLE
Drop /api from Launchpad service root

### DIFF
--- a/src/server/launchpad/uri.js
+++ b/src/server/launchpad/uri.js
@@ -13,16 +13,16 @@ import url from 'url';
  */
 export function normalizeURI(base_uri, uri) {
   const base_parsed = url.parse(base_uri);
-  const service_base = base_parsed.pathname.replace(/\/+$/, '') + '/api/devel';
+  const service_base = base_parsed.pathname.replace(/\/+$/, '') + '/devel';
   const parsed = url.parse(uri);
 
   if (parsed.host !== null) {
-    // e.g. 'http://www.example.com/api/devel/foo';
+    // e.g. 'http://www.example.com/devel/foo';
     // Don't try to insert the service base into what was an absolute URL.
     // So 'http://www.example.com/foo' remains unchanged.
   } else {
     if (!parsed.pathname.startsWith('/')) {
-      // e.g. 'api/devel/foo' or 'foo'
+      // e.g. 'devel/foo' or 'foo'
       parsed.pathname = '/' + parsed.pathname;
     }
     if (!parsed.pathname.startsWith(service_base)) {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -78,19 +78,19 @@ describe('The Launchpad API endpoint', () => {
           .reply(200, 'name: test-snap\n');
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
-          .post('/api/devel/+snaps')
+          .post('/devel/+snaps')
           .query({ 'ws.op': 'new' })
           .reply(201, 'Created', {
-            Location: `${lp_api_url}/api/devel/~test-user/+snap/test-snap`
+            Location: `${lp_api_url}/devel/~test-user/+snap/test-snap`
           });
         nock(lp_api_url)
-          .get('/api/devel/~test-user/+snap/test-snap')
+          .get('/devel/~test-user/+snap/test-snap')
           .reply(200, {
-            resource_type_link: `${lp_api_url}/api/devel/#snap`,
-            self_link: `${lp_api_url}/api/devel/~test-user/+snap/test-snap`
+            resource_type_link: `${lp_api_url}/devel/#snap`,
+            self_link: `${lp_api_url}/devel/~test-user/+snap/test-snap`
           });
         nock(lp_api_url)
-          .post('/api/devel/~test-user/+snap/test-snap')
+          .post('/devel/~test-user/+snap/test-snap')
           .query({ 'ws.op': 'beginAuthorization' })
           .reply(200, JSON.stringify(caveatId), {
             'Content-Type': 'application/json'
@@ -132,7 +132,7 @@ describe('The Launchpad API endpoint', () => {
           .reply(200, 'name: test-snap\n');
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
-          .post('/api/devel/+snaps')
+          .post('/devel/+snaps')
           .query({ 'ws.op': 'new' })
           .reply(
             400,
@@ -287,9 +287,9 @@ describe('The Launchpad API endpoint', () => {
     context('when snap exists', () => {
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
-        const lp_api_base = `${lp_api_url}/api/devel`;
+        const lp_api_base = `${lp_api_url}/devel`;
         nock(lp_api_url)
-          .get('/api/devel/+snaps')
+          .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
             url: 'https://github.com/anaccount/arepo'
@@ -338,7 +338,7 @@ describe('The Launchpad API endpoint', () => {
           .query({ repository_url: 'https://github.com/anaccount/arepo' })
           .expect(hasMessage(
             'snap-found',
-            `${conf.get('LP_API_URL')}/api/devel/~test-user/+snap/test-snap`))
+            `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`))
           .end(done);
       });
     });
@@ -347,7 +347,7 @@ describe('The Launchpad API endpoint', () => {
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
-          .get('/api/devel/+snaps')
+          .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
             url: 'https://github.com/anaccount/arepo'
@@ -391,7 +391,7 @@ describe('The Launchpad API endpoint', () => {
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
-          .get('/api/devel/+snaps')
+          .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
             url: 'https://github.com/anaccount/arepo'
@@ -448,9 +448,9 @@ describe('The Launchpad API endpoint', () => {
     context('when snap exists', () => {
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
-        const lp_api_base = `${lp_api_url}/api/devel`;
+        const lp_api_base = `${lp_api_url}/devel`;
         nock(lp_api_url)
-          .get('/api/devel/+snaps')
+          .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
             url: 'https://github.com/anaccount/arepo'
@@ -467,7 +467,7 @@ describe('The Launchpad API endpoint', () => {
             ]
           });
         nock(lp_api_url)
-          .post('/api/devel/~test-user/+snap/test-snap')
+          .post('/devel/~test-user/+snap/test-snap')
           .query({
             'ws.op': 'completeAuthorization',
             'discharge_macaroon': 'dummy-discharge'
@@ -511,7 +511,7 @@ describe('The Launchpad API endpoint', () => {
           })
           .expect(hasMessage(
             'snap-authorized',
-            `${conf.get('LP_API_URL')}/api/devel/~test-user/+snap/test-snap`))
+            `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`))
           .end(done);
       });
     });
@@ -520,7 +520,7 @@ describe('The Launchpad API endpoint', () => {
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
-          .get('/api/devel/+snaps')
+          .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
             url: 'https://github.com/anaccount/arepo'

--- a/test/unit/src/server/launchpad/t_client.js
+++ b/test/unit/src/server/launchpad/t_client.js
@@ -53,7 +53,7 @@ describe('Launchpad', () => {
 
   describe('get', () => {
     it('handles successful response', () => {
-      lp.get('/api/devel/people')
+      lp.get('/devel/people')
         .matchHeader('Authorization', checkAuthorization)
         .matchHeader('Accept', /^application\/json$/)
         .reply(200, { entry: { resource_type_link: 'foo' } });
@@ -65,27 +65,26 @@ describe('Launchpad', () => {
     });
 
     it('handles failing response', () => {
-      lp.get('/api/devel/people').reply(503);
+      lp.get('/devel/people').reply(503);
 
       return getLaunchpad().get('/people').then(result => {
         assert(false, 'Expected promise to be rejected; got %s instead',
                result);
       }, error => {
         expect(error.response.status).toEqual(503);
-        expect(error.uri).toEqual(
-          'https://api.launchpad.net/api/devel/people');
+        expect(error.uri).toEqual('https://api.launchpad.net/devel/people');
       });
     });
   });
 
   describe('named_get', () => {
     it('handles successful response', () => {
-      lp.get('/api/devel/people')
+      lp.get('/devel/people')
         .query({ 'ws.op': 'getByEmail', 'email': 'foo@example.com' })
         .matchHeader('Authorization', checkAuthorization)
         .matchHeader('Accept', /^application\/json$/)
         .reply(200, {
-          resource_type_link: `${LP_API_URL}/api/devel/#person`,
+          resource_type_link: `${LP_API_URL}/devel/#person`,
           name: 'foo'
         });
 
@@ -98,7 +97,7 @@ describe('Launchpad', () => {
     });
 
     it('handles failing response', () => {
-      lp.get('/api/devel/people').query({ 'ws.op': 'getByEmail' }).reply(503);
+      lp.get('/devel/people').query({ 'ws.op': 'getByEmail' }).reply(503);
 
       return getLaunchpad().named_get('/people', 'getByEmail').then(result => {
         assert(false, 'Expected promise to be rejected; got %s instead',
@@ -106,15 +105,14 @@ describe('Launchpad', () => {
       }, error => {
         expect(error.response.status).toEqual(503);
         expect(error.uri).toEqual(
-          'https://api.launchpad.net/api/devel/people?' +
-          'ws.op=getByEmail');
+          'https://api.launchpad.net/devel/people?ws.op=getByEmail');
       });
     });
   });
 
   describe('named_post', () => {
     it('handles successful response', () => {
-      lp.post('/api/devel/people', { 'ws.op': 'newTeam' })
+      lp.post('/devel/people', { 'ws.op': 'newTeam' })
         .matchHeader('Authorization', checkAuthorization)
         .reply(200, { entry: { resource_type_link: 'foo' } });
 
@@ -125,12 +123,12 @@ describe('Launchpad', () => {
     });
 
     it('handles factory response', () => {
-      lp.post('/api/devel/people', { 'ws.op': 'newTeam', 'name': 'foo' })
+      lp.post('/devel/people', { 'ws.op': 'newTeam', 'name': 'foo' })
         .matchHeader('Authorization', checkAuthorization)
-        .reply(201, '', { 'Location': `${LP_API_URL}/api/devel/~foo` });
-      lp.get('/api/devel/~foo')
+        .reply(201, '', { 'Location': `${LP_API_URL}/devel/~foo` });
+      lp.get('/devel/~foo')
         .reply(200, {
-          resource_type_link: `${LP_API_URL}/api/devel/#team`,
+          resource_type_link: `${LP_API_URL}/devel/#team`,
           name: 'foo'
         });
 
@@ -143,28 +141,27 @@ describe('Launchpad', () => {
     });
 
     it('handles failing response', () => {
-      lp.post('/api/devel/people').reply(503);
+      lp.post('/devel/people').reply(503);
 
       return getLaunchpad().named_post('/people', 'newTeam').then(result => {
         assert(false, 'Expected promise to be rejected; got %s instead',
                result);
       }, error => {
         expect(error.response.status).toEqual(503);
-        expect(error.uri).toEqual(
-          'https://api.launchpad.net/api/devel/people');
+        expect(error.uri).toEqual('https://api.launchpad.net/devel/people');
       });
     });
   });
 
   describe('patch', () => {
     it('handles successful response', () => {
-      lp.post('/api/devel/~foo', { 'display_name': 'Foo' })
+      lp.post('/devel/~foo', { 'display_name': 'Foo' })
         .matchHeader('Authorization', checkAuthorization)
         .matchHeader('Accept', /^application\/json$/)
         .matchHeader('X-HTTP-Method-Override', /^PATCH$/)
         .matchHeader('X-Content-Type-Override', /^application\/json$/)
         .reply(200, {
-          resource_type_link: `${LP_API_URL}/api/devel/#person`,
+          resource_type_link: `${LP_API_URL}/devel/#person`,
           name: 'foo',
           display_name: 'Foo'
         });
@@ -177,7 +174,7 @@ describe('Launchpad', () => {
     });
 
     it('handles failing response', () => {
-      lp.post('/api/devel/~foo').reply(503);
+      lp.post('/devel/~foo').reply(503);
 
       return getLaunchpad().patch('/~foo', { 'display_name': 'Foo' })
         .then(result => {
@@ -185,8 +182,7 @@ describe('Launchpad', () => {
                  result);
         }, error => {
           expect(error.response.status).toEqual(503);
-          expect(error.uri).toEqual(
-            'https://api.launchpad.net/api/devel/~foo');
+          expect(error.uri).toEqual('https://api.launchpad.net/devel/~foo');
         });
     });
   });

--- a/test/unit/src/server/launchpad/t_resources.js
+++ b/test/unit/src/server/launchpad/t_resources.js
@@ -34,7 +34,7 @@ describe('Resources', () => {
         entries: [{ name: 'one' }, { name: 'two' }]
       };
       const collection = new Collection(
-        getLaunchpad(), representation, `${LP_API_URL}/api/devel/~foo/ppas`);
+        getLaunchpad(), representation, `${LP_API_URL}/devel/~foo/ppas`);
       expect(collection.total_size).toEqual(2);
       expect(collection.entries.length).toEqual(2);
       expect(collection.entries[0].name).toEqual('one');
@@ -47,12 +47,12 @@ describe('Resources', () => {
         entries.push({ name: `person${i}` });
       }
 
-      lp.get('/api/devel/~foo/ppas')
+      lp.get('/devel/~foo/ppas')
         .query({ 'ws.start': 75, 'ws.size': 25 })
         .reply(200, {
           total_size: entries.length,
           start: 75,
-          prev_collection_link: `${LP_API_URL}/api/devel/~foo/ppas?ws.size=75`,
+          prev_collection_link: `${LP_API_URL}/devel/~foo/ppas?ws.size=75`,
           entries: entries.slice(75, 100)
         });
 
@@ -60,11 +60,11 @@ describe('Resources', () => {
         total_size: entries.length,
         start: 0,
         next_collection_link:
-          `${LP_API_URL}/api/devel/~foo/ppas?ws.start=75&ws.size=75`,
+          `${LP_API_URL}/devel/~foo/ppas?ws.start=75&ws.size=75`,
         entries: entries.slice(0, 75)
       };
       const collection = new Collection(
-        getLaunchpad(), representation, `${LP_API_URL}/api/devel/~foo/ppas`);
+        getLaunchpad(), representation, `${LP_API_URL}/devel/~foo/ppas`);
       expect(collection.total_size).toEqual(100);
       expect(collection.entries.length).toEqual(75);
       return collection.lp_slice(75, 25).then(slice => {
@@ -80,12 +80,12 @@ describe('Resources', () => {
         entries.push({ name: `person${i}` });
       }
 
-      lp.get('/api/devel/~foo/ppas')
+      lp.get('/devel/~foo/ppas')
         .query({ 'ws.start': 75, 'ws.size': 75 })
         .reply(200, {
           total_size: entries.length,
           start: 75,
-          prev_collection_link: `${LP_API_URL}/api/devel/~foo/ppas?ws.size=75`,
+          prev_collection_link: `${LP_API_URL}/devel/~foo/ppas?ws.size=75`,
           entries: entries.slice(75, 100)
         });
 
@@ -93,11 +93,11 @@ describe('Resources', () => {
         total_size: entries.length,
         start: 0,
         next_collection_link:
-          `${LP_API_URL}/api/devel/~foo/ppas?ws.start=75&ws.size=75`,
+          `${LP_API_URL}/devel/~foo/ppas?ws.start=75&ws.size=75`,
         entries: entries.slice(0, 75)
       };
       const collection = new Collection(
-        getLaunchpad(), representation, `${LP_API_URL}/api/devel/~foo/ppas`);
+        getLaunchpad(), representation, `${LP_API_URL}/devel/~foo/ppas`);
       let copied_entries = [];
       // https://github.com/babel/babel-eslint/issues/415
       for await (const entry of collection) { // eslint-disable-line semi
@@ -121,35 +121,35 @@ describe('Resources', () => {
 
     it('defines properties based on the given representation', () => {
       const representation = {
-        resource_type_link: `${LP_API_URL}/api/devel/#person`,
+        resource_type_link: `${LP_API_URL}/devel/#person`,
         name: 'foo'
       };
       const entry = new Entry(
-        getLaunchpad(), representation, `${LP_API_URL}/api/devel/~foo`);
+        getLaunchpad(), representation, `${LP_API_URL}/devel/~foo`);
       expect(entry.resource_type_link)
-        .toEqual(`${LP_API_URL}/api/devel/#person`);
+        .toEqual(`${LP_API_URL}/devel/#person`);
       expect(entry.name).toEqual('foo');
     });
 
     it('saves modified attributes', () => {
-      lp.post('/api/devel/~foo', { 'display_name': 'Bar' })
+      lp.post('/devel/~foo', { 'display_name': 'Bar' })
         .matchHeader('X-HTTP-Method-Override', /^PATCH$/)
         .reply(200, {
-          resource_type_link: `${LP_API_URL}/api/devel/#person`,
-          self_link: `${LP_API_URL}/api/devel/~foo`,
+          resource_type_link: `${LP_API_URL}/devel/#person`,
+          self_link: `${LP_API_URL}/devel/~foo`,
           name: 'foo',
           display_name: 'Bar'
         });
 
       const representation = {
         http_etag: 'test-etag',
-        resource_type_link: `${LP_API_URL}/api/devel/#person`,
-        self_link: `${LP_API_URL}/api/devel/~foo`,
+        resource_type_link: `${LP_API_URL}/devel/#person`,
+        self_link: `${LP_API_URL}/devel/~foo`,
         name: 'foo',
         display_name: 'Foo'
       };
       let entry = new Entry(
-        getLaunchpad(), representation, `${LP_API_URL}/api/devel/~foo`);
+        getLaunchpad(), representation, `${LP_API_URL}/devel/~foo`);
       entry.display_name = 'Bar';
       expect(entry.dirty_attributes).toEqual(['display_name']);
       return entry.lp_save()

--- a/test/unit/src/server/launchpad/t_uri.js
+++ b/test/unit/src/server/launchpad/t_uri.js
@@ -10,8 +10,8 @@ describe('normalizeURI', () => {
   it('handles absolute URI', () => {
     const result = normalizeURI(
       'http://www.example.com/path',
-      'http://www.example.com/path/api/devel/foo');
-    expect(result).toEqual('http://www.example.com/path/api/devel/foo');
+      'http://www.example.com/path/devel/foo');
+    expect(result).toEqual('http://www.example.com/path/devel/foo');
   });
 
   it('handles absolute URI without inserting service base', () => {
@@ -22,23 +22,23 @@ describe('normalizeURI', () => {
 
   it('prepends base URI and service base to relative URI', () => {
     const result = normalizeURI('http://www.example.com/path', '/foo/bar');
-    expect(result).toEqual('http://www.example.com/path/api/devel/foo/bar');
+    expect(result).toEqual('http://www.example.com/path/devel/foo/bar');
   });
 
   it('prepends base URI to relative URI with service base', () => {
     const result = normalizeURI(
-      'http://www.example.com/path', '/path/api/devel/foo/bar');
-    expect(result).toEqual('http://www.example.com/path/api/devel/foo/bar');
+      'http://www.example.com/path', '/path/devel/foo/bar');
+    expect(result).toEqual('http://www.example.com/path/devel/foo/bar');
   });
 
   it('prepends base URI and service base to /-less relative URI', () => {
     const result = normalizeURI('http://www.example.com/path', 'foo/bar');
-    expect(result).toEqual('http://www.example.com/path/api/devel/foo/bar');
+    expect(result).toEqual('http://www.example.com/path/devel/foo/bar');
   });
 
   it('prepends base URI to /-less relative URI with service base', () => {
     const result = normalizeURI(
-      'http://www.example.com/path', 'path/api/devel/foo/bar');
-    expect(result).toEqual('http://www.example.com/path/api/devel/foo/bar');
+      'http://www.example.com/path', 'path/devel/foo/bar');
+    expect(result).toEqual('http://www.example.com/path/devel/foo/bar');
   });
 });


### PR DESCRIPTION
The client in the Launchpad source tree uses /api/devel as its service
root because it's running on launchpad.net itself, and in that context
it's easier to use the webservice on https://launchpad.net/api/devel/
and not have to worry about cross-origin issues.

However, in our case we're running on a different domain and using
api.launchpad.net, and https://api.launchpad.net/api/devel/ seems to
have at least some of the same rules as https://launchpad.net/api/devel/
in that it requires a Referer header.  That's awkward and unnecessary
here.  Using just https://api.launchpad.net/devel/ is simpler and avoids
this requirement.