### PR TITLE
Hook up snap creation in the frontend

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -42,6 +42,9 @@ least one of these teams to use the application.
 
 ## Launchpad settings
 
+Use `scripts/create-launchpad-credentials` to create these (apart from
+`LP_API_URL`).
+
 ### LP\_API\_URL
 
 - **Example**: `https://api.launchpad.net`

--- a/scripts/create-launchpad-credentials
+++ b/scripts/create-launchpad-credentials
@@ -1,0 +1,62 @@
+#! /usr/bin/python
+
+from __future__ import print_function
+
+import sys
+
+from launchpadlib.credentials import (
+    CredentialStore,
+    RequestTokenAuthorizationEngine,
+    )
+from launchpadlib.launchpad import Launchpad
+
+
+class MemoryCredentialStore(CredentialStore):
+    """Store OAuth credentials in memory."""
+
+    def __init__(self, *args, **kwargs):
+        super(MemoryCredentialStore, self).__init__(*args, **kwargs)
+        self.store = {}
+
+    def do_save(self, credentials, unique_key):
+        self.store[unique_key] = credentials
+
+    def do_load(self, unique_key):
+        return self.store.get(unique_key)
+
+
+class AuthorizeRequestTokenRemotely(RequestTokenAuthorizationEngine):
+    """Ask the user to authorize the request token in a remote browser."""
+
+    def make_end_user_authorize_token(self, credentials, request_token):
+        authorization_url = self.authorization_url(request_token)
+        print("Visit the authorization page in a browser logged in as the "
+              "desired Launchpad user:")
+        print("  {}".format(authorization_url))
+        print("Press Enter here when you have authorized the token.")
+        sys.stdin.readline()
+        credentials.exchange_request_token_for_access_token(self.web_root)
+
+
+def main():
+    store = MemoryCredentialStore()
+    authorization_engine = AuthorizeRequestTokenRemotely(
+        "production", consumer_name="build.snapcraft.io development",
+        allow_access_levels=["WRITE_PRIVATE"])
+    lp = Launchpad.login_with(
+        service_root="production",
+        authorization_engine=authorization_engine,
+        credential_store=store)
+    creds = store.store.values()[0]
+    print("Now set the following values in environments/development.env, and "
+          "make sure to keep them private (including 'chmod 600') as they "
+          "allow full access to your Launchpad account:")
+    print()
+    print("LP_API_USERNAME={}".format(lp.me.name))
+    print("LP_API_CONSUMER_KEY='{}'".format(creds.consumer.key))
+    print("LP_API_TOKEN={}".format(creds.access_token.key))
+    print("LP_API_TOKEN_SECRET={}".format(creds.access_token.secret))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -2,6 +2,8 @@ import 'isomorphic-fetch';
 
 import conf from '../helpers/config';
 
+const BASE_URL = conf.get('BASE_URL');
+
 export const SET_GITHUB_REPOSITORY = 'SET_GITHUB_REPOSITORY';
 export const VERIFY_GITHUB_REPOSITORY = 'VERIFY_GITHUB_REPOSITORY';
 export const VERIFY_GITHUB_REPOSITORY_SUCCESS = 'VERIFY_GITHUB_REPOSITORY_SUCCESS';
@@ -65,7 +67,6 @@ export function createSnap(repository, location) {
         payload: repository
       });
 
-      const BASE_URL = conf.get('BASE_URL');
       return fetch(`${BASE_URL}/api/launchpad/snaps`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -1,9 +1,13 @@
 import 'isomorphic-fetch';
 
+import conf from '../helpers/config';
+
 export const SET_GITHUB_REPOSITORY = 'SET_GITHUB_REPOSITORY';
 export const VERIFY_GITHUB_REPOSITORY = 'VERIFY_GITHUB_REPOSITORY';
 export const VERIFY_GITHUB_REPOSITORY_SUCCESS = 'VERIFY_GITHUB_REPOSITORY_SUCCESS';
 export const VERIFY_GITHUB_REPOSITORY_ERROR = 'VERIFY_GITHUB_REPOSITORY_ERROR';
+export const CREATE_SNAP = 'CREATE_SNAP';
+export const CREATE_SNAP_ERROR = 'CREATE_SNAP_ERROR';
 
 export function setGitHubRepository(value) {
   return {
@@ -48,6 +52,52 @@ export function verifyGitHubRepositorySuccess(repositoryUrl) {
 export function verifyGitHubRepositoryError(error) {
   return {
     type: VERIFY_GITHUB_REPOSITORY_ERROR,
+    payload: error,
+    error: true
+  };
+}
+
+export function createSnap(repository, location) {
+  return (dispatch) => {
+    if (repository) {
+      dispatch({
+        type: CREATE_SNAP,
+        payload: repository
+      });
+
+      const BASE_URL = conf.get('BASE_URL');
+      return fetch(`${BASE_URL}/api/launchpad/snaps`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repository_url: `https://github.com/${repository}`
+        }),
+        credentials: 'same-origin'
+      })
+        .then(checkStatus)
+        .then(response => {
+          return response.json().then(result => {
+            if (result.status !== 'success' ||
+                result.payload.code !== 'snap-created') {
+              const error = new Error(response.statusText);
+              error.response = response;
+              throw error;
+            }
+            const startingUrl = `${BASE_URL}/${repository}/builds`;
+            (location || window.location).href =
+              `${BASE_URL}/login/authenticate` +
+              `?starting_url=${encodeURIComponent(startingUrl)}` +
+              `&caveat_id=${encodeURIComponent(result.payload.message)}`;
+          });
+        })
+        .catch(error => dispatch(createSnapError(error)));
+    }
+  };
+}
+
+export function createSnapError(error) {
+  return {
+    type: CREATE_SNAP_ERROR,
     payload: error,
     error: true
   };

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -44,16 +44,10 @@ export class RepositoryInput extends Component {
     }
   }
 
-  render() {
-    const input = this.props.repositoryInput;
-
-    const isTouched = input.inputValue.length > 2;
-    const isValid = !!input.repository && !input.error;
-
-    let submitButton;
+  submitButton(input, isValid) {
     if (conf.get('LP_API_USERNAME')) {
       // Main path, for use in production.
-      submitButton = (
+      return (
         <Button type='submit' disabled={!isValid || input.isFetching}>
           { input.isFetching ? 'Creating...' : 'Create' }
         </Button>
@@ -61,12 +55,19 @@ export class RepositoryInput extends Component {
     } else {
       // If the Launchpad API isn't configured, fall back to just verifying
       // the repository.  This is handy in development.
-      submitButton = (
+      return (
         <Button type='submit' disabled={!isValid || input.isFetching}>
           { input.isFetching ? 'Verifying...' : 'Verify' }
         </Button>
       );
     }
+  }
+
+  render() {
+    const input = this.props.repositoryInput;
+
+    const isTouched = input.inputValue.length > 2;
+    const isValid = !!input.repository && !input.error;
 
     return (
       <Form onSubmit={this.onSubmit.bind(this)}>
@@ -85,7 +86,7 @@ export class RepositoryInput extends Component {
             Repository <a href={input.repositoryUrl}>{input.repository}</a> contains snapcraft project and can be built.
           </Message>
         }
-        {submitButton}
+        { this.submitButton.call(this, input, isValid) }
       </Form>
     );
   }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -44,25 +44,6 @@ export class RepositoryInput extends Component {
     }
   }
 
-  submitButton(input, isValid) {
-    if (conf.get('LP_API_USERNAME')) {
-      // Main path, for use in production.
-      return (
-        <Button type='submit' disabled={!isValid || input.isFetching}>
-          { input.isFetching ? 'Creating...' : 'Create' }
-        </Button>
-      );
-    } else {
-      // If the Launchpad API isn't configured, fall back to just verifying
-      // the repository.  This is handy in development.
-      return (
-        <Button type='submit' disabled={!isValid || input.isFetching}>
-          { input.isFetching ? 'Verifying...' : 'Verify' }
-        </Button>
-      );
-    }
-  }
-
   render() {
     const input = this.props.repositoryInput;
 
@@ -86,7 +67,9 @@ export class RepositoryInput extends Component {
             Repository <a href={input.repositoryUrl}>{input.repository}</a> contains snapcraft project and can be built.
           </Message>
         }
-        { this.submitButton.call(this, input, isValid) }
+        <Button type='submit' disabled={!isValid || input.isFetching}>
+          { input.isFetching ? 'Creating...' : 'Create' }
+        </Button>
       </Form>
     );
   }
@@ -99,14 +82,7 @@ export class RepositoryInput extends Component {
     const { repository } = this.props.repositoryInput;
 
     if (repository) {
-      if (conf.get('LP_API_USERNAME')) {
-        // Main path, for use in production.
-        this.props.dispatch(createSnap(repository));
-      } else {
-        // If the Launchpad API isn't configured, fall back to just
-        // verifying the repository.  This is handy in development.
-        this.props.dispatch(verifyGitHubRepository(repository));
-      }
+      this.props.dispatch(createSnap(repository));
     }
     event.preventDefault();
   }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -6,10 +6,8 @@ import { connect } from 'react-redux';
 
 import {
   createSnap,
-  setGitHubRepository,
-  verifyGitHubRepository
+  setGitHubRepository
 } from '../../actions/repository-input';
-import conf from '../../helpers/config';
 
 import Button from '../button';
 import { Form, InputField, Message } from '../forms';

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -43,6 +43,18 @@ export function repositoryInput(state = {
         success: false,
         error: action.payload
       };
+    case ActionTypes.CREATE_SNAP:
+      return {
+        ...state,
+        isFetching: true
+      };
+    case ActionTypes.CREATE_SNAP_ERROR:
+      return {
+        ...state,
+        isFetching: false,
+        success: false,
+        error: action.payload
+      };
     default:
       return state;
   }

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -43,11 +43,15 @@ export function repositoryInput(state = {
         success: false,
         error: action.payload
       };
+    // XXX cjwatson 2016-12-21: Merge with
+    // ActionTypes.VERIFY_GITHUB_REPOSITORY?
     case ActionTypes.CREATE_SNAP:
       return {
         ...state,
         isFetching: true
       };
+    // XXX cjwatson 2016-12-21: Merge with
+    // ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR?
     case ActionTypes.CREATE_SNAP_ERROR:
       return {
         ...state,

--- a/src/server/helpers/config.js
+++ b/src/server/helpers/config.js
@@ -9,7 +9,8 @@ import dotenv from 'dotenv';
  */
 const CLIENT_SIDE_WHITELIST = [
   'NODE_ENV',
-  'BASE_URL'
+  'BASE_URL',
+  'LP_API_USERNAME'
 ];
 
 let configForClient;

--- a/src/server/helpers/config.js
+++ b/src/server/helpers/config.js
@@ -9,8 +9,7 @@ import dotenv from 'dotenv';
  */
 const CLIENT_SIDE_WHITELIST = [
   'NODE_ENV',
-  'BASE_URL',
-  'LP_API_USERNAME'
+  'BASE_URL'
 ];
 
 let configForClient;

--- a/src/server/openid/extensions.js
+++ b/src/server/openid/extensions.js
@@ -15,7 +15,7 @@ export class Teams {
   }
 }
 
-export class Macaroons {
+export class Macaroon {
   constructor(cid) {
     this.requestParams = {
       'openid.ns.macaroon': 'http://ns.login.ubuntu.com/2016/openid-macaroon'

--- a/test/routes/src/server/routes/t_login.js
+++ b/test/routes/src/server/routes/t_login.js
@@ -60,32 +60,115 @@ describe('login routes', () => {
   });
 
   describe('authenticate', () => {
-    it('should redirect from /login/authenticate to SSO', (done) => {
-      supertest(app)
-        .get('/login/authenticate')
-        .expect(res => {
-          const loc = res.header['location'];
-          if (!loc.startsWith(UBUNTU_SSO_URL)) {
-            throw new Error(
-              `Location header ${loc} does not start with ${UBUNTU_SSO_URL}`);
-          }
-        })
-        .expect(302, done);
+    context('with no options', () => {
+      it('should redirect from /login/authenticate to SSO', (done) => {
+        supertest(app)
+          .get('/login/authenticate')
+          .expect(res => {
+            const loc = res.header['location'];
+            if (!loc.startsWith(UBUNTU_SSO_URL)) {
+              throw new Error(
+                `Location header ${loc} does not start with ${UBUNTU_SSO_URL}`);
+            }
+          })
+          .expect(302, done);
+      });
+
+      it('should include verify url in redirect header', (done) => {
+        supertest(app)
+          .get('/login/authenticate')
+          .expect(res => {
+            const parsedLocation = url.parse(res.header['location'], true);
+            const returnTo = parsedLocation.query['openid.return_to'];
+            if (returnTo !== OPENID_VERIFY_URL) {
+              throw new Error(
+                `openid.return_to is ${returnTo}, ` +
+                `expected ${OPENID_VERIFY_URL}`);
+            }
+          })
+          .end(done);
+      });
+
+      it('should not include macaroon extension in redirect ' +
+         'header', (done) => {
+        supertest(app)
+          .get('/login/authenticate')
+          .expect(res => {
+            const parsedLocation = url.parse(res.header['location'], true);
+            if ('openid.ns.macaroon' in parsedLocation.query) {
+              throw new Error('query string contains openid.ns.macaroon');
+            }
+            if ('openid.macaroon.caveat_id' in parsedLocation.query) {
+              throw new Error('query string contains ' +
+                              'openid.macaroon.caveat_id');
+            }
+          })
+          .end(done);
+      });
     });
 
-    it('should include verify url in redirect header', (done) => {
-      supertest(app)
-        .get('/login/authenticate')
-        .expect(res => {
-          const parsedLocation = url.parse(res.header['location'], true);
-          const returnTo = parsedLocation.query['openid.return_to'];
-          if (returnTo != OPENID_VERIFY_URL) {
-            throw new Error(
-              `openid.return_to is ${returnTo}, ` +
-              `expected ${OPENID_VERIFY_URL}`);
-          }
-        })
-        .end(done);
+    context('with options', () => {
+      it('should redirect from /login/authenticate to SSO', (done) => {
+        supertest(app)
+          .get('/login/authenticate')
+          .query({ 'starting_url': 'http://www.example.com/origin' })
+          .query({ 'caveat_id': 'dummy caveat' })
+          .expect(res => {
+            const loc = res.header['location'];
+            if (!loc.startsWith(UBUNTU_SSO_URL)) {
+              throw new Error(
+                `Location header ${loc} does not start with ${UBUNTU_SSO_URL}`);
+            }
+          })
+          .expect(302, done);
+      });
+
+      it('should include verify url in redirect header', (done) => {
+        supertest(app)
+          .get('/login/authenticate')
+          .query({ 'starting_url': 'http://www.example.com/origin' })
+          .query({ 'caveat_id': 'dummy caveat' })
+          .expect(res => {
+            const parsedLocation = url.parse(res.header['location'], true);
+            const returnTo = parsedLocation.query['openid.return_to'];
+            const expectedReturnTo =
+              OPENID_VERIFY_URL +
+              '?starting_url=http%3A%2F%2Fwww.example.com%2Forigin' +
+              '&caveat_id=dummy%20caveat';
+            if (returnTo !== expectedReturnTo) {
+              throw new Error(
+                `openid.return_to is ${returnTo}, ` +
+                `expected ${expectedReturnTo}`);
+            }
+          })
+          .end(done);
+      });
+
+      it('should include macaroon extension in redirect header', (done) => {
+        const expectedCaveatId = 'dummy caveat';
+        supertest(app)
+          .get('/login/authenticate')
+          .query({ 'starting_url': 'http://www.example.com/origin' })
+          .query({ 'caveat_id': expectedCaveatId })
+          .expect(res => {
+            const parsedLocation = url.parse(res.header['location'], true);
+            const nsMacaroon = parsedLocation.query['openid.ns.macaroon'];
+            const expectedNsMacaroon =
+              'http://ns.login.ubuntu.com/2016/openid-macaroon';
+            if (nsMacaroon !== expectedNsMacaroon) {
+              throw new Error(
+                `openid.ns.macaroon is ${nsMacaroon}, ` +
+                `expected ${expectedNsMacaroon}`);
+            }
+            const caveatId = parsedLocation.query['openid.macaroon.caveat_id'];
+            if (caveatId !== expectedCaveatId) {
+              throw new Error(
+                `openid.macaroon.caveat_id is ${caveatId}, ` +
+                `expected ${expectedCaveatId}`);
+            }
+          })
+          .end(done);
+      });
     });
   });
 });

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -6,3 +6,7 @@ require.extensions['.svg'] = () => 'example.svg';
 require.extensions['.png'] = () => 'example.png';
 require.extensions['.gif'] = () => 'example.gif';
 require.extensions['.jpg', '.jpeg'] = () => 'example.jpg';
+
+import { getClientConfig } from '../../src/server/helpers/config';
+
+global.__CONFIG__ = getClientConfig();

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -155,4 +155,41 @@ describe('repositoryInput reducers', () => {
       });
     });
   });
+
+  context('CREATE_SNAP', () => {
+    it('stores fetching status when repository is being created', () => {
+      const action = {
+        type: ActionTypes.CREATE_SNAP,
+        payload: 'dummy/repo'
+      };
+
+      expect(repositoryInput(initialState, action)).toEqual({
+        ...initialState,
+        isFetching: true
+      });
+    });
+  });
+
+  context('CREATE_SNAP_ERROR', () => {
+    it('handles snap creation failure', () => {
+      const state = {
+        ...initialState,
+        repository: 'dummy/repo',
+        isFetching: true
+      };
+
+      const action = {
+        type: ActionTypes.CREATE_SNAP_ERROR,
+        payload: new Error('Something went wrong!'),
+        error: true
+      };
+
+      expect(repositoryInput(state, action)).toEqual({
+        ...state,
+        isFetching: false,
+        success: false,
+        error: action.payload
+      });
+    });
+  });
 });

--- a/test/unit/src/server/openid/t_extensions.js
+++ b/test/unit/src/server/openid/t_extensions.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { Teams, Macaroons } from '../../../../../src/server/openid/extensions.js';
+import { Teams, Macaroon } from '../../../../../src/server/openid/extensions.js';
 
 describe('Teams', () => {
   it('should have lp namespace', () => {
@@ -34,9 +34,9 @@ describe('Teams', () => {
   });
 });
 
-describe('Macaroons', () => {
+describe('Macaroon', () => {
   it('should have the sso macaroon namespace', () => {
-    const macaroons = new Macaroons();
+    const macaroons = new Macaroon();
 
     expect(macaroons.requestParams).toEqual({
       'openid.ns.macaroon': 'http://ns.login.ubuntu.com/2016/openid-macaroon'
@@ -45,7 +45,7 @@ describe('Macaroons', () => {
 
   it('should send caveat id', () => {
     const cid = 'foo';
-    const macaroons = new Macaroons(cid);
+    const macaroons = new Macaroon(cid);
 
     expect(macaroons.requestParams).toEqual({
       'openid.ns.macaroon': 'http://ns.login.ubuntu.com/2016/openid-macaroon',
@@ -55,7 +55,7 @@ describe('Macaroons', () => {
 
   it('should fill result caveat id', () => {
     const cid = 'foo';
-    const macaroons = new Macaroons(cid);
+    const macaroons = new Macaroon(cid);
     const params = {
       'openid.macaroon.discharge': cid
     };

--- a/test/unit/src/server/openid/t_relyingparty.js
+++ b/test/unit/src/server/openid/t_relyingparty.js
@@ -13,7 +13,7 @@ describe('RelyingParty', () => {
   let rp;
 
   before(() => {
-    rp = RelyingPartyFactory({});
+    rp = RelyingPartyFactory({}, VERIFY_URL);
   });
 
   it('should set verify url from config', () => {
@@ -38,7 +38,7 @@ describe('RelyingParty default extensions', () => {
 
   before(() => {
     conf.stores['test-overrides'].set('OPENID_TEAMS', 'null');
-    rp = RelyingPartyFactory({});
+    rp = RelyingPartyFactory({}, VERIFY_URL);
   });
 
   after(() => {
@@ -57,7 +57,7 @@ describe('RelyingParty with teams extension', () => {
 
   before(() => {
     conf.stores['test-overrides'].set('OPENID_TEAMS', '["test1", "test2"]');
-    rp = RelyingPartyFactory({});
+    rp = RelyingPartyFactory({}, VERIFY_URL);
   });
 
   after(() => {


### PR DESCRIPTION
If LP_API_USERNAME is set, then we now create a snap based on the given
GitHub repository rather than merely verifying it.  This uses the
/launchpad/snaps API to create the snap in Launchpad, then redirects
through OpenID to authorise uploads of it to the store, then redirects
to the builds page for that repository.

If LP_API_USERNAME is not set, then we behave as before and only verify
the repository.  This is partly because it's handy in development, and
partly because we still need the verify actions to support future plans.