### PR TITLE
Create snaps with more appropriate architectures

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -15,6 +15,7 @@ const logger = logging.getLogger('express-error');
 // configurable.
 const DISTRIBUTION = 'ubuntu';
 const DISTRO_SERIES = 'xenial';
+const ARCHITECTURES = ['amd64', 'armhf'];
 const STORE_SERIES = '16';
 
 const RESPONSE_NOT_LOGGED_IN = {
@@ -148,8 +149,6 @@ const getSnapcraftYaml = (req, res, callback) => {
   });
 };
 
-// XXX cjwatson 2016-12-13: We should set an appropriate set of
-// architectures.
 export const newSnap = (req, res) => {
   // XXX cjwatson 2016-12-15: Limit to only repositories the user owns.
   if (!req.session || !req.session.token) {
@@ -174,6 +173,9 @@ export const newSnap = (req, res) => {
         auto_build: true,
         auto_build_archive: `/${DISTRIBUTION}/+archive/primary`,
         auto_build_pocket: 'Updates',
+        processors: ARCHITECTURES.map(arch => {
+          return `/+processors/${arch}`;
+        }),
         store_upload: true,
         store_series: `/+snappy-series/${STORE_SERIES}`,
         store_name: snapcraftYaml.name

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -78,8 +78,12 @@ describe('The Launchpad API endpoint', () => {
           .reply(200, 'name: test-snap\n');
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
-          .post('/devel/+snaps')
-          .query({ 'ws.op': 'new' })
+          .post('/devel/+snaps', {
+            'ws.op': 'new',
+            git_repository_url: 'https://github.com/anaccount/arepo',
+            processors: ['/+processors/amd64', '/+processors/armhf'],
+            store_name: 'test-snap'
+          })
           .reply(201, 'Created', {
             Location: `${lp_api_url}/devel/~test-user/+snap/test-snap`
           });
@@ -90,8 +94,9 @@ describe('The Launchpad API endpoint', () => {
             self_link: `${lp_api_url}/devel/~test-user/+snap/test-snap`
           });
         nock(lp_api_url)
-          .post('/devel/~test-user/+snap/test-snap')
-          .query({ 'ws.op': 'beginAuthorization' })
+          .post('/devel/~test-user/+snap/test-snap', {
+            'ws.op': 'beginAuthorization'
+          })
           .reply(200, JSON.stringify(caveatId), {
             'Content-Type': 'application/json'
           });
@@ -132,8 +137,7 @@ describe('The Launchpad API endpoint', () => {
           .reply(200, 'name: test-snap\n');
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
-          .post('/devel/+snaps')
-          .query({ 'ws.op': 'new' })
+          .post('/devel/+snaps', { 'ws.op': 'new' })
           .reply(
             400,
             'There is already a snap package with the same name and owner.');
@@ -467,8 +471,7 @@ describe('The Launchpad API endpoint', () => {
             ]
           });
         nock(lp_api_url)
-          .post('/devel/~test-user/+snap/test-snap')
-          .query({
+          .post('/devel/~test-user/+snap/test-snap', {
             'ws.op': 'completeAuthorization',
             'discharge_macaroon': 'dummy-discharge'
           })


### PR DESCRIPTION
Launchpad defaults to [amd64, i386], which is possibly not ideal for
snaps.  Let's go for [amd64, armhf] instead; we need this to be
user-selectable in the long run, but this will be better for demo
purposes.

In the process, I fixed some buggy use of nock in tests: the Launchpad
client passes parameters to POST requests using the request body, not
the query string.