### PR TITLE
Getting snap builds from LP into views

### DIFF
--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -39,19 +39,13 @@ export function fetchSnap(repository) {
         type: FETCH_BUILDS
       });
 
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve({
-            status: 'success',
-            payload: {
-              code: 'snap-found',
-              message: 'https://api.launchpad.net/devel/~snappy-dev/+snap/core'
-            }
-          });
-        }, 1000);
-      })
-      .then(json => dispatch(fetchBuilds(json.payload.message)))
-      .catch(error => dispatch(fetchBuildsError(error)));
+      const repositoryUrl = encodeURIComponent(`https://github.com/${repository}.git`);
+      const url = `${BASE_URL}/api/launchpad/snaps?repository_url=${repositoryUrl}`;
+      return fetch(url)
+        .then(checkStatus)
+        .then(response => response.json())
+        .then((json) => dispatch(fetchBuilds(json.payload.message)))
+        .catch( error => dispatch(fetchBuildsError(error)));
     }
   };
 }

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -1,3 +1,7 @@
+import conf from '../helpers/config';
+
+const BASE_URL = conf.get('BASE_URL');
+
 export const FETCH_BUILDS = 'FETCH_BUILDS';
 export const FETCH_BUILDS_SUCCESS = 'FETCH_BUILDS_SUCCESS';
 export const FETCH_BUILDS_ERROR = 'FETCH_BUILDS_ERROR';
@@ -17,169 +21,37 @@ export function fetchBuildsError(error) {
   };
 }
 
+function checkStatus(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  } else {
+    const error = new Error(response.statusText);
+    error.status = response.status;
+    error.response = response;
+    throw error;
+  }
+}
+
 export function fetchBuilds(repository) {
   return (dispatch) => {
+
     if (repository) {
       dispatch({
         type: FETCH_BUILDS,
         payload: repository
       });
 
-      // TODO: real async call to load the builds
-      // return fetch(...)
-      //   .then(checkStatus)
-      //   ...
+      // TODO: bartaz
+      // mocked URL just for dev test purposes, to be replaced with fetched self_link
+      const snap_link = encodeURIComponent('https://api.launchpad.net/devel/~snappy-dev/+snap/core');
 
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(SNAP_BUILDS_RESPONSE);
-        }, 1000);
-      }).then((json) => dispatch(fetchBuildsSuccess(json.entries)))
+
+      const url = `${BASE_URL}/api/launchpad/builds?snap_link=${snap_link}`;
+      return fetch(url)
+        .then(checkStatus)
+        .then(response => response.json())
+        .then((json) => dispatch(fetchBuildsSuccess(json.payload.builds)))
         .catch( error => dispatch(fetchBuildsError(error)));
     }
   };
 }
-
-// MOCKED BUILDS RESPONSE
-// based on https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/builds
-const SNAP_BUILDS_RESPONSE = {
-  'total_size': 5,
-  'start': 0,
-  'entries': [{
-    'can_be_rescored': false,
-    'builder_link': 'https://api.launchpad.net/devel/builders/lgw01-11',
-    'datebuilt': '2016-11-09T17:08:36.317805+00:00',
-    'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/amd64',
-    'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
-    'duration': '0:02:36.314039',
-    'can_be_cancelled': false,
-    'title': 'amd64 build of godd-test-2 snap package in ubuntu xenial-updates',
-    'buildstate': 'Currently building',
-    'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
-    'http_etag': '\'d4a5173d51d6525b6d07709306bcfd65dbb68c5c-303718749dd6021eaf21d1a9eb4ae538de800de2\'',
-    'score': null,
-    'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/9590',
-    'date_started': '2016-11-09T17:06:00.003766+00:00',
-    'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
-    'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590/+files/buildlog_snap_ubuntu_xenial_amd64_godd-test-2_BUILDING.txt.gz',
-    'pocket': 'Updates',
-    'dependencies': null,
-    'date_first_dispatched': '2016-11-09T17:06:00.003766+00:00',
-    'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
-    'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/9590',
-    'datecreated': '2016-11-09T17:05:52.436792+00:00',
-    'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
-    'arch_tag': 'amd64',
-    'upload_log_url': null
-  }, {
-    'can_be_rescored': false,
-    'builder_link': 'https://api.launchpad.net/devel/builders/lgw01-06',
-    'datebuilt': '2016-06-06T16:44:15.404592+00:00',
-    'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/amd64',
-    'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
-    'duration': '0:03:21.345313',
-    'can_be_cancelled': false,
-    'title': 'amd64 build of godd-test-2 snap package in ubuntu xenial-updates',
-    'buildstate': 'Failed to build',
-    'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
-    'http_etag': '\'8e0a4c14356c8028f2b9ccb77312222ad045b388-b02297890f0ad92c486cfc11f279f452cb8f7dcc\'',
-    'score': null,
-    'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/1149',
-    'date_started': '2016-06-06T16:40:54.059279+00:00',
-    'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
-    'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1149/+files/buildlog_snap_ubuntu_xenial_amd64_godd-test-2_BUILDING.txt.gz',
-    'pocket': 'Updates',
-    'dependencies': null,
-    'date_first_dispatched': '2016-06-06T16:40:54.059279+00:00',
-    'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
-    'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1149',
-    'datecreated': '2016-06-06T16:40:51.698805+00:00',
-    'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
-    'arch_tag': 'amd64',
-    'upload_log_url': null
-  }, {
-    'can_be_rescored': false,
-    'builder_link': 'https://api.launchpad.net/devel/builders/lgw01-08',
-    'datebuilt': '2016-06-06T16:43:46.951477+00:00',
-    'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/i386',
-    'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
-    'duration': '0:02:52.464213',
-    'can_be_cancelled': false,
-    'title': 'i386 build of godd-test-2 snap package in ubuntu xenial-updates',
-    'buildstate': 'Successfully built',
-    'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
-    'http_etag': '\'b4a80f0bb7035d4020aee06934da6d0722285052-60c8d24f5a0b7e8619bce064d9e64f09be1a2042\'',
-    'score': null,
-    'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/1150',
-    'date_started': '2016-06-06T16:40:54.487264+00:00',
-    'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
-    'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1150/+files/buildlog_snap_ubuntu_xenial_i386_godd-test-2_BUILDING.txt.gz',
-    'pocket': 'Updates',
-    'dependencies': null,
-    'date_first_dispatched': '2016-06-06T16:40:54.487264+00:00',
-    'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
-    'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1150',
-    'datecreated': '2016-06-06T16:40:51.698805+00:00',
-    'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
-    'arch_tag': 'i386',
-    'upload_log_url': null
-  }, {
-    'can_be_rescored': false,
-    'builder_link': 'https://api.launchpad.net/devel/builders/lcy01-07',
-    'datebuilt': '2016-06-02T07:56:07.834750+00:00',
-    'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/amd64',
-    'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
-    'duration': '0:02:05.065412',
-    'can_be_cancelled': false,
-    'title': 'amd64 build of godd-test-2 snap package in ubuntu xenial-updates',
-    'buildstate': 'Cancelled build',
-    'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
-    'http_etag': '\'09eda0e0a7d977ea137e20f231c617a70709d100-72488fcf39f1485b3274027ae4a01cc52ca154a5\'',
-    'score': null,
-    'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/1063',
-    'date_started': '2016-06-02T07:54:02.769338+00:00',
-    'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
-    'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1063/+files/buildlog_snap_ubuntu_xenial_amd64_godd-test-2_BUILDING.txt.gz',
-    'pocket': 'Updates',
-    'dependencies': null,
-    'date_first_dispatched': '2016-06-02T07:54:02.769338+00:00',
-    'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
-    'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1063',
-    'datecreated': '2016-06-01T13:44:04.646067+00:00',
-    'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
-    'arch_tag': 'amd64',
-    'upload_log_url': null
-  }, {
-    'can_be_rescored': false,
-    'builder_link': 'https://api.launchpad.net/devel/builders/lcy01-05',
-    'datebuilt': '2016-06-02T07:56:07.748129+00:00',
-    'distro_arch_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial/i386',
-    'snap_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2',
-    'duration': '0:01:50.046060',
-    'can_be_cancelled': false,
-    'title': 'i386 build of godd-test-2 snap package in ubuntu xenial-updates',
-    'buildstate': 'Successfully built',
-    'requester_link': 'https://api.launchpad.net/devel/~cjwatson',
-    'http_etag': '\'c34118394abae39240e95f2bc620f6f96a379a68-264ca7acd85945668d342842b2039d75d7b673ff\'',
-    'score': null,
-    'self_link': 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2/+build/1064',
-    'date_started': '2016-06-02T07:54:17.702069+00:00',
-    'resource_type_link': 'https://api.launchpad.net/devel/#snap_build',
-    'build_log_url': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1064/+files/buildlog_snap_ubuntu_xenial_i386_godd-test-2_BUILDING.txt.gz',
-    'pocket': 'Updates',
-    'dependencies': null,
-    'date_first_dispatched': '2016-06-02T07:54:17.702069+00:00',
-    'distribution_link': 'https://api.launchpad.net/devel/ubuntu',
-    'distro_series_link': 'https://api.launchpad.net/devel/ubuntu/xenial',
-    'web_link': 'https://launchpad.net/~cjwatson/+snap/godd-test-2/+build/1064',
-    'datecreated': '2016-06-01T13:44:04.646067+00:00',
-    'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
-    'arch_tag': 'i386',
-    'upload_log_url': null
-  }],
-  'resource_type_link': 'https://api.launchpad.net/devel/#snap_build-page-resource'
-};

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -25,10 +25,13 @@ function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response;
   } else {
-    const error = new Error(response.statusText);
-    error.status = response.status;
-    error.response = response;
-    throw error;
+    return response.json().then(json => {
+      // throw an error based on message from response body or status text
+      const error = new Error(json.payload.message || response.statusText);
+      error.status = response.status;
+      error.response = response;
+      throw error;
+    });
   }
 }
 

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -25,7 +25,7 @@ function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response;
   } else {
-    return response.json().then(json => {
+    return response.json().then((json) => {
       // throw an error based on message from response body or status text
       const error = new Error(json.payload.message || response.statusText);
       error.status = response.status;
@@ -48,7 +48,7 @@ export function fetchSnap(repository) {
         .then(checkStatus)
         .then(response => response.json())
         .then((json) => dispatch(fetchBuilds(json.payload.message)))
-        .catch( error => dispatch(fetchBuildsError(error)));
+        .catch((error) => dispatch(fetchBuildsError(error)));
     }
   };
 }
@@ -66,7 +66,7 @@ export function fetchBuilds(snapLink) {
         .then(checkStatus)
         .then(response => response.json())
         .then((json) => dispatch(fetchBuildsSuccess(json.payload.builds)))
-        .catch( error => dispatch(fetchBuildsError(error)));
+        .catch((error) => dispatch(fetchBuildsError(error)));
     }
   };
 }

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -32,21 +32,39 @@ function checkStatus(response) {
   }
 }
 
-export function fetchBuilds(repository) {
+export function fetchSnap(repository) {
   return (dispatch) => {
-
     if (repository) {
       dispatch({
-        type: FETCH_BUILDS,
-        payload: repository
+        type: FETCH_BUILDS
       });
 
-      // TODO: bartaz
-      // mocked URL just for dev test purposes, to be replaced with fetched self_link
-      const snap_link = encodeURIComponent('https://api.launchpad.net/devel/~snappy-dev/+snap/core');
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            status: 'success',
+            payload: {
+              code: 'snap-found',
+              message: 'https://api.launchpad.net/devel/~snappy-dev/+snap/core'
+            }
+          });
+        }, 1000);
+      })
+      .then(json => dispatch(fetchBuilds(json.payload.message)))
+      .catch(error => dispatch(fetchBuildsError(error)));
+    }
+  };
+}
 
+export function fetchBuilds(snapLink) {
+  return (dispatch) => {
+    if (snapLink) {
+      dispatch({
+        type: FETCH_BUILDS
+      });
 
-      const url = `${BASE_URL}/api/launchpad/builds?snap_link=${snap_link}`;
+      snapLink = encodeURIComponent(snapLink);
+      const url = `${BASE_URL}/api/launchpad/builds?snap_link=${snapLink}`;
       return fetch(url)
         .then(checkStatus)
         .then(response => response.json())

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -61,7 +61,7 @@ export function fetchBuilds(snapLink) {
       });
 
       snapLink = encodeURIComponent(snapLink);
-      const url = `${BASE_URL}/api/launchpad/builds?snap_link=${snapLink}`;
+      const url = `${BASE_URL}/api/launchpad/builds?snap=${snapLink}`;
       return fetch(url)
         .then(checkStatus)
         .then(response => response.json())

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -4,14 +4,15 @@ import Helmet from 'react-helmet';
 
 import BuildRow from '../components/build-row';
 import BuildLog from '../components/build-log';
-import { fetchBuilds } from '../actions/snap-builds';
+import { Message } from '../components/forms';
+import { fetchSnap } from '../actions/snap-builds';
 
 import styles from './container.css';
 
 class BuildDetails extends Component {
 
   componentWillMount() {
-    this.props.dispatch(fetchBuilds(this.props.fullName));
+    this.props.dispatch(fetchSnap(this.props.fullName));
   }
 
   render() {
@@ -25,6 +26,9 @@ class BuildDetails extends Component {
         <h1>{fullName} build #{buildId}</h1>
         { this.props.isFetching &&
           <span>Loading...</span>
+        }
+        { this.props.error &&
+          <Message status='error'>{ this.props.error.message || this.props.error }</Message>
         }
         { build &&
           <div>
@@ -45,6 +49,7 @@ BuildDetails.propTypes = {
   buildId: PropTypes.string.isRequired,
   build: PropTypes.object,
   isFetching: PropTypes.bool,
+  error: PropTypes.oneOfType([ PropTypes.object, PropTypes.bool ]),
   dispatch: PropTypes.func.isRequired
 };
 
@@ -56,6 +61,7 @@ const mapStateToProps = (state, ownProps) => {
   const fullName = `${account}/${repo}`;
   const build = state.snapBuilds.builds.filter((build) => build.buildId === buildId)[0];
   const isFetching = state.snapBuilds.isFetching;
+  const error = state.snapBuilds.error;
 
   return {
     account,
@@ -63,7 +69,8 @@ const mapStateToProps = (state, ownProps) => {
     fullName,
     buildId,
     build,
-    isFetching
+    isFetching,
+    error
   };
 };
 

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -49,7 +49,7 @@ BuildDetails.propTypes = {
   buildId: PropTypes.string.isRequired,
   build: PropTypes.object,
   isFetching: PropTypes.bool,
-  error: PropTypes.oneOfType([ PropTypes.object, PropTypes.bool ]),
+  error: PropTypes.object,
   dispatch: PropTypes.func.isRequired
 };
 

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
 
 import BuildHistory from '../components/build-history';
+import { Message } from '../components/forms';
 import { fetchSnap } from '../actions/snap-builds';
 
 import styles from './container.css';
@@ -26,6 +27,9 @@ class Builds extends Component {
         { this.props.isFetching &&
           <span>Loading...</span>
         }
+        { this.props.error &&
+          <Message status='error'>{ this.props.error.message || this.props.error }</Message>
+        }
       </div>
     );
   }
@@ -37,6 +41,7 @@ Builds.propTypes = {
   repo: PropTypes.string.isRequired,
   fullName: PropTypes.string.isRequired,
   isFetching: PropTypes.bool,
+  error: PropTypes.oneOfType([ PropTypes.object, PropTypes.bool ]),
   dispatch: PropTypes.func.isRequired
 };
 
@@ -46,9 +51,11 @@ const mapStateToProps = (state, ownProps) => {
   const fullName = `${account}/${repo}`;
 
   const isFetching = state.snapBuilds.isFetching;
+  const error = state.snapBuilds.error;
 
   return {
     isFetching,
+    error,
     account,
     repo,
     fullName

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -41,7 +41,7 @@ Builds.propTypes = {
   repo: PropTypes.string.isRequired,
   fullName: PropTypes.string.isRequired,
   isFetching: PropTypes.bool,
-  error: PropTypes.oneOfType([ PropTypes.object, PropTypes.bool ]),
+  error: PropTypes.object,
   dispatch: PropTypes.func.isRequired
 };
 

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -3,14 +3,14 @@ import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
 
 import BuildHistory from '../components/build-history';
-import { fetchBuilds } from '../actions/snap-builds';
+import { fetchSnap } from '../actions/snap-builds';
 
 import styles from './container.css';
 
 class Builds extends Component {
 
   componentWillMount() {
-    this.props.dispatch(fetchBuilds(this.props.fullName));
+    this.props.dispatch(fetchSnap(this.props.fullName));
   }
 
   render() {

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -4,7 +4,7 @@ import { snapBuildFromAPI } from '../helpers/snap-builds';
 export function snapBuilds(state = {
   isFetching: false,
   builds: [],
-  error: false
+  error: null
 }, action) {
   switch(action.type) {
     case ActionTypes.FETCH_BUILDS:
@@ -17,7 +17,7 @@ export function snapBuilds(state = {
         ...state,
         isFetching: false,
         builds: action.payload.map(snapBuildFromAPI),
-        error: false
+        error: null
       };
     case ActionTypes.FETCH_BUILDS_ERROR:
       return {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -317,22 +317,22 @@ export const completeSnapAuthorization = async (req, res) => {
 };
 
 export const getSnapBuilds = (req, res) => {
-  const snap_link = req.query.snap_link;
+  const snapUrl = req.query.snap;
 
   const start = typeof req.query.start !== 'undefined' ? req.query.start : 0;
   const size = typeof req.query.size !== 'undefined' ? req.query.size : 10;
 
-  if (!snap_link) {
+  if (!snapUrl) {
     return res.status(404).send({
       status: 'error',
       payload: {
         code: 'missing-snap-link',
-        message: 'Missing query parameter snap_link'
+        message: 'Missing query parameter snap'
       }
     });
   }
 
-  return getLaunchpad().get(snap_link).then(snap => {
+  return getLaunchpad().get(snapUrl).then(snap => {
     return getLaunchpad().get(snap.builds_collection_link, { start: start, size: size })
       .then(builds => {
         return res.status(200).send({

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -582,14 +582,14 @@ describe('The Launchpad API endpoint', () => {
     let lp_api_url;
     let lp_snap_path;
     let lp_builds_path;
-    let lp_snap_link;
+    let lp_snap_url;
 
     before(() => {
       lp_api_url = conf.get('LP_API_URL');
       lp_snap_path = `/devel/~${lp_snap_user}/+snap/${lp_snap_name}`;
       lp_builds_path = `${lp_snap_path}/builds`;
 
-      lp_snap_link = `${lp_api_url}${lp_snap_path}`;
+      lp_snap_url = `${lp_api_url}${lp_snap_path}`;
     });
 
     context('when snap and builds are successfully fetched', () => {
@@ -630,14 +630,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 200 OK response', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(200, done);
       });
 
       it('should return a "success" status', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(hasStatus('success'))
           .end(done);
       });
@@ -645,7 +645,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return body with "snap-builds-found" message', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(hasMessage('snap-builds-found'))
           .end(done);
       });
@@ -653,7 +653,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return builds list in payload', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .end((err, res) => {
             const build = res.body.payload.builds[0];
             // XXX bartaz
@@ -698,7 +698,7 @@ describe('The Launchpad API endpoint', () => {
 
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(200, (err) => {
             lp.done();
             done(err);
@@ -717,7 +717,7 @@ describe('The Launchpad API endpoint', () => {
 
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link, size: 42, start: 7 })
+          .query({ snap: lp_snap_url, size: 42, start: 7 })
           .expect(200, (err) => {
             lp.done();
             done(err);
@@ -754,14 +754,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 response', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(404, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -769,7 +769,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return body with error message', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(hasMessage('lp-error', 'Not found'))
           .end(done);
       });
@@ -792,14 +792,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 response', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(404, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -807,14 +807,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return body with error message', (done) => {
         supertest(app)
           .get('/launchpad/builds')
-          .query({ snap_link: lp_snap_link })
+          .query({ snap: lp_snap_url })
           .expect(hasMessage('lp-error', 'Not found'))
           .end(done);
       });
 
     });
 
-    context('when snap_link parameter is missing', () => {
+    context('when snap parameter is missing', () => {
 
       it('should return a 404 response', (done) => {
         supertest(app)

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -7,6 +7,7 @@ import { isFSA } from 'flux-standard-action';
 import { conf } from '../../../../../src/server/helpers/config';
 
 import {
+  fetchSnap,
   fetchBuilds,
   fetchBuildsSuccess,
   fetchBuildsError
@@ -76,7 +77,49 @@ describe('repository input actions', () => {
   });
 
   context('fetchBuilds', () => {
+    let api;
 
+    beforeEach(() => {
+      api = nock(conf.get('BASE_URL'));
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should store builds on fetch success', () => {
+      api.get('/api/launchpad/builds')
+        .query({ snap_link: 'http://api.example.com/test/+snap' }) // accept any snap_link in query
+        .reply(200, {
+          status: 'success',
+          payload: {
+            code: 'snap-builds-found',
+            builds: []
+          }
+        });
+
+      return store.dispatch(fetchBuilds('http://api.example.com/test/+snap'))
+        .then(() => {
+          api.done();
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.FETCH_BUILDS_SUCCESS
+          );
+        });
+    });
+
+    // TODO: pending - mocked actions never fail
+    xit('should store error on Launchpad request failure', () => {
+      // return store.dispatch(fetchBuilds( '...' ))
+      //   .then(() => {
+      //     expect(store.getActions()).toHaveActionOfType(
+      //       ActionTypes.FETCH_BUILDS_ERROR
+      //     );
+      //   });
+    });
+
+  });
+
+  context('fetchSnap', () => {
     let api;
 
     beforeEach(() => {
@@ -98,7 +141,7 @@ describe('repository input actions', () => {
           }
         });
 
-      return store.dispatch(fetchBuilds('foo/bar'))
+      return store.dispatch(fetchSnap('foo/bar'))
         .then(() => {
           api.done();
           expect(store.getActions()).toHaveActionOfType(
@@ -109,7 +152,7 @@ describe('repository input actions', () => {
 
     // TODO: pending - mocked actions never fail
     xit('should store error on Launchpad request failure', () => {
-      // return store.dispatch(fetchBuilds('foo/bar'))
+      // return store.dispatch(fetchSnap('foo/bar'))
       //   .then(() => {
       //     expect(store.getActions()).toHaveActionOfType(
       //       ActionTypes.FETCH_BUILDS_ERROR

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -88,8 +88,10 @@ describe('repository input actions', () => {
     });
 
     it('should store builds on fetch success', () => {
+      const snapUrl = 'https://api.launchpad.net/devel/~foo/+snap/bar';
+
       api.get('/api/launchpad/builds')
-        .query({ snap_link: 'http://api.example.com/test/+snap' }) // accept any snap_link in query
+        .query({ snap_link: snapUrl })
         .reply(200, {
           status: 'success',
           payload: {
@@ -98,7 +100,7 @@ describe('repository input actions', () => {
           }
         });
 
-      return store.dispatch(fetchBuilds('http://api.example.com/test/+snap'))
+      return store.dispatch(fetchBuilds(snapUrl))
         .then(() => {
           api.done();
           expect(store.getActions()).toHaveActionOfType(
@@ -107,14 +109,25 @@ describe('repository input actions', () => {
         });
     });
 
-    // TODO: pending - mocked actions never fail
-    xit('should store error on Launchpad request failure', () => {
-      // return store.dispatch(fetchBuilds( '...' ))
-      //   .then(() => {
-      //     expect(store.getActions()).toHaveActionOfType(
-      //       ActionTypes.FETCH_BUILDS_ERROR
-      //     );
-      //   });
+    it('should store error on Launchpad request failure', () => {
+      const barUrl = 'https://api.launchpad.net/devel/~foo/+snap/bad';
+
+      api.get('/api/launchpad/builds')
+        .query({ snap_link: barUrl })
+        .reply(404, {
+          status: 'error',
+          payload: {
+            code: 'lp-error',
+            message: 'Something went wrong'
+          }
+        });
+
+      return store.dispatch(fetchBuilds(barUrl))
+        .then(() => {
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.FETCH_BUILDS_ERROR
+          );
+        });
     });
 
   });
@@ -167,14 +180,75 @@ describe('repository input actions', () => {
         });
     });
 
-    // TODO: pending - mocked actions never fail
-    xit('should store error on Launchpad request failure', () => {
-      // return store.dispatch(fetchSnap('foo/bar'))
-      //   .then(() => {
-      //     expect(store.getActions()).toHaveActionOfType(
-      //       ActionTypes.FETCH_BUILDS_ERROR
-      //     );
-      //   });
+    context('on builds call failure', () => {
+      const barUrl = 'https://api.launchpad.net/devel/~foo/+snap/bad';
+
+      beforeEach(() => {
+        api.get('/api/launchpad/builds')
+        .query({ snap_link: barUrl })
+        .reply(404, {
+          status: 'error',
+          payload: {
+            code: 'lp-error',
+            message: 'Bad snap URL'
+          }
+        });
+      });
+
+      it('should dispatch error action', () => {
+        return store.dispatch(fetchBuilds(barUrl))
+          .then(() => {
+            expect(store.getActions()).toHaveActionOfType(
+              ActionTypes.FETCH_BUILDS_ERROR
+            );
+          });
+      });
+
+      it('should pass error message from repsponse to action', () => {
+        return store.dispatch(fetchBuilds(barUrl))
+          .then(() => {
+            const action = store.getActions().filter(a => a.type === ActionTypes.FETCH_BUILDS_ERROR)[0];
+            expect(action.payload.message).toBe('Bad snap URL');
+          });
+      });
+
+    });
+
+    context('on snaps call failure', () => {
+      const badRepo = 'foo/bad';
+      const repositoryUrl = `https://github.com/${badRepo}.git`;
+
+      beforeEach(() => {
+        api.get('/api/launchpad/snaps')
+          .query({
+            repository_url: repositoryUrl
+          })
+          .reply(404, {
+            status: 'error',
+            payload: {
+              code: 'lp-error',
+              message: 'Bad repo URL'
+            }
+          });
+      });
+
+      it('should dispatch error action', () => {
+        return store.dispatch(fetchSnap(badRepo))
+          .then(() => {
+            expect(store.getActions()).toHaveActionOfType(
+              ActionTypes.FETCH_BUILDS_ERROR
+            );
+          });
+      });
+
+      it('should pass error message from repsponse to action', () => {
+        return store.dispatch(fetchSnap(badRepo))
+          .then(() => {
+            const action = store.getActions().filter(a => a.type === ActionTypes.FETCH_BUILDS_ERROR)[0];
+            expect(action.payload.message).toBe('Bad repo URL');
+          });
+      });
+
     });
 
   });

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -91,7 +91,7 @@ describe('repository input actions', () => {
       const snapUrl = 'https://api.launchpad.net/devel/~foo/+snap/bar';
 
       api.get('/api/launchpad/builds')
-        .query({ snap_link: snapUrl })
+        .query({ snap: snapUrl })
         .reply(200, {
           status: 'success',
           payload: {
@@ -113,7 +113,7 @@ describe('repository input actions', () => {
       const barUrl = 'https://api.launchpad.net/devel/~foo/+snap/bad';
 
       api.get('/api/launchpad/builds')
-        .query({ snap_link: barUrl })
+        .query({ snap: barUrl })
         .reply(404, {
           status: 'error',
           payload: {
@@ -161,7 +161,7 @@ describe('repository input actions', () => {
         });
       api.get('/api/launchpad/builds')
         .query({
-          snap_link: snapUrl // should match what /api/launchpad/snaps returned
+          snap: snapUrl // should match what /api/launchpad/snaps returned
         })
         .reply(200, {
           status: 'success',
@@ -185,7 +185,7 @@ describe('repository input actions', () => {
 
       beforeEach(() => {
         api.get('/api/launchpad/builds')
-        .query({ snap_link: barUrl })
+        .query({ snap: barUrl })
         .reply(404, {
           status: 'error',
           payload: {

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -131,8 +131,25 @@ describe('repository input actions', () => {
     });
 
     it('should store builds on fetch success', () => {
+      const repo = 'foo/bar';
+      const repositoryUrl = `https://github.com/${repo}.git`;
+      const snapUrl = 'https://api.launchpad.net/devel/~foo/+snap/bar';
+
+      api.get('/api/launchpad/snaps')
+        .query({
+          repository_url: repositoryUrl // should be called with valid GH url
+        })
+        .reply(200, {
+          status: 'success',
+          payload: {
+            code: 'snap-found',
+            message: snapUrl
+          }
+        });
       api.get('/api/launchpad/builds')
-        .query((query) => query.snap_link) // accept any snap_link in query
+        .query({
+          snap_link: snapUrl // should match what /api/launchpad/snaps returned
+        })
         .reply(200, {
           status: 'success',
           payload: {

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -9,7 +9,7 @@ describe('snapBuilds reducers', () => {
   const initialState = {
     isFetching: false,
     builds: [],
-    error: false
+    error: null
   };
 
   const SNAP_ENTRIES = [{
@@ -125,7 +125,7 @@ describe('snapBuilds reducers', () => {
         payload: SNAP_ENTRIES
       };
 
-      expect(snapBuilds(state, action).error).toBe(false);
+      expect(snapBuilds(state, action).error).toBe(null);
     });
   });
 


### PR DESCRIPTION
<img width="945" alt="screen shot 2016-12-22 at 13 38 22" src="https://cloud.githubusercontent.com/assets/83575/21429498/4ffb1166-c85f-11e6-82e0-0e5e87a8ebee.png">

Going to `/user/repo/builds/` now properly asks LP for snap for given repository and then for builds of this snap.

To test is locally you need to have LP_ env variables properly set up with your user name and auth tokens. Also you need to have a snap created from GH url in LP (for your user) to make it available for your app.

### TODO
- [x] action to get builds from LP API (with hardcoded snap URL)
- [x] action to get snap URL for repository (with mocked response)
- [x] really fetch snap URL from LP API (needs proper LP credentials and some build to test)
