### PR TITLE
Use GITHUB_API_ENDPOINT in RepositoryInput

### DIFF
--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -3,6 +3,7 @@ import 'isomorphic-fetch';
 import conf from '../helpers/config';
 
 const BASE_URL = conf.get('BASE_URL');
+const GITHUB_API_ENDPOINT = conf.get('GITHUB_API_ENDPOINT');
 
 export const SET_GITHUB_REPOSITORY = 'SET_GITHUB_REPOSITORY';
 export const VERIFY_GITHUB_REPOSITORY = 'VERIFY_GITHUB_REPOSITORY';
@@ -36,7 +37,7 @@ export function verifyGitHubRepository(repository) {
         payload: repository
       });
 
-      return fetch(`https://api.github.com/repos/${repository}/contents/snapcraft.yaml`)
+      return fetch(`${GITHUB_API_ENDPOINT}/repos/${repository}/contents/snapcraft.yaml`)
         .then(checkStatus)
         .then(() => dispatch(verifyGitHubRepositorySuccess(`https://github.com/${repository}.git`)))
         .catch(error => dispatch(verifyGitHubRepositoryError(error)));

--- a/src/server/helpers/config.js
+++ b/src/server/helpers/config.js
@@ -9,7 +9,8 @@ import dotenv from 'dotenv';
  */
 const CLIENT_SIDE_WHITELIST = [
   'NODE_ENV',
-  'BASE_URL'
+  'BASE_URL',
+  'GITHUB_API_ENDPOINT'
 ];
 
 let configForClient;

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -105,10 +105,11 @@ describe('repository input actions', () => {
   });
 
   context('verifyGitHubRepository', () => {
+    const GITHUB_API_ENDPOINT = conf.get('GITHUB_API_ENDPOINT');
     let scope;
 
     beforeEach(() => {
-      scope = nock('https://api.github.com');
+      scope = nock(GITHUB_API_ENDPOINT);
     });
 
     afterEach(() => {


### PR DESCRIPTION
Rather than hardcoding api.github.com in RepositoryInput, expose
GITHUB_API_ENDPOINT to the client (which is safe) and use that.