### PR TITLE
Avoid proxy for login.ubuntu.com

### DIFF
--- a/environments/production.env
+++ b/environments/production.env
@@ -12,3 +12,4 @@ GITHUB_API_ENDPOINT=https://api.github.com
 GITHUB_AUTH_LOGIN_URL=https://github.com/login/oauth/authorize
 GITHUB_AUTH_VERIFY_URL=https://github.com/login/oauth/access_token
 GITHUB_AUTH_REDIRECT_URL=https://build.snapcraft.io/auth/verify
+NO_PROXY=login.ubuntu.com

--- a/environments/staging.env
+++ b/environments/staging.env
@@ -12,3 +12,4 @@ GITHUB_API_ENDPOINT=https://api.github.com
 GITHUB_AUTH_LOGIN_URL=https://github.com/login/oauth/authorize
 GITHUB_AUTH_VERIFY_URL=https://github.com/login/oauth/access_token
 GITHUB_AUTH_REDIRECT_URL=https://build.staging.snapcraft.io/auth/verify
+NO_PROXY=login.ubuntu.com


### PR DESCRIPTION
Otherwise OpenID discovery breaks and confuses us all.  This is a bit of
a hack, but it's the simplest way out of our current situation.