### PR TITLE
Making memcached optional (for development and tests)

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -112,6 +112,11 @@ const getMemcached = () => {
   return memcached;
 };
 
+// Test affordance.
+export const setMemcached = (value) => {
+  memcached = value;
+};
+
 class PreparedError extends Error {
   constructor(status, body) {
     super();

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -92,17 +92,24 @@ const RESPONSE_SNAP_NOT_FOUND = {
 
 let memcached = null;
 
-const getMemcached = () => {
-  if (memcached === null) {
-    memcached = new Memcached(conf.get('MEMCACHED_HOST').split(','),
-                              { namespace: 'lp:' });
-  }
-  return memcached;
+const getMemcachedStub = () => {
+  return {
+    get: (key, callback) => callback(),
+    set: (key, value, lifetime, callback) => callback()
+  };
 };
 
-// Test affordance.
-export const setMemcached = (value) => {
-  memcached = value;
+const getMemcached = () => {
+  const host = conf.get('MEMCACHED_HOST') ? conf.get('MEMCACHED_HOST').split(',') : null;
+
+  if (memcached === null) {
+    if (host) {
+      memcached = new Memcached(host, { namespace: 'lp:' });
+    } else {
+      memcached = getMemcachedStub();
+    }
+  }
+  return memcached;
 };
 
 class PreparedError extends Error {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -1,10 +1,10 @@
 import { createHash } from 'crypto';
 
 import yaml from 'js-yaml';
-import Memcached from 'memcached';
 import parseGitHubUrl from 'parse-github-url';
 
 import { conf } from '../helpers/config';
+import { getMemcached } from '../helpers/memcached';
 import requestGitHub from '../helpers/github';
 import getLaunchpad from '../launchpad';
 import logging from '../logging';
@@ -88,33 +88,6 @@ const RESPONSE_SNAP_NOT_FOUND = {
     code: 'snap-not-found',
     message: 'Cannot find existing snap based on this URL'
   }
-};
-
-let memcached = null;
-
-const getMemcachedStub = () => {
-  return {
-    get: (key, callback) => callback(),
-    set: (key, value, lifetime, callback) => callback()
-  };
-};
-
-const getMemcached = () => {
-  const host = conf.get('MEMCACHED_HOST') ? conf.get('MEMCACHED_HOST').split(',') : null;
-
-  if (memcached === null) {
-    if (host) {
-      memcached = new Memcached(host, { namespace: 'lp:' });
-    } else {
-      memcached = getMemcachedStub();
-    }
-  }
-  return memcached;
-};
-
-// Test affordance.
-export const setMemcached = (value) => {
-  memcached = value;
 };
 
 class PreparedError extends Error {

--- a/src/server/helpers/memcached.js
+++ b/src/server/helpers/memcached.js
@@ -1,0 +1,30 @@
+import Memcached from 'memcached';
+
+import { conf } from '../helpers/config';
+
+let memcached = null;
+
+const getMemcachedStub = () => {
+  return {
+    get: (key, callback) => callback(),
+    set: (key, value, lifetime, callback) => callback()
+  };
+};
+
+export const getMemcached = () => {
+  const host = conf.get('MEMCACHED_HOST') ? conf.get('MEMCACHED_HOST').split(',') : null;
+
+  if (memcached === null) {
+    if (host) {
+      memcached = new Memcached(host, { namespace: 'lp:' });
+    } else {
+      memcached = getMemcachedStub();
+    }
+  }
+  return memcached;
+};
+
+// Test affordance.
+export const setMemcached = (value) => {
+  memcached = value;
+};

--- a/src/server/helpers/memcached.js
+++ b/src/server/helpers/memcached.js
@@ -11,6 +11,24 @@ const getMemcachedStub = () => {
   };
 };
 
+const getInMemoryMemcachedStub = () => {
+  const memcachedStub = { cache: {} };
+
+  memcachedStub.get = (key, callback) => {
+    if (callback) {
+      callback(undefined, memcachedStub.cache[key]);
+    }
+  };
+  memcachedStub.set = (key, value, lifetime, callback) => {
+    memcachedStub.cache[key] = value;
+    if (callback) {
+      callback(undefined, true);
+    }
+  };
+
+  return memcachedStub;
+};
+
 export const getMemcached = () => {
   const host = conf.get('MEMCACHED_HOST') ? conf.get('MEMCACHED_HOST').split(',') : null;
 
@@ -24,7 +42,11 @@ export const getMemcached = () => {
   return memcached;
 };
 
-// Test affordance.
-export const setMemcached = (value) => {
-  memcached = value;
+// Test affordance
+export const initInMemoryMemcached = () => {
+  memcached = getInMemoryMemcachedStub();
+};
+
+export const resetMemcached = () => {
+  memcached = null;
 };

--- a/src/server/helpers/memcached.js
+++ b/src/server/helpers/memcached.js
@@ -43,7 +43,7 @@ export const getMemcached = () => {
 };
 
 // Test affordance
-export const initInMemoryMemcached = () => {
+export const setupInMemoryMemcached = () => {
   memcached = getInMemoryMemcachedStub();
 };
 

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -3,7 +3,7 @@ import nock from 'nock';
 import supertest from 'supertest';
 import expect from 'expect';
 
-import { setMemcached } from '../../../../../src/server/handlers/launchpad';
+import { setMemcached } from '../../../../../src/server/helpers/memcached';
 import launchpad from '../../../../../src/server/routes/launchpad';
 import { conf } from '../../../../../src/server/helpers/config.js';
 

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -3,6 +3,7 @@ import nock from 'nock';
 import supertest from 'supertest';
 import expect from 'expect';
 
+import { setMemcached } from '../../../../../src/server/handlers/launchpad';
 import launchpad from '../../../../../src/server/routes/launchpad';
 import { conf } from '../../../../../src/server/helpers/config.js';
 
@@ -457,6 +458,54 @@ describe('The Launchpad API endpoint', () => {
           .end(done);
       });
     });
+
+    context('when repository is memcached', () => {
+      const repositoryUrl = 'https://github.com/anaccount/arepo';
+      const snapUrl = `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`;
+
+      beforeEach(() => {
+        const memcachedStub = { cache: {} };
+        memcachedStub.get = (key, callback) => {
+          callback(undefined, memcachedStub.cache[key]);
+        };
+        memcachedStub.set = (key, value, lifetime, callback) => {
+          memcachedStub.cache[key] = value;
+          callback(undefined, true);
+        };
+        setMemcached(memcachedStub);
+
+        memcachedStub.cache[`url:${repositoryUrl}`] = snapUrl;
+      });
+
+      afterEach(() => {
+        setMemcached(null);
+      });
+
+      it('should return a 200 response', (done) => {
+        supertest(app)
+          .get('/launchpad/snaps')
+          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .expect(200, done);
+      });
+
+      it('should return a "success" status', (done) => {
+        supertest(app)
+          .get('/launchpad/snaps')
+          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .expect(hasStatus('success'))
+          .end(done);
+      });
+
+      it('should return a body with a "snap-found" message with the correct URL', (done) => {
+        supertest(app)
+          .get('/launchpad/snaps')
+          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .expect(hasMessage('snap-found', snapUrl))
+          .end(done);
+      });
+
+    });
+
   });
 
   describe('complete snap authorization route', () => {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -954,22 +954,6 @@ describe('The Launchpad API endpoint', () => {
     const lp_snap_user = 'test-user';
     const lp_snap_path = `/~${lp_snap_user}/+snap/test-snap`;
 
-    beforeEach(() => {
-      const memcachedStub = { cache: {} };
-      memcachedStub.get = (key, callback) => {
-        callback(undefined, memcachedStub.cache[key]);
-      };
-      memcachedStub.set = (key, value, lifetime, callback) => {
-        memcachedStub.cache[key] = value;
-        callback(undefined, true);
-      };
-      setMemcached(memcachedStub);
-    });
-
-    afterEach(() => {
-      setMemcached(null);
-    });
-
     context('when snap exists', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -3,7 +3,6 @@ import nock from 'nock';
 import supertest from 'supertest';
 import expect from 'expect';
 
-import { setMemcached } from '../../../../../src/server/handlers/launchpad';
 import launchpad from '../../../../../src/server/routes/launchpad';
 import { conf } from '../../../../../src/server/helpers/config.js';
 
@@ -315,21 +314,6 @@ describe('The Launchpad API endpoint', () => {
   });
 
   describe('find snap route', () => {
-    beforeEach(() => {
-      const memcachedStub = { cache: {} };
-      memcachedStub.get = (key, callback) => {
-        callback(undefined, memcachedStub.cache[key]);
-      };
-      memcachedStub.set = (key, value, lifetime, callback) => {
-        memcachedStub.cache[key] = value;
-        callback(undefined, true);
-      };
-      setMemcached(memcachedStub);
-    });
-
-    afterEach(() => {
-      setMemcached(null);
-    });
 
     context('when snap exists', () => {
       beforeEach(() => {
@@ -476,21 +460,6 @@ describe('The Launchpad API endpoint', () => {
   });
 
   describe('complete snap authorization route', () => {
-    beforeEach(() => {
-      const memcachedStub = { cache: {} };
-      memcachedStub.get = (key, callback) => {
-        callback(undefined, memcachedStub.cache[key]);
-      };
-      memcachedStub.set = (key, value, lifetime, callback) => {
-        memcachedStub.cache[key] = value;
-        callback(undefined, true);
-      };
-      setMemcached(memcachedStub);
-    });
-
-    afterEach(() => {
-      setMemcached(null);
-    });
 
     context('when snap exists', () => {
       beforeEach(() => {

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -3,7 +3,6 @@ import Express from 'express';
 import nock from 'nock';
 import supertest from 'supertest';
 
-import { setMemcached } from '../../../../../src/server/handlers/launchpad';
 import { conf } from '../../../../../src/server/helpers/config';
 import github from '../../../../../src/server/routes/webhook';
 
@@ -30,20 +29,7 @@ describe('The WebHook API endpoint', () => {
     overrides.clear('LP_API_TOKEN_SECRET');
   });
 
-  beforeEach(() => {
-    const memcachedStub = { cache: {} };
-    memcachedStub.get = (key, callback) => {
-      callback(undefined, memcachedStub.cache[key]);
-    };
-    memcachedStub.set = (key, value, lifetime, callback) => {
-      memcachedStub.cache[key] = value;
-      callback(undefined, true);
-    };
-    setMemcached(memcachedStub);
-  });
-
   afterEach(() => {
-    setMemcached(null);
     nock.cleanAll();
   });
 


### PR DESCRIPTION
If `MEMCACHED_HOST` is not configured launchpad handler will just pass through memcached calls without caching anything.

This allows to run dev server without running memcached server and test without stubbing memcached.