### PR TITLE
Create webhook after creating snap

### DIFF
--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -85,7 +85,7 @@ export function createSnap(repository, location) {
               error.response = response;
               throw error;
             }
-            const startingUrl = `${BASE_URL}/${repository}/builds`;
+            const startingUrl = `${BASE_URL}/${repository}/setup`;
             (location || window.location).href =
               `${BASE_URL}/login/authenticate` +
               `?starting_url=${encodeURIComponent(startingUrl)}` +

--- a/src/common/actions/webhook.js
+++ b/src/common/actions/webhook.js
@@ -1,5 +1,5 @@
 import 'isomorphic-fetch';
-import { createSnap } from './repository-input';
+import { browserHistory } from 'react-router';
 
 export const WEBHOOK_FAILURE = 'WEBHOOK_FAILURE';
 const REQUEST_OPTIONS = {
@@ -10,13 +10,10 @@ const REQUEST_OPTIONS = {
   credentials: 'same-origin'
 };
 
-export function createWebhook(repositoryString) {
+export function createWebhook(account, repo) {
   return (dispatch) => {
-    let settings = REQUEST_OPTIONS;
-    settings.body = JSON.stringify({
-      account: repositoryString.split('/')[0],
-      repo: repositoryString.split('/')[1]
-    });
+    const settings = REQUEST_OPTIONS;
+    settings.body = JSON.stringify({ account, repo });
 
     return fetch(`${getBaseUrl()}/api/github/webhook`, settings)
       .then((response) => {
@@ -27,7 +24,7 @@ export function createWebhook(repositoryString) {
         if (result.status && result.payload) {
           if (result.status == 'success' || result.payload.code == 'github-already-created') {
             // Treat pre-existing builds like a new build
-            dispatch(createSnap(repositoryString));
+            browserHistory.push(`/${account}/${repo}/builds`);
             return;
           }
 

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -2,8 +2,10 @@ import 'isomorphic-fetch';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { setGitHubRepository } from '../../actions/repository-input';
-import { createWebhook } from '../../actions/webhook';
+import {
+  createSnap,
+  setGitHubRepository
+} from '../../actions/repository-input';
 import Button from '../button';
 import Step from '../step';
 import { Anchor } from '../button';
@@ -90,7 +92,7 @@ class RepositoryInput extends Component {
     const { repository } = this.props.repositoryInput;
 
     if (repository) {
-      this.props.dispatch(createWebhook(repository));
+      this.props.dispatch(createSnap(repository));
     }
   }
 }

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -22,7 +22,7 @@ class RepositorySetup extends Component {
     const { fullName, isFetching, success, error } = this.props;
 
     if (success) {
-      this.props.router.push(`/${fullName}/builds`);
+      this.props.router.replace(`/${fullName}/builds`);
     } else {
       return (
         <div className={styles.container}>

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -29,7 +29,6 @@ class RepositorySetup extends Component {
           <Helmet
             title={`Setting up ${fullName}`}
           />
-          <h1>Setting up {fullName}</h1>
           { isFetching &&
             <div className={styles.spinner}><Spinner /></div>
           }

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -11,15 +11,15 @@ import styles from './container.css';
 
 class RepositorySetup extends Component {
   componentDidMount() {
-    const { account, repo, isPending } = this.props;
+    const { account, repo, isFetching } = this.props;
 
-    if (!isPending) {
+    if (!isFetching) {
       this.props.dispatch(createWebhook(account, repo));
     }
   }
 
   render() {
-    const { fullName, isPending, success, error } = this.props;
+    const { fullName, isFetching, success, error } = this.props;
 
     if (success) {
       this.props.router.push(`/${fullName}/builds`);
@@ -30,7 +30,7 @@ class RepositorySetup extends Component {
             title={`Setting up ${fullName}`}
           />
           <h1>Setting up {fullName}</h1>
-          { isPending &&
+          { isFetching &&
             <div className={styles.spinner}><Spinner /></div>
           }
           { error &&
@@ -46,7 +46,7 @@ RepositorySetup.propTypes = {
   account: PropTypes.string.isRequired,
   repo: PropTypes.string.isRequired,
   fullName: PropTypes.string.isRequired,
-  isPending: PropTypes.bool,
+  isFetching: PropTypes.bool,
   success: PropTypes.bool,
   error: PropTypes.object,
   router: PropTypes.object.isRequired,
@@ -58,7 +58,7 @@ const mapStateToProps = (state, ownProps) => {
   const repo = ownProps.params.repo.toLowerCase();
   const fullName = `${account}/${repo}`;
 
-  const isPending = state.webhook.isPending;
+  const isFetching = state.webhook.isFetching;
   const success = state.webhook.success;
   const error = state.webhook.error;
 
@@ -66,7 +66,7 @@ const mapStateToProps = (state, ownProps) => {
     account,
     repo,
     fullName,
-    isPending,
+    isFetching,
     success,
     error
   };

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -1,0 +1,49 @@
+import React, { Component, PropTypes } from 'react';
+import Helmet from 'react-helmet';
+import { connect } from 'react-redux';
+
+import { createWebhook } from '../actions/webhook';
+import Spinner from '../components/spinner';
+
+import styles from './container.css';
+
+class RepositorySetup extends Component {
+  componentDidMount() {
+    this.props.dispatch(createWebhook(this.props.account, this.props.repo));
+  }
+
+  render() {
+    const { fullName } = this.props;
+
+    return (
+      <div className={styles.container}>
+        <Helmet
+          title={`Setting up ${fullName}`}
+        />
+        <h1>Setting up {fullName}</h1>
+        <div className={styles.spinner}><Spinner /></div>
+      </div>
+    );
+  }
+}
+
+RepositorySetup.propTypes = {
+  account: PropTypes.string.isRequired,
+  repo: PropTypes.string.isRequired,
+  fullName: PropTypes.string.isRequired,
+  dispatch: PropTypes.func.isRequired
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const account = ownProps.params.account.toLowerCase();
+  const repo = ownProps.params.repo.toLowerCase();
+  const fullName = `${account}/${repo}`;
+
+  return {
+    account,
+    repo,
+    fullName
+  };
+};
+
+export default connect(mapStateToProps)(RepositorySetup);

--- a/src/common/reducers/webhook.js
+++ b/src/common/reducers/webhook.js
@@ -1,7 +1,7 @@
 import * as ActionTypes from '../actions/webhook';
 
 const INITIAL_STATE = {
-  isPending: false,
+  isFetching: false,
   success: false,
   error: null
 };
@@ -17,19 +17,19 @@ export function webhook(state = INITIAL_STATE, action) {
     case ActionTypes.WEBHOOK:
       return {
         ...state,
-        isPending: true
+        isFetching: true
       };
     case ActionTypes.WEBHOOK_SUCCESS:
       return {
         ...state,
-        isPending: false,
+        isFetching: false,
         success: true,
         error: null
       };
     case ActionTypes.WEBHOOK_FAILURE:
       return {
         ...state,
-        isPending: false,
+        isFetching: false,
         success: false,
         error: { message: ERROR_MESSAGES[action.code] }
       };

--- a/src/common/reducers/webhook.js
+++ b/src/common/reducers/webhook.js
@@ -1,9 +1,9 @@
-import { WEBHOOK_FAILURE } from '../actions/webhook';
+import * as ActionTypes from '../actions/webhook';
 
 const INITIAL_STATE = {
   isPending: false,
   success: false,
-  error: false
+  error: null
 };
 
 const ERROR_MESSAGES = {
@@ -12,12 +12,26 @@ const ERROR_MESSAGES = {
   'github-error-other': 'A problem occurred while the repository was being built. Please try again later'
 };
 
-export function webhook(state = INITIAL_STATE, code) {
-  switch (code.type) {
-    case WEBHOOK_FAILURE:
+export function webhook(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case ActionTypes.WEBHOOK:
       return {
         ...state,
-        error: { message:  ERROR_MESSAGES[code.code] }
+        isPending: true
+      };
+    case ActionTypes.WEBHOOK_SUCCESS:
+      return {
+        ...state,
+        isPending: false,
+        success: true,
+        error: null
+      };
+    case ActionTypes.WEBHOOK_FAILURE:
+      return {
+        ...state,
+        isPending: false,
+        success: false,
+        error: { message: ERROR_MESSAGES[action.code] }
       };
     default:
       return state;

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -5,10 +5,12 @@ import Builds from './containers/builds.js';
 import BuildDetails from './containers/build-details.js';
 import Home from './containers/home.js';
 import LoginFailed from './containers/login-failed.js';
+import RepositorySetup from './containers/repository-setup.js';
 
 export default (
   <Route component={App}>
     <Route path="/" component={Home}/>
+    <Route path="/:account/:repo/setup" component={RepositorySetup}/>
     <Route path="/:account/:repo/builds" component={Builds}/>
     <Route path="/:account/:repo/builds/:buildId" component={BuildDetails}/>
     <Route path="/login/failed" component={LoginFailed}/>

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -174,7 +174,7 @@ describe('repository input actions', () => {
           expect(url.parse(location.href, true)).toMatch({
             path: '/login/authenticate',
             query: {
-              starting_url: '/foo/bar/builds',
+              starting_url: '/foo/bar/setup',
               caveat_id: 'dummy-caveat'
             }
           });

--- a/test/unit/src/common/actions/t_webhook.js
+++ b/test/unit/src/common/actions/t_webhook.js
@@ -2,14 +2,8 @@ import expect from 'expect';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import nock from 'nock';
-import proxyquire from 'proxyquire';
-import sinon from 'sinon';
 
-const browserHistoryStub = {};
-const { createWebhook } = proxyquire(
-  '../../../../../src/common/actions/webhook',
-  { 'react-router': { browserHistory: browserHistoryStub } }
-);
+import { createWebhook } from '../../../../../src/common/actions/webhook';
 
 const middlewares = [ thunk ];
 const mockStore = configureMockStore(middlewares);
@@ -18,19 +12,17 @@ const BASE_URL = 'http://localhost:8000';
 describe('The createWebhook action creator', () => {
   let store;
 
-  beforeEach(() => {
+  before(() => {
     global.window = {
       location: {
         protocol: 'http:',
         host: 'localhost:8000'
       }
     };
-    browserHistoryStub.push = sinon.spy();
   });
 
-  afterEach(() => {
+  after(() => {
     global.window = undefined;
-    delete browserHistoryStub.push;
   });
 
   context('when submitted repository exists and does not have a build', () => {
@@ -55,10 +47,9 @@ describe('The createWebhook action creator', () => {
       nock.cleanAll();
     });
 
-    it('should navigate to builds page', (done) => {
+    it('should dispatch the WEBHOOK_SUCCESS action', (done) => {
       store.dispatch(createWebhook('example', 'example')).then(() => {
-        expect(browserHistoryStub.push.calledWith('/example/example/builds'))
-          .toBeTruthy();
+        expect(store.getActions()).toHaveActionOfType('WEBHOOK_SUCCESS');
         done();
       });
     });
@@ -86,10 +77,9 @@ describe('The createWebhook action creator', () => {
       nock.cleanAll();
     });
 
-    it('should navigate to builds page', (done) => {
+    it('should dispatch the WEBHOOK_SUCCESS', (done) => {
       store.dispatch(createWebhook('example', 'example')).then(() => {
-        expect(browserHistoryStub.push.calledWith('/example/example/builds'))
-          .toBeTruthy();
+        expect(store.getActions()).toHaveActionOfType('WEBHOOK_SUCCESS');
         done();
       });
     });

--- a/test/unit/src/common/actions/t_webhook.js
+++ b/test/unit/src/common/actions/t_webhook.js
@@ -37,7 +37,7 @@ describe('The createWebhook action creator', () => {
         })
       );
       store = mockStore({
-        isPending: false,
+        isFetching: false,
         success: false,
         error: false
       });
@@ -67,7 +67,7 @@ describe('The createWebhook action creator', () => {
         })
       );
       store = mockStore({
-        isPending: false,
+        isFetching: false,
         success: false,
         error: false
       });
@@ -97,7 +97,7 @@ describe('The createWebhook action creator', () => {
         })
       );
       store = mockStore({
-        isPending: false,
+        isFetching: false,
         success: false,
         error: false
       });
@@ -125,7 +125,7 @@ describe('The createWebhook action creator', () => {
         .reply('500', JSON.stringify({}));
 
       store = mockStore({
-        isPending: false,
+        isFetching: false,
         success: false,
         error: false
       });

--- a/test/unit/src/common/reducers/t_webhook.js
+++ b/test/unit/src/common/reducers/t_webhook.js
@@ -4,7 +4,7 @@ import { webhook } from '../../../../../src/common/reducers/webhook';
 
 describe('webhook reducers', () => {
   const initialState = {
-    isPending: false,
+    isFetching: false,
     success: false,
     error: null
   };
@@ -18,20 +18,20 @@ describe('webhook reducers', () => {
   context('WEBHOOK', () => {
     const action = { type: 'WEBHOOK' };
 
-    it('should store pending state', () => {
+    it('should store fetching state', () => {
       expect(webhook(initialState, action)).toEqual({
         ...initialState,
-        isPending: true
+        isFetching: true
       });
     });
   });
 
   context('WEBHOOK_SUCCESS', () => {
-    const state = { ...initialState, isPending: true };
+    const state = { ...initialState, isFetching: true };
     const action = { type: 'WEBHOOK_SUCCESS' };
 
-    it('should clear pending state', () => {
-      expect(webhook(state, action).isPending).toBe(false);
+    it('should clear fetching state', () => {
+      expect(webhook(state, action).isFetching).toBe(false);
     });
 
     it('should store success state', () => {
@@ -41,14 +41,14 @@ describe('webhook reducers', () => {
 
   context('WEBHOOK_FAILURE', () => {
     context('code github-repository-not-found', () => {
-      const state = { ...initialState, isPending: true };
+      const state = { ...initialState, isFetching: true };
       const action = {
         type: 'WEBHOOK_FAILURE',
         code: 'github-repository-not-found'
       };
 
-      it('should clear pending state', () => {
-        expect(webhook(state, action).isPending).toBe(false);
+      it('should clear fetching state', () => {
+        expect(webhook(state, action).isFetching).toBe(false);
       });
 
       it('should clear success state', () => {
@@ -63,14 +63,14 @@ describe('webhook reducers', () => {
     });
 
     context('code github-authentication-failed', () => {
-      const state = { ...initialState, isPending: true };
+      const state = { ...initialState, isFetching: true };
       const action = {
         type: 'WEBHOOK_FAILURE',
         code: 'github-authentication-failed'
       };
 
-      it('should clear pending state', () => {
-        expect(webhook(state, action).isPending).toBe(false);
+      it('should clear fetching state', () => {
+        expect(webhook(state, action).isFetching).toBe(false);
       });
 
       it('should clear success state', () => {
@@ -85,14 +85,14 @@ describe('webhook reducers', () => {
     });
 
     context('code github-error-other', () => {
-      const state = { ...initialState, isPending: true };
+      const state = { ...initialState, isFetching: true };
       const action = {
         type: 'WEBHOOK_FAILURE',
         code: 'github-error-other'
       };
 
-      it('should clear pending state', () => {
-        expect(webhook(state, action).isPending).toBe(false);
+      it('should clear fetching state', () => {
+        expect(webhook(state, action).isFetching).toBe(false);
       });
 
       it('should clear success state', () => {

--- a/test/unit/src/common/reducers/t_webhook.js
+++ b/test/unit/src/common/reducers/t_webhook.js
@@ -6,69 +6,104 @@ describe('webhook reducers', () => {
   const initialState = {
     isPending: false,
     success: false,
-    error: false
+    error: null
   };
 
   context('when called with an unknown action', () => {
-    let resultState;
-
-    beforeEach(() => {
-      resultState = webhook(undefined, {});
-    });
-
     it('should return the initial state', () => {
-      expect(resultState).toEqual(initialState);
+      expect(webhook(undefined, {})).toEqual(initialState);
     });
   });
 
-  context('when called with action type WEBHOOK_FAILURE and code github-repository-not-found', () => {
-    let resultState;
+  context('WEBHOOK', () => {
+    const action = { type: 'WEBHOOK' };
 
-    beforeEach(() => {
-      resultState = webhook(initialState, {
+    it('should store pending state', () => {
+      expect(webhook(initialState, action)).toEqual({
+        ...initialState,
+        isPending: true
+      });
+    });
+  });
+
+  context('WEBHOOK_SUCCESS', () => {
+    const state = { ...initialState, isPending: true };
+    const action = { type: 'WEBHOOK_SUCCESS' };
+
+    it('should clear pending state', () => {
+      expect(webhook(state, action).isPending).toBe(false);
+    });
+
+    it('should store success state', () => {
+      expect(webhook(state, action).success).toBe(true);
+    });
+  });
+
+  context('WEBHOOK_FAILURE', () => {
+    context('code github-repository-not-found', () => {
+      const state = { ...initialState, isPending: true };
+      const action = {
         type: 'WEBHOOK_FAILURE',
         code: 'github-repository-not-found'
+      };
+
+      it('should clear pending state', () => {
+        expect(webhook(state, action).isPending).toBe(false);
+      });
+
+      it('should clear success state', () => {
+        expect(webhook(state, action).success).toBe(false);
+      });
+
+      it('should store error message beginning "A repository could not be found"', () => {
+        expect(webhook(state, action).error.message).toBe(
+          'A repository could not be found, or access is not granted for given repository details'
+        );
       });
     });
 
-    it('should return a state with an error message beginning "A repository could not be found"', () => {
-      expect(resultState.error.message).toBe(
-        'A repository could not be found, or access is not granted for given repository details'
-      );
-    });
-  });
-
-  context('when called with action type WEBHOOK_FAILURE and code github-authentication-failed', () => {
-    let resultState;
-
-    beforeEach(() => {
-      resultState = webhook(initialState, {
+    context('code github-authentication-failed', () => {
+      const state = { ...initialState, isPending: true };
+      const action = {
         type: 'WEBHOOK_FAILURE',
         code: 'github-authentication-failed'
+      };
+
+      it('should clear pending state', () => {
+        expect(webhook(state, action).isPending).toBe(false);
+      });
+
+      it('should clear success state', () => {
+        expect(webhook(state, action).success).toBe(false);
+      });
+
+      it('should store error message beginning "A problem occurred when accessing repository"', () => {
+        expect(webhook(state, action).error.message).toBe(
+          'A problem occurred when accessing repository. Please try logging in again'
+        );
       });
     });
 
-    it('should return a state with an error message beginning "A problem occurred when accessing repository"', () => {
-      expect(resultState.error.message).toBe(
-        'A problem occurred when accessing repository. Please try logging in again'
-      );
-    });
-  });
-
-  context('when called with action type WEBHOOK_FAILURE and code github-error-other', () => {
-    let resultState;
-
-    beforeEach(() => {
-      resultState = webhook(initialState, {
+    context('code github-error-other', () => {
+      const state = { ...initialState, isPending: true };
+      const action = {
         type: 'WEBHOOK_FAILURE',
         code: 'github-error-other'
-      });
-    });
+      };
 
-    it('should return a state with an error message beginning "A problem occurred while the repository was being built"', () => {
-      expect(resultState.error.message).toBe(
-        'A problem occurred while the repository was being built. Please try again later'
-      );
+      it('should clear pending state', () => {
+        expect(webhook(state, action).isPending).toBe(false);
+      });
+
+      it('should clear success state', () => {
+        expect(webhook(state, action).success).toBe(false);
+      });
+
+      it('should store error message beginning "A problem occurred while the repository was being built"', () => {
+        expect(webhook(state, action).error.message).toBe(
+          'A problem occurred while the repository was being built. Please try again later'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
We should only install a webhook on the repository once we have a snap
for it to operate on.  This also reduces rollback complexity in the case
where something goes wrong while creating the snap.

I added a new client-side /:account/:repo/setup route that deals with
setting up the repository (currently only installing the webhook) and
then redirects to /:account/:repo/builds.  This gives us somewhere we
can run repository setup code after emerging from SSO authorisation, and
seems a better idea than doing it directly on /:account/:repo/builds.