### PR TITLE
Import isomorphic-fetch consistently

### DIFF
--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -1,3 +1,5 @@
+import 'isomorphic-fetch';
+
 import conf from '../helpers/config';
 import getGitHubRepoUrl from '../helpers/github-url';
 

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -1,4 +1,3 @@
-import 'isomorphic-fetch';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 


### PR DESCRIPTION
For consistency, we should import isomorphic-fetch anywhere that we're
using fetch, and not where we aren't.