### PR TITLE
Request initial builds from repository setup page

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -70,7 +70,7 @@ as returned by the Launchpad API:
 
 To request builds of an existing snap:
 
-    POST /api/launchpad/snap/request-builds
+    POST /api/launchpad/snaps/request-builds
     Cookie: <session cookie>
     Content-Type: application/json
     Accept: application/json

--- a/src/common/actions/request-snap-builds.js
+++ b/src/common/actions/request-snap-builds.js
@@ -1,0 +1,67 @@
+import 'isomorphic-fetch';
+
+import conf from '../helpers/config';
+import getGitHubRepoUrl from '../helpers/github-url';
+
+const BASE_URL = conf.get('BASE_URL');
+
+export const REQUEST_BUILDS = 'REQUEST_BUILDS';
+export const REQUEST_BUILDS_SUCCESS = 'REQUEST_BUILDS_SUCCESS';
+export const REQUEST_BUILDS_ERROR = 'REQUEST_BUILDS_ERROR';
+
+const REQUEST_OPTIONS = {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json'
+  },
+  credentials: 'same-origin'
+};
+
+export function requestBuildsSuccess(builds) {
+  return {
+    type: REQUEST_BUILDS_SUCCESS,
+    payload: builds
+  };
+}
+
+export function requestBuildsError(error) {
+  return {
+    type: REQUEST_BUILDS_ERROR,
+    payload: error,
+    error: true
+  };
+}
+
+function checkStatus(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  } else {
+    return response.json().then((json) => {
+      // throw an error based on message from response body or status text
+      const error = new Error(json.payload.message || response.statusText);
+      error.status = response.status;
+      error.response = response;
+      throw error;
+    });
+  }
+}
+
+export function requestBuilds(repository) {
+  return (dispatch) => {
+    if (repository) {
+      dispatch({
+        type: REQUEST_BUILDS
+      });
+
+      const repositoryUrl = getGitHubRepoUrl(repository);
+      const url = `${BASE_URL}/api/launchpad/snaps/request-builds`;
+      const settings = REQUEST_OPTIONS;
+      settings.body = JSON.stringify({ repository_url: repositoryUrl });
+      return fetch(url, settings)
+        .then(checkStatus)
+        .then((response) => response.json())
+        .then((json) => dispatch(requestBuildsSuccess(json.payload.builds)))
+        .catch((error) => dispatch(requestBuildsError(error)));
+    }
+  };
+}

--- a/src/common/reducers/index.js
+++ b/src/common/reducers/index.js
@@ -4,6 +4,7 @@ import { combineReducers } from 'redux';
 import * as repositoryInput from './repository-input';
 import * as authError from './auth-error';
 import * as snapBuilds from '../reducers/snap-builds';
+import * as requestSnapBuilds from '../reducers/request-snap-builds';
 import * as auth from './auth';
 import * as webhook from './webhook';
 
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   ...repositoryInput,
   ...authError,
   ...snapBuilds,
+  ...requestSnapBuilds,
   ...auth,
   ...webhook,
   routing: routerReducer

--- a/src/common/reducers/request-snap-builds.js
+++ b/src/common/reducers/request-snap-builds.js
@@ -1,0 +1,34 @@
+import * as ActionTypes from '../actions/request-snap-builds';
+import { snapBuildFromAPI } from '../helpers/snap-builds';
+
+export function requestSnapBuilds(state = {
+  isFetching: false,
+  builds: [],
+  success: false,
+  error: null
+}, action) {
+  switch(action.type) {
+    case ActionTypes.REQUEST_BUILDS:
+      return {
+        ...state,
+        isFetching: true
+      };
+    case ActionTypes.REQUEST_BUILDS_SUCCESS:
+      return {
+        ...state,
+        isFetching: false,
+        success: true,
+        builds: action.payload.map(snapBuildFromAPI),
+        error: null
+      };
+    case ActionTypes.REQUEST_BUILDS_ERROR:
+      return {
+        ...state,
+        isFetching: false,
+        success: false,
+        error: action.payload
+      };
+    default:
+      return state;
+  }
+}

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -388,7 +388,7 @@ export const requestSnapBuilds = (req, res) => {
         status: 'success',
         payload: {
           code: 'snap-builds-requested',
-          builds: builds.entries
+          builds: builds
         }
       });
     })

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -800,20 +800,16 @@ describe('The Launchpad API endpoint', () => {
           .post(`/devel${lp_snap_path}`, {
             'ws.op': 'requestAutoBuilds'
           })
-          .reply(200, {
-            total_size: 2,
-            start: 0,
-            entries: [
-              {
-                resource_type_link: `${lp_api_base}/#snap_build`,
-                self_link: `${lp_api_base}${lp_snap_path}/+build/1`
-              },
-              {
-                resource_type_link: `${lp_api_base}/#snap_build`,
-                self_link: `${lp_api_base}${lp_snap_path}/+build/2`
-              }
-            ]
-          });
+          .reply(200, [
+            {
+              resource_type_link: `${lp_api_base}/#snap_build`,
+              self_link: `${lp_api_base}${lp_snap_path}/+build/1`
+            },
+            {
+              resource_type_link: `${lp_api_base}/#snap_build`,
+              self_link: `${lp_api_base}${lp_snap_path}/+build/2`
+            }
+          ]);
       });
 
       afterEach(() => {

--- a/test/unit/src/common/actions/t_request-snap-builds.js
+++ b/test/unit/src/common/actions/t_request-snap-builds.js
@@ -1,0 +1,134 @@
+import expect from 'expect';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import nock from 'nock';
+import { isFSA } from 'flux-standard-action';
+
+import { conf } from '../../../../../src/server/helpers/config';
+
+import {
+  requestBuilds,
+  requestBuildsSuccess,
+  requestBuildsError
+} from '../../../../../src/common/actions/request-snap-builds';
+import * as ActionTypes from '../../../../../src/common/actions/request-snap-builds';
+
+const middlewares = [ thunk ];
+const mockStore = configureMockStore(middlewares);
+
+describe('request snap builds actions', () => {
+  const initialState = {
+    isFetching: false,
+    builds: [],
+    error: false
+  };
+
+  let store;
+  let action;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+  });
+
+  context('requestBuildsSuccess', () => {
+    let payload = [ { build: 'test1' }, { build: 'test2' }];
+
+    beforeEach(() => {
+      action = requestBuildsSuccess(payload);
+    });
+
+    it('should create an action to store snap builds', () => {
+      const expectedAction = {
+        type: ActionTypes.REQUEST_BUILDS_SUCCESS,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('requestBuildsError', () => {
+    let payload = 'Something went wrong!';
+
+    beforeEach(() => {
+      action = requestBuildsError(payload);
+    });
+
+    it('should create an action to store request error on failure', () => {
+      const expectedAction = {
+        type: ActionTypes.REQUEST_BUILDS_ERROR,
+        error: true,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('requestBuilds', () => {
+    let api;
+    const repo = 'foo/bar';
+    const repositoryUrl = `https://github.com/${repo}`;
+
+    beforeEach(() => {
+      api = nock(conf.get('BASE_URL'));
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('should store builds on request success', () => {
+      api
+        .post('/api/launchpad/snaps/request-builds', {
+          repository_url: repositoryUrl
+        })
+        .reply(201, {
+          status: 'success',
+          payload: {
+            code: 'snap-builds-requested',
+            builds: []
+          }
+        });
+
+      return store.dispatch(requestBuilds(repo))
+        .then(() => {
+          api.done();
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.REQUEST_BUILDS_SUCCESS
+          );
+        });
+    });
+
+    it('should store error on Launchpad request failure', () => {
+      api
+        .post('/api/launchpad/snaps/request-builds', {
+          repository_url: repositoryUrl
+        })
+        .reply(404, {
+          status: 'error',
+          payload: {
+            code: 'lp-error',
+            message: 'Something went wrong'
+          }
+        });
+
+      return store.dispatch(requestBuilds(repo))
+        .then(() => {
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.REQUEST_BUILDS_ERROR
+          );
+        });
+    });
+  });
+});

--- a/test/unit/src/common/reducers/t_request-snap-builds.js
+++ b/test/unit/src/common/reducers/t_request-snap-builds.js
@@ -1,0 +1,127 @@
+import expect from 'expect';
+
+import { requestSnapBuilds } from '../../../../../src/common/reducers/request-snap-builds';
+import * as ActionTypes from '../../../../../src/common/actions/request-snap-builds';
+
+import { snapBuildFromAPI } from '../../../../../src/common/helpers/snap-builds';
+
+describe('requestSnapBuilds reducers', () => {
+  const initialState = {
+    isFetching: false,
+    builds: [],
+    success: false,
+    error: null
+  };
+
+  const BUILD_ENTRIES = [{
+    resource_type_link: 'https://api.launchpad.net/devel/#snap_build',
+    self_link: 'https://api.launchpad.net/devel/~foo/+snap/bar/+build/1',
+    buildstate: 'Needs building'
+  }, {
+    resource_type_link: 'https://api.launchpad.net/devel/#snap_build',
+    self_link: 'https://api.launchpad.net/devel/~foo/+snap/bar/+build/2',
+    buildstate: 'Needs building'
+  }];
+
+  it('should return the initial state', () => {
+    expect(requestSnapBuilds(undefined, {})).toEqual(initialState);
+  });
+
+  context('REQUEST_BUILDS', () => {
+    it('should store requesting status when requesting builds', () => {
+      const action = {
+        type: ActionTypes.REQUEST_BUILDS,
+        payload: 'test'
+      };
+
+      expect(requestSnapBuilds(initialState, action)).toEqual({
+        ...initialState,
+        isFetching: true
+      });
+    });
+  });
+
+  context('REQUEST_BUILDS_SUCCESS', () => {
+
+    it('should stop fetching', () => {
+      const state = {
+        ...initialState,
+        isFetching: true
+      };
+
+      const action = {
+        type: ActionTypes.REQUEST_BUILDS_SUCCESS,
+        payload: BUILD_ENTRIES
+      };
+
+      expect(requestSnapBuilds(state, action).isFetching).toBe(false);
+    });
+
+    it('should store builds on request success', () => {
+      const state = {
+        ...initialState,
+        isFetching: true
+      };
+
+      const action = {
+        type: ActionTypes.REQUEST_BUILDS_SUCCESS,
+        payload: BUILD_ENTRIES
+      };
+
+      expect(requestSnapBuilds(state, action).builds)
+        .toEqual(BUILD_ENTRIES.map(snapBuildFromAPI));
+    });
+
+    it('should store success state', () => {
+      const state = {
+        ...initialState,
+        isFetching: true
+      };
+
+      const action = {
+        type: ActionTypes.REQUEST_BUILDS_SUCCESS,
+        payload: BUILD_ENTRIES
+      };
+
+      expect(requestSnapBuilds(state, action).success).toBe(true);
+    });
+
+    it('should clean error', () => {
+      const state = {
+        ...initialState,
+        error: 'Previous error'
+      };
+
+      const action = {
+        type: ActionTypes.REQUEST_BUILDS_SUCCESS,
+        payload: BUILD_ENTRIES
+      };
+
+      expect(requestSnapBuilds(state, action).error).toBe(null);
+    });
+  });
+
+  context('REQUEST_BUILDS_ERROR', () => {
+    it('should handle request builds failure', () => {
+      const state = {
+        ...initialState,
+        success: true,
+        builds: BUILD_ENTRIES,
+        isFetching: true
+      };
+
+      const action = {
+        type: ActionTypes.REQUEST_BUILDS_ERROR,
+        payload: 'Something went wrong!',
+        error: true
+      };
+
+      expect(requestSnapBuilds(state, action)).toEqual({
+        ...state,
+        isFetching: false,
+        success: false,
+        error: action.payload
+      });
+    });
+  });
+});

--- a/test/unit/src/common/reducers/t_request-snap-builds.js
+++ b/test/unit/src/common/reducers/t_request-snap-builds.js
@@ -28,7 +28,7 @@ describe('requestSnapBuilds reducers', () => {
   });
 
   context('REQUEST_BUILDS', () => {
-    it('should store requesting status when requesting builds', () => {
+    it('should store fetching status when requesting builds', () => {
       const action = {
         type: ActionTypes.REQUEST_BUILDS,
         payload: 'test'


### PR DESCRIPTION
We can do this in parallel with installing the webhook, and it means
that we get a satisfying response from the builds page right away.