### PR TITLE
If error from LP says that snap exists, just redirect to builds view

### DIFF
--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -99,7 +99,14 @@ export function createSnap(repository, location) {
               `&repository_url=${encodeURIComponent(repositoryUrl)}`;
           });
         })
-        .catch(error => dispatch(createSnapError(error)));
+        .catch(error => {
+          // if LP error says there is already such snap, just redirect to builds page
+          if (error.message === 'There is already a snap package with the same name and owner.') {
+            (location || window.location).href = `${BASE_URL}/${repository}/builds`;
+          } else {
+            dispatch(createSnapError(error));
+          }
+        });
     }
   };
 }


### PR DESCRIPTION
As title says.

A little hacky (as it seems the only way to check this specific error is to compare error message), but seems to be working good enough.