### PR TITLE
Fix HMAC chaining in webhook verification

### DIFF
--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -1,7 +1,7 @@
 import { conf } from '../helpers/config';
 import requestGitHub from '../helpers/github';
 import logging from '../logging';
-import { makeWebhookHmac } from './webhook';
+import { makeWebhookSecret } from './webhook';
 
 const logger = logging.getLogger('express-error');
 
@@ -50,7 +50,7 @@ export const createWebhook = (req, res) => {
 
   let secret;
   try {
-    secret = makeWebhookHmac(account, repo).digest('hex');
+    secret = makeWebhookSecret(account, repo);
   } catch (e) {
     return res.status(500).send({
       status: 'error',

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -30,8 +30,7 @@ export const notify = (req, res) => {
     logger.info(`Unexpected token ${firstchar}`);
     return res.status(400).send();
   }
-  const body = JSON.parse(req.body);
-  logger.debug('Received webhook: ', body);
+  logger.debug('Received webhook: ', req.body);
 
   let hmac;
   try {

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -6,7 +6,7 @@ const logging = require('../logging/').default;
 const logger = logging.getLogger('express-error');
 import { uncheckedRequestSnapBuilds } from './launchpad';
 
-export const makeWebhookHmac = (account, repo) => {
+export const makeWebhookSecret = (account, repo) => {
   const rootSecret = conf.get('GITHUB_WEBHOOK_SECRET');
   if (!rootSecret) {
     throw new Error('GitHub webhook secret not configured');
@@ -14,7 +14,7 @@ export const makeWebhookHmac = (account, repo) => {
   const hmac = createHmac('sha1', rootSecret);
   hmac.update(account);
   hmac.update(repo);
-  return hmac;
+  return hmac.digest('hex');
 };
 
 // Response bodies won't go anywhere very useful, but at least try to send
@@ -32,13 +32,14 @@ export const notify = (req, res) => {
   }
   logger.debug('Received webhook: ', req.body);
 
-  let hmac;
+  let secret;
   try {
-    hmac = makeWebhookHmac(req.params.account, req.params.repo);
+    secret = makeWebhookSecret(req.params.account, req.params.repo);
   } catch (e) {
     logger.info(e.message);
     return res.status(500).send();
   }
+  const hmac = createHmac('sha1', secret);
   hmac.update(req.body);
   const computedSignature = `sha1=${hmac.digest('hex')}`;
   if (signature !== computedSignature) {

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -55,9 +55,10 @@ describe('The WebHook API endpoint', () => {
 
     it('rejects requests with a bad signature', (done) => {
       const body = JSON.stringify({ ref: 'refs/heads/master' });
-      const hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
+      let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
       hmac.update('anaccount');
       hmac.update('arepo');
+      hmac = createHmac('sha1', hmac.digest('hex'));
       hmac.update(body + ' ');
       supertest(app)
         .post('/anaccount/arepo/webhook/notify')
@@ -108,9 +109,10 @@ describe('The WebHook API endpoint', () => {
         });
 
       const body = JSON.stringify({ ref: 'refs/heads/master' });
-      const hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
+      let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
       hmac.update('anaccount');
       hmac.update('arepo');
+      hmac = createHmac('sha1', hmac.digest('hex'));
       hmac.update(body);
       supertest(app)
         .post('/anaccount/arepo/webhook/notify')
@@ -138,9 +140,10 @@ describe('The WebHook API endpoint', () => {
         });
 
       const body = JSON.stringify({ ref: 'refs/heads/master' });
-      const hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
+      let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
       hmac.update('anaccount');
       hmac.update('arepo');
+      hmac = createHmac('sha1', hmac.digest('hex'));
       hmac.update(body);
       supertest(app)
         .post('/anaccount/arepo/webhook/notify')


### PR DESCRIPTION
We pass the hex digest of an HMAC to GitHub for it to use as the secret
for a new HMAC; this is not equivalent to chaining multiple update calls
onto a single HMAC instance.  Fix the verification process to match what
GitHub is doing.