### PR TITLE
Fix spurious promise rejection in internalFindSnap

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -328,7 +328,7 @@ const internalFindSnap = async (repositoryUrl) => {
         // https://github.com/babel/babel-eslint/issues/415
         for await (const entry of result) { // eslint-disable-line semi
           if (entry.owner_link.endsWith(`/~${username}`)) {
-            getMemcached().set(cacheId, entry.self_link, 3600, () => {
+            return getMemcached().set(cacheId, entry.self_link, 3600, () => {
               return resolve(entry.self_link);
             });
           }

--- a/src/server/helpers/memcached.js
+++ b/src/server/helpers/memcached.js
@@ -4,10 +4,16 @@ import { conf } from '../helpers/config';
 
 let memcached = null;
 
+// Return a Promise that calls the given callback soon, but not immediately.
+// This helps to exercise asynchronicity bugs in memcached client code.
+const runSoon = (callback) => {
+  return new Promise((resolve) => setTimeout(resolve, 1)).then(callback);
+};
+
 const getMemcachedStub = () => {
   return {
-    get: (key, callback) => callback(),
-    set: (key, value, lifetime, callback) => callback()
+    get: (key, callback) => runSoon(callback),
+    set: (key, value, lifetime, callback) => runSoon(callback)
   };
 };
 
@@ -16,13 +22,13 @@ const getInMemoryMemcachedStub = () => {
 
   memcachedStub.get = (key, callback) => {
     if (callback) {
-      callback(undefined, memcachedStub.cache[key]);
+      runSoon(() => callback(undefined, memcachedStub.cache[key]));
     }
   };
   memcachedStub.set = (key, value, lifetime, callback) => {
     memcachedStub.cache[key] = value;
     if (callback) {
-      callback(undefined, true);
+      runSoon(() => callback(undefined, true));
     }
   };
 


### PR DESCRIPTION
If internalFindSnap doesn't find the given repository URL in memcached,
it looks for it in Launchpad, iterating through all snaps with that URL.
If one of them matches the service username, it stores that in memcached
and resolves the promise with its link; otherwise, it rejects the
promise with a snap-not-found error.

However, this code incorrectly fell through to the last-resort promise
rejection, and because memcached set is asynchronous the rejection would
typically be processed before the resolution.  We didn't catch this
because the memcached stub in tests was synchronous.  Avoid this
incorrect fallthrough and strengthen the tests to catch bugs of this
form.

Fixes #79.