### PR TITLE
Various logging improvements

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -865,6 +865,9 @@
         }
       }
     },
+    "winston-daily-rotate-file": {
+      "version": "1.4.2"
+    },
     "wrap-ansi": {
       "version": "2.1.0"
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
     "request": "^2.79.0",
-    "winston": "^2.3.0"
+    "winston": "^2.3.0",
+    "winston-daily-rotate-file": "^1.4.2"
   },
   "devDependencies": {
     "assets-webpack-plugin": "^3.5.0",
@@ -106,7 +107,6 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.8.4",
-    "webpack-hot-middleware": "^2.13.0",
-    "winston": "^2.3.0"
+    "webpack-hot-middleware": "^2.13.0"
   }
 }

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -3,7 +3,8 @@ import requestGitHub from '../helpers/github';
 import logging from '../logging';
 import { makeWebhookSecret } from './webhook';
 
-const logger = logging.getLogger('express-error');
+const logger = logging.getLogger('express');
+const errorLogger = logging.getLogger('express-error');
 
 const RESPONSE_NOT_FOUND = {
   status: 'error',
@@ -79,14 +80,14 @@ export const createWebhook = (req, res) => {
             return res.status(422).send(RESPONSE_ALREADY_CREATED);
           default:
             // Something else
-            logger.info('GitHub API error', response.statusCode);
+            errorLogger.info('GitHub API error', response.statusCode);
             return res.status(500).send(RESPONSE_OTHER);
         }
       }
 
       return res.status(201).send(RESPONSE_CREATED);
     }).catch((err) => {
-      logger.info('GitHub API error', err);
+      errorLogger.info('GitHub API error', err);
       return res.status(500).send(err.message);
     });
 };

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -4,7 +4,6 @@ import logging from '../logging';
 import { makeWebhookSecret } from './webhook';
 
 const logger = logging.getLogger('express');
-const errorLogger = logging.getLogger('express-error');
 
 const RESPONSE_NOT_FOUND = {
   status: 'error',
@@ -80,14 +79,14 @@ export const createWebhook = (req, res) => {
             return res.status(422).send(RESPONSE_ALREADY_CREATED);
           default:
             // Something else
-            errorLogger.info('GitHub API error', response.statusCode);
+            logger.error('GitHub API error', response.statusCode);
             return res.status(500).send(RESPONSE_OTHER);
         }
       }
 
       return res.status(201).send(RESPONSE_CREATED);
     }).catch((err) => {
-      errorLogger.info('GitHub API error', err);
+      logger.error('GitHub API error', err);
       return res.status(500).send(err.message);
     });
 };

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -10,7 +10,6 @@ import getLaunchpad from '../launchpad';
 import logging from '../logging';
 
 const logger = logging.getLogger('express');
-const errorLogger = logging.getLogger('express-error');
 
 // XXX cjwatson 2016-12-08: Hardcoded for now, but should eventually be
 // configurable.
@@ -110,7 +109,7 @@ const prepareError = (error) => {
     // if it's ResourceError from LP client at least for the moment
     // we just wrap the error we get from LP
     return error.response.text().then((text) => {
-      errorLogger.info('Launchpad API error:', text);
+      logger.error('Launchpad API error:', text);
       return new PreparedError(error.response.status, {
         status: 'error',
         payload: {
@@ -144,7 +143,7 @@ const checkGitHubStatus = (response) => {
       try {
         body = JSON.parse(body);
       } catch (e) {
-        errorLogger.info('Invalid JSON received', e, body);
+        logger.error('Invalid JSON received', e, body);
         throw new PreparedError(500, RESPONSE_GITHUB_OTHER);
       }
     }
@@ -157,7 +156,7 @@ const checkGitHubStatus = (response) => {
         throw new PreparedError(401, RESPONSE_GITHUB_AUTHENTICATION_FAILED);
       default:
         // Something else
-        errorLogger.info('GitHub API error:', response.statusCode, body);
+        logger.error('GitHub API error:', response.statusCode, body);
         throw new PreparedError(500, RESPONSE_GITHUB_OTHER);
     }
   }

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -9,7 +9,8 @@ import requestGitHub from '../helpers/github';
 import getLaunchpad from '../launchpad';
 import logging from '../logging';
 
-const logger = logging.getLogger('express-error');
+const logger = logging.getLogger('express');
+const errorLogger = logging.getLogger('express-error');
 
 // XXX cjwatson 2016-12-08: Hardcoded for now, but should eventually be
 // configurable.
@@ -109,7 +110,7 @@ const prepareError = (error) => {
     // if it's ResourceError from LP client at least for the moment
     // we just wrap the error we get from LP
     return error.response.text().then((text) => {
-      logger.info('Launchpad API error:', text);
+      errorLogger.info('Launchpad API error:', text);
       return new PreparedError(error.response.status, {
         status: 'error',
         payload: {
@@ -143,7 +144,7 @@ const checkGitHubStatus = (response) => {
       try {
         body = JSON.parse(body);
       } catch (e) {
-        logger.info('Invalid JSON received', e, body);
+        errorLogger.info('Invalid JSON received', e, body);
         throw new PreparedError(500, RESPONSE_GITHUB_OTHER);
       }
     }
@@ -156,7 +157,7 @@ const checkGitHubStatus = (response) => {
         throw new PreparedError(401, RESPONSE_GITHUB_AUTHENTICATION_FAILED);
       default:
         // Something else
-        logger.info('GitHub API error:', response.statusCode, body);
+        errorLogger.info('GitHub API error:', response.statusCode, body);
         throw new PreparedError(500, RESPONSE_GITHUB_OTHER);
     }
   }

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -2,9 +2,11 @@ import { createHmac } from 'crypto';
 
 import getGitHubRepoUrl from '../../common/helpers/github-url';
 import { conf } from '../helpers/config';
-const logging = require('../logging/').default;
-const logger = logging.getLogger('express-error');
+import logging from '../logging';
 import { uncheckedRequestSnapBuilds } from './launchpad';
+
+const logger = logging.getLogger('express');
+const errorLogger = logging.getLogger('express-error');
 
 export const makeWebhookSecret = (account, repo) => {
   const rootSecret = conf.get('GITHUB_WEBHOOK_SECRET');
@@ -36,7 +38,7 @@ export const notify = (req, res) => {
   try {
     secret = makeWebhookSecret(req.params.account, req.params.repo);
   } catch (e) {
-    logger.info(e.message);
+    errorLogger.info(e.message);
     return res.status(500).send();
   }
   const hmac = createHmac('sha1', secret);
@@ -60,7 +62,8 @@ export const notify = (req, res) => {
         return res.status(200).send();
       })
       .catch((error) => {
-        logger.info(`Failed to request builds of ${repositoryUrl}: ${error}.`);
+        errorLogger.info(`Failed to request builds of ${repositoryUrl}: ` +
+                         `${error}.`);
         return res.status(500).send();
       });
   }

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -6,7 +6,6 @@ import logging from '../logging';
 import { uncheckedRequestSnapBuilds } from './launchpad';
 
 const logger = logging.getLogger('express');
-const errorLogger = logging.getLogger('express-error');
 
 export const makeWebhookSecret = (account, repo) => {
   const rootSecret = conf.get('GITHUB_WEBHOOK_SECRET');
@@ -38,7 +37,7 @@ export const notify = (req, res) => {
   try {
     secret = makeWebhookSecret(req.params.account, req.params.repo);
   } catch (e) {
-    errorLogger.info(e.message);
+    logger.error(e.message);
     return res.status(500).send();
   }
   const hmac = createHmac('sha1', secret);
@@ -62,8 +61,8 @@ export const notify = (req, res) => {
         return res.status(200).send();
       })
       .catch((error) => {
-        errorLogger.info(`Failed to request builds of ${repositoryUrl}: ` +
-                         `${error}.`);
+        logger.error(`Failed to request builds of ${repositoryUrl}: ` +
+                     `${error}.`);
         return res.status(500).send();
       });
   }

--- a/src/server/logging/index.js
+++ b/src/server/logging/index.js
@@ -14,8 +14,9 @@ const debug = process.env.DEBUGLOG;
 const loggerDefaults = {
   exitOnError: false,
   levels: {
-    info: 0,
-    debug: 1
+    error: 0,
+    info: 1,
+    debug: 2
   },
   rewriters: [ idRewriter ]
 };

--- a/src/server/logging/index.js
+++ b/src/server/logging/index.js
@@ -1,22 +1,14 @@
 import winston from 'winston';
+import 'winston-daily-rotate-file';
 
+import { conf } from '../helpers/config';
 import { formatter, timestamp } from './lib/log-formatter.js';
 
-// configure the 2 transports, share with all loggers, label from config ...
+// configure the transports, share with all loggers, label from config ...
 // add bug that label should be set in logger
 
+const LOGS_PATH = conf.get('LOGS_PATH');
 const debug = process.env.DEBUGLOG;
-
-// console transport for info level messages, sent to stderr
-const transports = [
-  new winston.transports.Console({
-    colorize: true,
-    formatter: formatter,
-    level: 'info',
-    stderrLevels: ['info'],
-    timestamp: timestamp
-  })
-];
 
 // default logger settings
 const loggerDefaults = {
@@ -25,8 +17,7 @@ const loggerDefaults = {
     info: 0,
     debug: 1
   },
-  rewriters: [ idRewriter ],
-  transports: transports,
+  rewriters: [ idRewriter ]
 };
 
 winston.configure({
@@ -34,21 +25,18 @@ winston.configure({
   id: 'root'
 });
 
+let debugTransport = null;
 if (debug) {
-  enableDebugLogger(debug, formatter, timestamp, winston);
+  debugTransport = getDebugTransport(debug, formatter, timestamp, winston);
 }
 
-export function enableDebugLogger(filename, formatter, timestamp, winston) {
-  // TODO daily rotating log transport
-  const transport = new winston.transports.File({
-    filename: filename,
-    formatter: formatter,
+export function getDebugTransport(filename, formatter, timestamp, winston) {
+  const transport = new winston.transports.DailyRotateFile({
+    filename,
+    formatter,
     json: false,
     level: 'debug',
-    maxFiles: 1,
-    maxsize: 1e+8, // 100MB
-    tailable: true,
-    timestamp: timestamp
+    timestamp
   });
   winston.add(transport, null, true);
   // winston file transport will try and open file (maxRetries) and if it fails,
@@ -61,7 +49,7 @@ export function enableDebugLogger(filename, formatter, timestamp, winston) {
       });
     }
   });
-  transports.push(transport);
+  return transport;
 }
 
 export function idRewriter (level, msg, meta, logger) {
@@ -72,9 +60,31 @@ export function idRewriter (level, msg, meta, logger) {
 }
 
 export function createLogger(name) {
+  const transports = [];
+  if (LOGS_PATH) {
+    transports.push(new winston.transports.DailyRotateFile({
+      filename: `${LOGS_PATH}/${name}.log`,
+      formatter,
+      json: false,
+      level: 'info',
+      timestamp
+    }));
+  } else {
+    transports.push(new winston.transports.Console({
+      colorize: true,
+      formatter,
+      level: 'info',
+      stderrLevels: ['info'],
+      timestamp
+    }));
+  }
+  if (debugTransport !== null) {
+    transports.push(debugTransport);
+  }
   return new winston.Logger({
     ...loggerDefaults,
     id: name,
+    transports
   });
 }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -31,7 +31,15 @@ app.use(setRevisionHeader);
 app.use(raven.middleware.express.requestHandler(conf.get('SENTRY_DSN')));
 app.use(expressWinston.logger({
   winstonInstance: accessLogger,
-  level: 'info'
+  level: 'info',
+  requestFilter: (req, propName) => {
+    if (propName === 'headers') {
+      const filteredHeaders = { ...req[propName] };
+      delete filteredHeaders.cookie;
+      return filteredHeaders;
+    }
+    return req[propName];
+  }
 }));
 app.use(helmet());
 app.use(session(sessionConfig(conf)));

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -14,7 +14,6 @@ import setRevisionHeader from './middleware/set-revision-header.js';
 const appUrl = url.parse(conf.get('BASE_URL'));
 const app = Express();
 const accessLogger = logging.getLogger('express-access');
-const errorLogger = logging.getLogger('express-error');
 const logger = logging.getLogger('express');
 
 app.set('logger', logger);
@@ -58,8 +57,8 @@ app.use('/', routes.universal);
 // https://github.com/canonical-ols/javan-rhino/issues/210
 app.use(raven.middleware.express.errorHandler(conf.get('SENTRY_DSN')));
 app.use(expressWinston.errorLogger({
-  winstonInstance: errorLogger,
-  level: 'info'
+  winstonInstance: logger,
+  level: 'error'
 }));
 
 export { app as default };


### PR DESCRIPTION
Right now, we only log to the console.  This is fine for development, but cumbersome for the staging/production deployments, where the only way to debug anything is to log into the unit and use `systemctl status --lines=1000 snap-build`; this is made worse by switch deploys, since the unit that contains the logging information is likely to go away.

Part of fixing this will be sending logs to ELK, which is outside the scope of this PR since it'll be done by the Mojo spec.  However, as a prerequisite for that, we need to log to files.  This PR arranges to write logs to files under `LOGS_PATH` (already set by the charm), and tries to reserve the `express-error` logger only for actual errors.