### PR TITLE
Disabling repository input if user is not logged to GH

### DIFF
--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -80,6 +80,7 @@ class RepositoryInput extends Component {
             valid={isValid}
             onChange={this.onChange.bind(this)}
             errorMsg={this.getErrorMessage()}
+            disabled={!authenticated}
           />
           { input.success &&
             <Message status='info'>


### PR DESCRIPTION
<img width="946" alt="screen shot 2017-01-10 at 10 35 07" src="https://cloud.githubusercontent.com/assets/83575/21801101/863af4d8-d720-11e6-925b-d0e47a964bf9.png">

Helps to finalise fixing issues around #46

Having input available before logging into GH may be bit confusing (as 'Create' button cannot be clicked). Also putting value into the input and logging to GH later makes the value disappear because of auth reload.

So it seems easier to simply disable whole Step 2 before user logs into GH in Step 1.