### PR TITLE
Only fetch snap by repo URL when needed

### DIFF
--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -6,6 +6,7 @@ import getGitHubRepoUrl from '../helpers/github-url';
 const BASE_URL = conf.get('BASE_URL');
 
 export const FETCH_BUILDS = 'FETCH_BUILDS';
+export const FETCH_SNAP_SUCCESS = 'FETCH_SNAP_SUCCESS';
 export const FETCH_BUILDS_SUCCESS = 'FETCH_BUILDS_SUCCESS';
 export const FETCH_BUILDS_ERROR = 'FETCH_BUILDS_ERROR';
 
@@ -59,7 +60,13 @@ export function fetchSnap(repository) {
       return fetch(url)
         .then(checkStatus)
         .then(response => response.json())
-        .then((json) => dispatch(fetchBuilds(json.payload.message)))
+        .then((json) => {
+          const snapLink = json.payload.message;
+          dispatch({
+            type: FETCH_SNAP_SUCCESS,
+            payload: snapLink
+          });
+        })
         .catch((error) => dispatch(fetchBuildsError(error)));
     }
   };

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -13,11 +13,11 @@ import styles from './container.css';
 class Builds extends Component {
   fetchInterval = null
 
-  fetchData({ snapLink, fullName }) {
+  fetchData({ snapLink, repoFullName }) {
     if (snapLink) {
       this.props.dispatch(fetchBuilds(snapLink));
     } else {
-      this.props.dispatch(fetchSnap(fullName));
+      this.props.dispatch(fetchSnap(repoFullName));
     }
   }
 
@@ -36,22 +36,22 @@ class Builds extends Component {
   componentWillReceiveProps(nextProps) {
     // if snap link or repo name changed, fetch new data
     if ((this.props.snapLink !== nextProps.snapLink) ||
-        (this.props.fullName !== nextProps.fullName)) {
+        (this.props.repoFullName !== nextProps.repoFullName)) {
       this.fetchData(nextProps);
     }
   }
 
   render() {
-    const { account, repo, fullName } = this.props;
+    const { account, repo, repoFullName } = this.props;
     // only show spinner when data is loading for the first time
     const isLoading = this.props.isFetching && !this.props.success;
 
     return (
       <div className={ styles.container }>
         <Helmet
-          title={`${fullName} builds`}
+          title={`${repoFullName} builds`}
         />
-        <h1>{fullName} builds</h1>
+        <h1>{repoFullName} builds</h1>
         <BuildHistory account={account} repo={repo}/>
         { isLoading &&
           <div className={styles.spinner}><Spinner /></div>
@@ -68,7 +68,7 @@ class Builds extends Component {
 Builds.propTypes = {
   account: PropTypes.string.isRequired,
   repo: PropTypes.string.isRequired,
-  fullName: PropTypes.string.isRequired,
+  repoFullName: PropTypes.string.isRequired,
   isFetching: PropTypes.bool,
   snapLink: PropTypes.string,
   success: PropTypes.bool,
@@ -79,7 +79,7 @@ Builds.propTypes = {
 const mapStateToProps = (state, ownProps) => {
   const account = ownProps.params.account.toLowerCase();
   const repo = ownProps.params.repo.toLowerCase();
-  const fullName = `${account}/${repo}`;
+  const repoFullName = `${account}/${repo}`;
 
   const isFetching = state.snapBuilds.isFetching;
   const snapLink = state.snapBuilds.snapLink;
@@ -93,7 +93,7 @@ const mapStateToProps = (state, ownProps) => {
     error,
     account,
     repo,
-    fullName
+    repoFullName
   };
 };
 

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -3,6 +3,7 @@ import { snapBuildFromAPI } from '../helpers/snap-builds';
 
 export function snapBuilds(state = {
   isFetching: false,
+  snapLink: null,
   builds: [],
   success: false,
   error: null
@@ -12,6 +13,12 @@ export function snapBuilds(state = {
       return {
         ...state,
         isFetching: true
+      };
+    case ActionTypes.FETCH_SNAP_SUCCESS:
+      return {
+        ...state,
+        isFetching: false,
+        snapLink: action.payload
       };
     case ActionTypes.FETCH_BUILDS_SUCCESS:
       return {

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -21,6 +21,7 @@ const mockStore = configureMockStore(middlewares);
 describe('snap builds actions', () => {
   const initialState = {
     isFetching: false,
+    snapLink: null,
     builds: [],
     error: false
   };
@@ -160,23 +161,12 @@ describe('snap builds actions', () => {
             message: snapUrl
           }
         });
-      api.get('/api/launchpad/builds')
-        .query({
-          snap: snapUrl // should match what /api/launchpad/snaps returned
-        })
-        .reply(200, {
-          status: 'success',
-          payload: {
-            code: 'snap-builds-found',
-            builds: []
-          }
-        });
 
       return store.dispatch(fetchSnap('foo/bar'))
         .then(() => {
           api.done();
           expect(store.getActions()).toHaveActionOfType(
-            ActionTypes.FETCH_BUILDS_SUCCESS
+            ActionTypes.FETCH_SNAP_SUCCESS
           );
         });
     });

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -110,7 +110,8 @@ describe('snapBuilds reducers', () => {
   context('FETCH_BUILDS_SUCCESS', () => {
     const state = {
       ...initialState,
-      isFetching: true
+      isFetching: true,
+      error: 'Previous error'
     };
 
     const action = {

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -73,12 +73,12 @@ describe('snapBuilds reducers', () => {
   });
 
   context('FETCH_BUILDS', () => {
-    it('should store fetching status when fetching builds', () => {
-      const action = {
-        type: ActionTypes.FETCH_BUILDS,
-        payload: 'test'
-      };
+    const action = {
+      type: ActionTypes.FETCH_BUILDS,
+      payload: 'test'
+    };
 
+    it('should store fetching status when fetching builds', () => {
       expect(snapBuilds(initialState, action)).toEqual({
         ...initialState,
         isFetching: true
@@ -108,79 +108,48 @@ describe('snapBuilds reducers', () => {
   });
 
   context('FETCH_BUILDS_SUCCESS', () => {
+    const state = {
+      ...initialState,
+      isFetching: true
+    };
+
+    const action = {
+      type: ActionTypes.FETCH_BUILDS_SUCCESS,
+      payload: SNAP_ENTRIES
+    };
 
     it('should stop fetching', () => {
-      const state = {
-        ...initialState,
-        isFetching: true
-      };
-
-      const action = {
-        type: ActionTypes.FETCH_BUILDS_SUCCESS,
-        payload: SNAP_ENTRIES
-      };
-
       expect(snapBuilds(state, action).isFetching).toBe(false);
     });
 
     it('should store builds on fetch success', () => {
-      const state = {
-        ...initialState,
-        isFetching: true
-      };
-
-      const action = {
-        type: ActionTypes.FETCH_BUILDS_SUCCESS,
-        payload: SNAP_ENTRIES
-      };
-
       expect(snapBuilds(state, action).builds).toEqual(SNAP_ENTRIES.map(snapBuildFromAPI));
     });
 
     it('should store success state', () => {
-      const state = {
-        ...initialState,
-        isFetching: true
-      };
-
-      const action = {
-        type: ActionTypes.FETCH_BUILDS_SUCCESS,
-        payload: SNAP_ENTRIES
-      };
-
       expect(snapBuilds(state, action).success).toBe(true);
     });
 
     it('should clean error', () => {
-      const state = {
-        ...initialState,
-        error: 'Previous error'
-      };
-
-      const action = {
-        type: ActionTypes.FETCH_BUILDS_SUCCESS,
-        payload: SNAP_ENTRIES
-      };
-
       expect(snapBuilds(state, action).error).toBe(null);
     });
   });
 
   context('FETCH_BUILDS_ERROR', () => {
+    const state = {
+      ...initialState,
+      success: true,
+      builds: SNAP_ENTRIES,
+      isFetching: true
+    };
+
+    const action = {
+      type: ActionTypes.FETCH_BUILDS_ERROR,
+      payload: 'Something went wrong!',
+      error: true
+    };
+
     it('should handle fetch builds failure', () => {
-      const state = {
-        ...initialState,
-        success: true,
-        builds: SNAP_ENTRIES,
-        isFetching: true
-      };
-
-      const action = {
-        type: ActionTypes.FETCH_BUILDS_ERROR,
-        payload: 'Something went wrong!',
-        error: true
-      };
-
       expect(snapBuilds(state, action)).toEqual({
         ...state,
         isFetching: false,

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -8,6 +8,7 @@ import { snapBuildFromAPI } from '../../../../../src/common/helpers/snap-builds'
 describe('snapBuilds reducers', () => {
   const initialState = {
     isFetching: false,
+    snapLink: null,
     builds: [],
     success: false,
     error: null
@@ -82,6 +83,27 @@ describe('snapBuilds reducers', () => {
         ...initialState,
         isFetching: true
       });
+    });
+  });
+
+  context('FETCH_SNAP_SUCCESS', () => {
+    const SNAP_LINK = 'https://api.launchpad.net/devel/~cjwatson/+snap/godd-test-2';
+
+    const state = {
+      ...initialState,
+      isFetching: true
+    };
+    const action = {
+      type: ActionTypes.FETCH_SNAP_SUCCESS,
+      payload: SNAP_LINK
+    };
+
+    it('should stop fetching', () => {
+      expect(snapBuilds(state, action).isFetching).toBe(false);
+    });
+
+    it('should store snap link', () => {
+      expect(snapBuilds(state, action).snapLink).toEqual(SNAP_LINK);
     });
   });
 


### PR DESCRIPTION
Currently we fetch snap by repo URL every time we fetch builds (every 15s on builds page). It's unnecessarily doubles numbers of requests made from the client.

With this update snap link is saved to the store and only list of builds is being fetched every 15 seconds to keep it up to date.