### PR TITLE
GH repository (owner, name, etc) naming consistency

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -16,7 +16,7 @@ To create a snap:
     Accept: application/json
 
     {
-      "repository_url": "https://github.com/:account/:repo"
+      "repository_url": "https://github.com/:owner/:name"
     }
 
 On success, returns:
@@ -76,7 +76,7 @@ To request builds of an existing snap:
     Accept: application/json
 
     {
-      "repository_url": "https://github.com/:account/:repo"
+      "repository_url": "https://github.com/:owner/:name"
     }
 
 On success, returns the following, where the items in `builds` are

--- a/mocks/service/github/index.js
+++ b/mocks/service/github/index.js
@@ -15,12 +15,12 @@ const authoriseLoginResponse = responses.okayPromptForLogin;
 
 const router = Router();
 router.use(json());
-router.post('/repos/:account/:repo/hooks', webhookResponse);
+router.post('/repos/:owner/:name/hooks', webhookResponse);
 router.get('/login/oauth/authorize', authoriseLoginResponse);
 router.post('/login/oauth/access_token', responses.okayAuthenticated);
 
-router.get('/repos/:account/:repo/contents/snapcraft.yaml', (req, res) => {
-  res.status(200).send(`name: ${req.params.repo}\n`);
+router.get('/repos/:owner/:name/contents/snapcraft.yaml', (req, res) => {
+  res.status(200).send(`name: ${req.params.name}\n`);
 });
 
 export default router;

--- a/mocks/service/github/responses.js
+++ b/mocks/service/github/responses.js
@@ -16,7 +16,7 @@ export function okayNewHookCreated(req, res) {
     'hook_id': 'anid',
     'hook': req.body.config
   });
-  const hmac = makeWebhookHmac(req.params.account, req.params.repo);
+  const hmac = makeWebhookHmac(req.params.owner, req.params.name);
   hmac.update(body);
   request.post({
     url: req.body.config.url,

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -1,7 +1,7 @@
 import 'isomorphic-fetch';
 
 import conf from '../helpers/config';
-import getGitHubRepoUrl from '../helpers/github-url';
+import { parseGitHubRepoUrl } from '../helpers/github-url';
 
 const BASE_URL = conf.get('BASE_URL');
 
@@ -34,17 +34,14 @@ function checkStatus(response) {
   }
 }
 
-// TODO: bartaz (accept repository object)?
-export function createSnap(repository, location) {
-  const fullName = repository;
-
+export function createSnap(repositoryUrl, location) { // location for tests
   return (dispatch) => {
-    if (fullName) {
+    if (repositoryUrl) {
+      const { fullName } = parseGitHubRepoUrl(repositoryUrl);
+
       dispatch({
-        type: CREATE_SNAP,
-        payload: fullName
+        type: CREATE_SNAP
       });
-      const repositoryUrl = getGitHubRepoUrl(fullName);
 
       return fetch(`${BASE_URL}/api/launchpad/snaps`, {
         method: 'POST',

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -4,12 +4,8 @@ import conf from '../helpers/config';
 import getGitHubRepoUrl from '../helpers/github-url';
 
 const BASE_URL = conf.get('BASE_URL');
-const GITHUB_API_ENDPOINT = conf.get('GITHUB_API_ENDPOINT');
 
 export const SET_GITHUB_REPOSITORY = 'SET_GITHUB_REPOSITORY';
-export const VERIFY_GITHUB_REPOSITORY = 'VERIFY_GITHUB_REPOSITORY';
-export const VERIFY_GITHUB_REPOSITORY_SUCCESS = 'VERIFY_GITHUB_REPOSITORY_SUCCESS';
-export const VERIFY_GITHUB_REPOSITORY_ERROR = 'VERIFY_GITHUB_REPOSITORY_ERROR';
 export const CREATE_SNAP = 'CREATE_SNAP';
 export const CREATE_SNAP_ERROR = 'CREATE_SNAP_ERROR';
 
@@ -36,38 +32,6 @@ function checkStatus(response) {
       throw getError(response, json);
     });
   }
-}
-
-export function verifyGitHubRepository(repository) {
-  const fullName = repository;
-  return (dispatch) => {
-    if (fullName) {
-      dispatch({
-        type: VERIFY_GITHUB_REPOSITORY,
-        payload: fullName
-      });
-
-      return fetch(`${GITHUB_API_ENDPOINT}/repos/${fullName}/contents/snapcraft.yaml`)
-        .then(checkStatus)
-        .then(() => dispatch(verifyGitHubRepositorySuccess(getGitHubRepoUrl(fullName))))
-        .catch(error => dispatch(verifyGitHubRepositoryError(error)));
-    }
-  };
-}
-
-export function verifyGitHubRepositorySuccess(repositoryUrl) {
-  return {
-    type: VERIFY_GITHUB_REPOSITORY_SUCCESS,
-    payload: repositoryUrl
-  };
-}
-
-export function verifyGitHubRepositoryError(error) {
-  return {
-    type: VERIFY_GITHUB_REPOSITORY_ERROR,
-    payload: error,
-    error: true
-  };
 }
 
 // TODO: bartaz (accept repository object)?

--- a/src/common/actions/repository-input.js
+++ b/src/common/actions/repository-input.js
@@ -39,16 +39,17 @@ function checkStatus(response) {
 }
 
 export function verifyGitHubRepository(repository) {
+  const fullName = repository;
   return (dispatch) => {
-    if (repository) {
+    if (fullName) {
       dispatch({
         type: VERIFY_GITHUB_REPOSITORY,
-        payload: repository
+        payload: fullName
       });
 
-      return fetch(`${GITHUB_API_ENDPOINT}/repos/${repository}/contents/snapcraft.yaml`)
+      return fetch(`${GITHUB_API_ENDPOINT}/repos/${fullName}/contents/snapcraft.yaml`)
         .then(checkStatus)
-        .then(() => dispatch(verifyGitHubRepositorySuccess(getGitHubRepoUrl(repository))))
+        .then(() => dispatch(verifyGitHubRepositorySuccess(getGitHubRepoUrl(fullName))))
         .catch(error => dispatch(verifyGitHubRepositoryError(error)));
     }
   };
@@ -69,14 +70,17 @@ export function verifyGitHubRepositoryError(error) {
   };
 }
 
+// TODO: bartaz (accept repository object)?
 export function createSnap(repository, location) {
+  const fullName = repository;
+
   return (dispatch) => {
-    if (repository) {
+    if (fullName) {
       dispatch({
         type: CREATE_SNAP,
-        payload: repository
+        payload: fullName
       });
-      const repositoryUrl = getGitHubRepoUrl(repository);
+      const repositoryUrl = getGitHubRepoUrl(fullName);
 
       return fetch(`${BASE_URL}/api/launchpad/snaps`, {
         method: 'POST',
@@ -91,7 +95,7 @@ export function createSnap(repository, location) {
                 result.payload.code !== 'snap-created') {
               throw getError(response, result);
             }
-            const startingUrl = `${BASE_URL}/${repository}/setup`;
+            const startingUrl = `${BASE_URL}/${fullName}/setup`;
             (location || window.location).href =
               `${BASE_URL}/login/authenticate` +
               `?starting_url=${encodeURIComponent(startingUrl)}` +
@@ -102,7 +106,7 @@ export function createSnap(repository, location) {
         .catch(error => {
           // if LP error says there is already such snap, just redirect to builds page
           if (error.message === 'There is already a snap package with the same name and owner.') {
-            (location || window.location).href = `${BASE_URL}/${repository}/builds`;
+            (location || window.location).href = `${BASE_URL}/${fullName}/builds`;
           } else {
             dispatch(createSnapError(error));
           }

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -1,7 +1,6 @@
 import 'isomorphic-fetch';
 
 import conf from '../helpers/config';
-import { getGitHubRepoUrl } from '../helpers/github-url';
 
 const BASE_URL = conf.get('BASE_URL');
 
@@ -47,17 +46,15 @@ function checkStatus(response) {
   }
 }
 
-// TODO: bartaz: repository = fullName
-// TODO: bartaz (accept repository object)?
 // Fetch snap info (self_link) for given repository
-export function fetchSnap(fullName) {
+export function fetchSnap(repositoryUrl) {
   return (dispatch) => {
-    if (fullName) {
+    if (repositoryUrl) {
       dispatch({
         type: FETCH_BUILDS
       });
 
-      const repositoryUrl = encodeURIComponent(getGitHubRepoUrl(fullName));
+      repositoryUrl = encodeURIComponent(repositoryUrl);
       const url = `${BASE_URL}/api/launchpad/snaps?repository_url=${repositoryUrl}`;
       return fetch(url)
         .then(checkStatus)

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -47,6 +47,7 @@ function checkStatus(response) {
   }
 }
 
+// TODO: bartaz: repository = fullName
 // Fetch snap info (self_link) for given repository
 export function fetchSnap(repository) {
   return (dispatch) => {
@@ -91,15 +92,16 @@ export function fetchBuilds(snapLink) {
   };
 }
 
+// TODO: bartaz (accept repository object)?
 // Reguest new builds for given repository
-export function requestBuilds(repository) {
+export function requestBuilds(fullName) {
   return (dispatch) => {
-    if (repository) {
+    if (fullName) {
       dispatch({
         type: FETCH_BUILDS
       });
 
-      const repositoryUrl = getGitHubRepoUrl(repository);
+      const repositoryUrl = getGitHubRepoUrl(fullName);
       const url = `${BASE_URL}/api/launchpad/snaps/request-builds`;
       const settings = {
         ...REQUEST_POST_OPTIONS,

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -93,16 +93,14 @@ export function fetchBuilds(snapLink) {
   };
 }
 
-// TODO: bartaz (accept repository object)?
 // Reguest new builds for given repository
-export function requestBuilds(fullName) {
+export function requestBuilds(repositoryUrl) {
   return (dispatch) => {
-    if (fullName) {
+    if (repositoryUrl) {
       dispatch({
         type: FETCH_BUILDS
       });
 
-      const repositoryUrl = getGitHubRepoUrl(fullName);
       const url = `${BASE_URL}/api/launchpad/snaps/request-builds`;
       const settings = {
         ...REQUEST_POST_OPTIONS,

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -48,15 +48,16 @@ function checkStatus(response) {
 }
 
 // TODO: bartaz: repository = fullName
+// TODO: bartaz (accept repository object)?
 // Fetch snap info (self_link) for given repository
-export function fetchSnap(repository) {
+export function fetchSnap(fullName) {
   return (dispatch) => {
-    if (repository) {
+    if (fullName) {
       dispatch({
         type: FETCH_BUILDS
       });
 
-      const repositoryUrl = encodeURIComponent(getGitHubRepoUrl(repository));
+      const repositoryUrl = encodeURIComponent(getGitHubRepoUrl(fullName));
       const url = `${BASE_URL}/api/launchpad/snaps?repository_url=${repositoryUrl}`;
       return fetch(url)
         .then(checkStatus)

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -1,7 +1,7 @@
 import 'isomorphic-fetch';
 
 import conf from '../helpers/config';
-import getGitHubRepoUrl from '../helpers/github-url';
+import { getGitHubRepoUrl } from '../helpers/github-url';
 
 const BASE_URL = conf.get('BASE_URL');
 

--- a/src/common/actions/webhook.js
+++ b/src/common/actions/webhook.js
@@ -29,7 +29,6 @@ export function createWebhookFailure(code, message) {
   return action;
 }
 
-// TODO: bartaz (accept repository object)?
 export function createWebhook(owner, name) {
   return (dispatch) => {
     dispatch({ type: WEBHOOK });

--- a/src/common/actions/webhook.js
+++ b/src/common/actions/webhook.js
@@ -29,12 +29,14 @@ export function createWebhookFailure(code, message) {
   return action;
 }
 
-export function createWebhook(account, repo) {
+// TODO: bartaz (accept repository object)?
+export function createWebhook(owner, name) {
   return (dispatch) => {
     dispatch({ type: WEBHOOK });
 
     const settings = REQUEST_OPTIONS;
-    settings.body = JSON.stringify({ account, repo });
+    // TODO: bartaz: serverside need to accept owner and name
+    settings.body = JSON.stringify({ account: owner, repo: name });
 
     return fetch(`${getBaseUrl()}/api/github/webhook`, settings)
       .then((response) => {

--- a/src/common/actions/webhook.js
+++ b/src/common/actions/webhook.js
@@ -35,8 +35,7 @@ export function createWebhook(owner, name) {
     dispatch({ type: WEBHOOK });
 
     const settings = REQUEST_OPTIONS;
-    // TODO: bartaz: serverside need to accept owner and name
-    settings.body = JSON.stringify({ account: owner, repo: name });
+    settings.body = JSON.stringify({ owner, name });
 
     return fetch(`${getBaseUrl()}/api/github/webhook`, settings)
       .then((response) => {

--- a/src/common/components/build-history/index.js
+++ b/src/common/components/build-history/index.js
@@ -7,9 +7,8 @@ import { Message } from '../forms';
 const BuildHistory = (props) => {
   const { repository, success } = props;
 
-  // TODO: bartaz account/repo to rename
   const builds = props.builds.map((build) => (
-    <BuildRow key={build.buildId} {...build} account={repository.owner} repo={repository.name} />
+    <BuildRow key={build.buildId} {...build} repository={repository} />
   ));
 
   return success ? (

--- a/src/common/components/build-history/index.js
+++ b/src/common/components/build-history/index.js
@@ -5,10 +5,11 @@ import BuildRow from '../build-row';
 import { Message } from '../forms';
 
 const BuildHistory = (props) => {
-  const { account, repo, success } = props;
+  const { repository, success } = props;
 
+  // TODO: bartaz account/repo to rename
   const builds = props.builds.map((build) => (
-    <BuildRow key={build.buildId} {...build} account={account} repo={repo} />
+    <BuildRow key={build.buildId} {...build} account={repository.owner} repo={repository.name} />
   ));
 
   return success ? (
@@ -22,8 +23,10 @@ const BuildHistory = (props) => {
 };
 
 BuildHistory.propTypes = {
-  account: PropTypes.string,
-  repo: PropTypes.string,
+  repository: PropTypes.shape({
+    owner: PropTypes.string,
+    name: PropTypes.string
+  }),
   success: PropTypes.bool,
   builds: React.PropTypes.arrayOf(React.PropTypes.object)
 };

--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -9,8 +9,7 @@ import styles from './buildRow.css';
 const BuildRow = (props) => {
 
   const {
-    account,
-    repo,
+    repository,
     architecture,
     buildId,
     duration,
@@ -46,7 +45,7 @@ const BuildRow = (props) => {
 
   return (
     <div className={ `${styles.buildRow} ${statusStyle[status]}` }>
-      <div className={ styles.item }><Link to={`/${account}/${repo}/builds/${buildId}`}>{`#${buildId}`}</Link> {statusMessage}</div>
+      <div className={ styles.item }><Link to={`/${repository.fullName}/builds/${buildId}`}>{`#${buildId}`}</Link> {statusMessage}</div>
       <div className={ styles.item }>
         {architecture}
       </div>
@@ -62,8 +61,10 @@ const BuildRow = (props) => {
 
 BuildRow.propTypes = {
   // params from URL
-  account: PropTypes.string,
-  repo: PropTypes.string,
+  repository: PropTypes.shape({
+    owner: PropTypes.string,
+    name: PropTypes.string
+  }),
 
   // build properties
   buildId:  PropTypes.string,

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -14,7 +14,7 @@ import { Form, InputField, Message } from '../forms';
 class RepositoryInput extends Component {
   getErrorMessage() {
     const input = this.props.repositoryInput;
-    const repository = input.repository;
+    const repository = this.props.repository;
 
     if (input.inputValue.length > 2 && !repository) {
       return 'Please enter a valid GitHub repository name or URL.';
@@ -67,8 +67,9 @@ class RepositoryInput extends Component {
   step2() {
     const { authenticated } = this.props.auth;
     const input = this.props.repositoryInput;
+    const repository = this.props.repository;
     const isTouched = input.inputValue.length > 2;
-    const isValid = !!input.repository && !input.error;
+    const isValid = !!repository && !input.error;
 
     return (
       <Step number="2" complete={ input.success }>
@@ -85,7 +86,7 @@ class RepositoryInput extends Component {
           />
           { input.success &&
             <Message status='info'>
-              Repository <a href={input.repository.url}>{input.repository.fullName}</a> contains snapcraft project and can be built.
+              Repository <a href={repository.url}>{repository.fullName}</a> contains snapcraft project and can be built.
             </Message>
           }
           <Button type='submit' disabled={!isValid || input.isFetching || !authenticated }>
@@ -102,7 +103,7 @@ class RepositoryInput extends Component {
 
   onSubmit(event) {
     event.preventDefault();
-    const { repository } = this.props.repositoryInput;
+    const repository = this.props.repository;
 
     if (repository) {
       this.props.dispatch(createSnap(repository.url));
@@ -111,6 +112,7 @@ class RepositoryInput extends Component {
 }
 
 RepositoryInput.propTypes = {
+  repository: PropTypes.object.isRequired,
   repositoryInput: PropTypes.object.isRequired,
   auth: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
@@ -118,12 +120,14 @@ RepositoryInput.propTypes = {
 
 function mapStateToProps(state) {
   const {
+    repository,
     repositoryInput,
     auth
   } = state;
 
   return {
     auth,
+    repository,
     repositoryInput
   };
 }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -104,7 +104,7 @@ class RepositoryInput extends Component {
     event.preventDefault();
     const { repository } = this.props.repositoryInput;
 
-    if (repository) {
+    if (repository.fullName) {
       this.props.dispatch(createSnap(repository.fullName));
     }
   }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -14,8 +14,9 @@ import { Form, InputField, Message } from '../forms';
 class RepositoryInput extends Component {
   getErrorMessage() {
     const input = this.props.repositoryInput;
+    const repository = input.repository;
 
-    if (input.inputValue.length > 2 && !input.repository) {
+    if (input.inputValue.length > 2 && !repository.fullName) {
       return 'Please enter a valid GitHub repository name or URL.';
     } else if (input.error) {
       const payload = input.error.json.payload;
@@ -84,7 +85,7 @@ class RepositoryInput extends Component {
           />
           { input.success &&
             <Message status='info'>
-              Repository <a href={input.repositoryUrl}>{input.repository}</a> contains snapcraft project and can be built.
+              Repository <a href={input.repository.url}>{input.repository.fullName}</a> contains snapcraft project and can be built.
             </Message>
           }
           <Button type='submit' disabled={!isValid || input.isFetching || !authenticated }>
@@ -104,7 +105,7 @@ class RepositoryInput extends Component {
     const { repository } = this.props.repositoryInput;
 
     if (repository) {
-      this.props.dispatch(createSnap(repository));
+      this.props.dispatch(createSnap(repository.fullName));
     }
   }
 }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -16,7 +16,7 @@ class RepositoryInput extends Component {
     const input = this.props.repositoryInput;
     const repository = input.repository;
 
-    if (input.inputValue.length > 2 && !repository.fullName) {
+    if (input.inputValue.length > 2 && !repository) {
       return 'Please enter a valid GitHub repository name or URL.';
     } else if (input.error) {
       const payload = input.error.json.payload;
@@ -104,8 +104,8 @@ class RepositoryInput extends Component {
     event.preventDefault();
     const { repository } = this.props.repositoryInput;
 
-    if (repository.fullName) {
-      this.props.dispatch(createSnap(repository.fullName));
+    if (repository) {
+      this.props.dispatch(createSnap(repository.url));
     }
   }
 }

--- a/src/common/components/repository-input/index.js
+++ b/src/common/components/repository-input/index.js
@@ -112,7 +112,7 @@ class RepositoryInput extends Component {
 }
 
 RepositoryInput.propTypes = {
-  repository: PropTypes.object.isRequired,
+  repository: PropTypes.object,
   repositoryInput: PropTypes.object.isRequired,
   auth: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -5,18 +5,35 @@ import Helmet from 'react-helmet';
 import BuildRow from '../components/build-row';
 import BuildLog from '../components/build-log';
 import { Message } from '../components/forms';
-import { fetchSnap } from '../actions/snap-builds';
+import { fetchBuilds, fetchSnap } from '../actions/snap-builds';
 
 import styles from './container.css';
 
 class BuildDetails extends Component {
 
+  fetchData({ snapLink, repository }) {
+    if (snapLink) {
+      this.props.dispatch(fetchBuilds(snapLink));
+    } else {
+      this.props.dispatch(fetchSnap(repository.fullName));
+    }
+  }
+
   componentWillMount() {
-    this.props.dispatch(fetchSnap(this.props.fullName));
+    this.fetchData(this.props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // if snap link or repo name changed, fetch new data
+    if ((this.props.snapLink !== nextProps.snapLink) ||
+        (this.props.repository.fullName !== nextProps.repository.fullName)) {
+      this.fetchData(nextProps);
+    }
   }
 
   render() {
-    const { account, repo, fullName, buildId, build } = this.props;
+    const { repository, buildId, build } = this.props;
+    const { fullName } = repository;
 
     return (
       <div className={ styles.container }>
@@ -32,7 +49,7 @@ class BuildDetails extends Component {
         }
         { build &&
           <div>
-            <BuildRow account={account} repo={repo} {...build} />
+            <BuildRow repository={repository} {...build} />
             <h3>Build log:</h3>
             <BuildLog logUrl={build.buildLogUrl} />
           </div>
@@ -43,33 +60,41 @@ class BuildDetails extends Component {
 
 }
 BuildDetails.propTypes = {
-  account: PropTypes.string.isRequired,
-  repo: PropTypes.string.isRequired,
-  fullName: PropTypes.string.isRequired,
+  repository: PropTypes.shape({
+    owner: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    fullName: PropTypes.string.isRequired,
+  }),
   buildId: PropTypes.string.isRequired,
   build: PropTypes.object,
   isFetching: PropTypes.bool,
+  snapLink: PropTypes.string,
   error: PropTypes.object,
   dispatch: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const account = ownProps.params.account.toLowerCase();
-  const repo = ownProps.params.repo.toLowerCase();
+  const owner = ownProps.params.owner.toLowerCase();
+  const name = ownProps.params.name.toLowerCase();
+  const fullName = `${owner}/${name}`;
+
   const buildId = ownProps.params.buildId.toLowerCase();
 
-  const fullName = `${account}/${repo}`;
   const build = state.snapBuilds.builds.filter((build) => build.buildId === buildId)[0];
   const isFetching = state.snapBuilds.isFetching;
   const error = state.snapBuilds.error;
+  const snapLink = state.snapBuilds.snapLink;
 
   return {
-    account,
-    repo,
-    fullName,
+    repository: {
+      owner,
+      name,
+      fullName
+    },
     buildId,
     build,
     isFetching,
+    snapLink,
     error
   };
 };

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -5,6 +5,8 @@ import Helmet from 'react-helmet';
 import BuildRow from '../components/build-row';
 import BuildLog from '../components/build-log';
 import { Message } from '../components/forms';
+
+import { getGitHubRepoUrl } from '../helpers/github-url';
 import { fetchBuilds, fetchSnap } from '../actions/snap-builds';
 
 import styles from './container.css';
@@ -15,7 +17,7 @@ class BuildDetails extends Component {
     if (snapLink) {
       this.props.dispatch(fetchBuilds(snapLink));
     } else {
-      this.props.dispatch(fetchSnap(repository.fullName));
+      this.props.dispatch(fetchSnap(repository.url));
     }
   }
 
@@ -64,6 +66,7 @@ BuildDetails.propTypes = {
     owner: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     fullName: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
   }),
   buildId: PropTypes.string.isRequired,
   build: PropTypes.object,
@@ -77,6 +80,7 @@ const mapStateToProps = (state, ownProps) => {
   const owner = ownProps.params.owner.toLowerCase();
   const name = ownProps.params.name.toLowerCase();
   const fullName = `${owner}/${name}`;
+  const url = getGitHubRepoUrl(fullName);
 
   const buildId = ownProps.params.buildId.toLowerCase();
 
@@ -89,7 +93,8 @@ const mapStateToProps = (state, ownProps) => {
     repository: {
       owner,
       name,
-      fullName
+      fullName,
+      url
     },
     buildId,
     build,

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -21,7 +21,7 @@ class BuildDetails extends Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     if (!this.props.repository && this.props.fullName) {
       this.props.dispatch(setGitHubRepository(this.props.fullName));
     }

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -6,7 +6,7 @@ import BuildRow from '../components/build-row';
 import BuildLog from '../components/build-log';
 import { Message } from '../components/forms';
 
-import { setGitHubRepository } from '../actions/repository-input';
+import withRepository from './with-repository';
 import { fetchBuilds, fetchSnap } from '../actions/snap-builds';
 
 import styles from './container.css';
@@ -22,41 +22,35 @@ class BuildDetails extends Component {
   }
 
   componentDidMount() {
-    if (!this.props.repository && this.props.fullName) {
-      this.props.dispatch(setGitHubRepository(this.props.fullName));
-    }
-
     this.fetchData(this.props);
   }
 
   componentWillReceiveProps(nextProps) {
     const currentSnapLink = this.props.snapLink;
     const nextSnapLink = nextProps.snapLink;
-    const currentRepository = this.props.repository && this.props.repository.fullName;
-    const nextRepository = nextProps.repository && nextProps.repository.fullName;
+    const currentRepository = this.props.repository.fullName;
+    const nextRepository = nextProps.repository.fullName;
 
-    if (this.props.fullName !== nextProps.fullName) {
-      this.props.dispatch(setGitHubRepository(nextProps.fullName));
-    } else if ((currentSnapLink !== nextSnapLink) || (currentRepository !== nextRepository)) {
+    if ((currentSnapLink !== nextSnapLink) || (currentRepository !== nextRepository)) {
       // if snap link or repo changed, fetch new data
       this.fetchData(nextProps);
     }
   }
 
   render() {
-    const { fullName, repository, buildId, build } = this.props;
+    const { repository, buildId, build, error, isFetching } = this.props;
 
     return (
       <div className={ styles.container }>
         <Helmet
-          title={`${fullName} builds`}
+          title={`${repository.fullName} builds`}
         />
-        <h1>{fullName} build #{buildId}</h1>
-        { this.props.isFetching &&
+        <h1>{repository.fullName} build #{buildId}</h1>
+        { isFetching &&
           <span>Loading...</span>
         }
-        { this.props.error &&
-          <Message status='error'>{ this.props.error.message || this.props.error }</Message>
+        { error &&
+          <Message status='error'>{ error.message || error }</Message>
         }
         { build &&
           <div>
@@ -71,13 +65,12 @@ class BuildDetails extends Component {
 
 }
 BuildDetails.propTypes = {
-  fullName: PropTypes.string.isRequired,
   repository: PropTypes.shape({
     owner: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     fullName: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired
-  }),
+  }).isRequired,
   buildId: PropTypes.string.isRequired,
   build: PropTypes.object,
   isFetching: PropTypes.bool,
@@ -110,4 +103,4 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-export default connect(mapStateToProps)(BuildDetails);
+export default connect(mapStateToProps)(withRepository(BuildDetails));

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -42,7 +42,7 @@ class Builds extends Component {
   }
 
   render() {
-    const { owner, name, fullName } = this.props.repository;
+    const { fullName } = this.props.repository;
     // only show spinner when data is loading for the first time
     const isLoading = this.props.isFetching && !this.props.success;
 
@@ -52,8 +52,7 @@ class Builds extends Component {
           title={`${fullName} builds`}
         />
         <h1>{fullName} builds</h1>
-        {/* TODO: bartaz account/repo to rename */}
-        <BuildHistory account={owner} repo={name}/>
+        <BuildHistory repository={this.props.repository} />
         { isLoading &&
           <div className={styles.spinner}><Spinner /></div>
         }

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -17,12 +17,12 @@ class Builds extends Component {
   fetchData({ snapLink, repository }) {
     if (snapLink) {
       this.props.dispatch(fetchBuilds(snapLink));
-    } else if (repository){
+    } else if (repository) {
       this.props.dispatch(fetchSnap(repository.url));
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     if (!this.props.repository && this.props.fullName) {
       this.props.dispatch(setGitHubRepository(this.props.fullName));
     }

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -6,6 +6,7 @@ import BuildHistory from '../components/build-history';
 import { Message } from '../components/forms';
 import Spinner from '../components/spinner';
 
+import { getGitHubRepoUrl } from '../helpers/github-url';
 import { fetchBuilds, fetchSnap } from '../actions/snap-builds';
 
 import styles from './container.css';
@@ -17,7 +18,7 @@ class Builds extends Component {
     if (snapLink) {
       this.props.dispatch(fetchBuilds(snapLink));
     } else {
-      this.props.dispatch(fetchSnap(repository.fullName));
+      this.props.dispatch(fetchSnap(repository.url));
     }
   }
 
@@ -70,6 +71,7 @@ Builds.propTypes = {
     owner: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     fullName: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
   }),
   isFetching: PropTypes.bool,
   snapLink: PropTypes.string,
@@ -82,6 +84,7 @@ const mapStateToProps = (state, ownProps) => {
   const owner = ownProps.params.owner.toLowerCase();
   const name = ownProps.params.name.toLowerCase();
   const fullName = `${owner}/${name}`;
+  const url = getGitHubRepoUrl(fullName);
 
   const isFetching = state.snapBuilds.isFetching;
   const snapLink = state.snapBuilds.snapLink;
@@ -96,7 +99,8 @@ const mapStateToProps = (state, ownProps) => {
     repository: {
       owner,
       name,
-      fullName
+      fullName,
+      url
     }
   };
 };

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -13,11 +13,11 @@ import styles from './container.css';
 class Builds extends Component {
   fetchInterval = null
 
-  fetchData({ snapLink, repoFullName }) {
+  fetchData({ snapLink, repository }) {
     if (snapLink) {
       this.props.dispatch(fetchBuilds(snapLink));
     } else {
-      this.props.dispatch(fetchSnap(repoFullName));
+      this.props.dispatch(fetchSnap(repository.fullName));
     }
   }
 
@@ -36,23 +36,24 @@ class Builds extends Component {
   componentWillReceiveProps(nextProps) {
     // if snap link or repo name changed, fetch new data
     if ((this.props.snapLink !== nextProps.snapLink) ||
-        (this.props.repoFullName !== nextProps.repoFullName)) {
+        (this.props.repository.fullName !== nextProps.repository.fullName)) {
       this.fetchData(nextProps);
     }
   }
 
   render() {
-    const { account, repo, repoFullName } = this.props;
+    const { owner, name, fullName } = this.props.repository;
     // only show spinner when data is loading for the first time
     const isLoading = this.props.isFetching && !this.props.success;
 
     return (
       <div className={ styles.container }>
         <Helmet
-          title={`${repoFullName} builds`}
+          title={`${fullName} builds`}
         />
-        <h1>{repoFullName} builds</h1>
-        <BuildHistory account={account} repo={repo}/>
+        <h1>{fullName} builds</h1>
+        {/* TODO: bartaz account/repo to rename */}
+        <BuildHistory account={owner} repo={name}/>
         { isLoading &&
           <div className={styles.spinner}><Spinner /></div>
         }
@@ -66,9 +67,11 @@ class Builds extends Component {
 }
 
 Builds.propTypes = {
-  account: PropTypes.string.isRequired,
-  repo: PropTypes.string.isRequired,
-  repoFullName: PropTypes.string.isRequired,
+  repository: PropTypes.shape({
+    owner: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    fullName: PropTypes.string.isRequired,
+  }),
   isFetching: PropTypes.bool,
   snapLink: PropTypes.string,
   success: PropTypes.bool,
@@ -77,9 +80,9 @@ Builds.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const account = ownProps.params.account.toLowerCase();
-  const repo = ownProps.params.repo.toLowerCase();
-  const repoFullName = `${account}/${repo}`;
+  const owner = ownProps.params.owner.toLowerCase();
+  const name = ownProps.params.name.toLowerCase();
+  const fullName = `${owner}/${name}`;
 
   const isFetching = state.snapBuilds.isFetching;
   const snapLink = state.snapBuilds.snapLink;
@@ -91,9 +94,11 @@ const mapStateToProps = (state, ownProps) => {
     snapLink,
     success,
     error,
-    account,
-    repo,
-    repoFullName
+    repository: {
+      owner,
+      name,
+      fullName
+    }
   };
 };
 

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -12,32 +12,33 @@ import styles from './container.css';
 
 class RepositorySetup extends Component {
   componentWillReceiveProps(nextProps) {
-    const { fullName, webhook, builds } = nextProps;
+    const { repository, webhook, builds } = nextProps;
 
     if (webhook.success && builds.success) {
-      this.props.router.replace(`/${fullName}/builds`);
+      this.props.router.replace(`/${repository.fullName}/builds`);
     }
   }
 
   componentDidMount() {
-    const { account, repo, fullName, webhook, builds } = this.props;
+    const { repository, webhook, builds } = this.props;
 
+    // TODO: bartaz - createWebhook and requestBuilds should have same params
     if (!webhook.isFetching) {
-      this.props.dispatch(createWebhook(account, repo));
+      this.props.dispatch(createWebhook(repository.owner, repository.name));
     }
     if (!builds.isFetching) {
-      this.props.dispatch(requestBuilds(fullName));
+      this.props.dispatch(requestBuilds(repository.fullName));
     }
   }
 
   render() {
-    const { fullName, webhook, builds } = this.props;
+    const { repository, webhook, builds } = this.props;
     const isFetching = webhook.isFetching || builds.isFetching;
 
     return (
       <div className={styles.container}>
         <Helmet
-          title={`Setting up ${fullName}`}
+          title={`Setting up ${repository.fullName}`}
         />
         { isFetching &&
           <div className={styles.spinner}><Spinner /></div>
@@ -55,9 +56,11 @@ class RepositorySetup extends Component {
 }
 
 RepositorySetup.propTypes = {
-  account: PropTypes.string.isRequired,
-  repo: PropTypes.string.isRequired,
-  fullName: PropTypes.string.isRequired,
+  repository: PropTypes.shape({
+    owner: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    fullName: PropTypes.string.isRequired
+  }),
   webhook: PropTypes.shape({
     isFetching: PropTypes.bool,
     success: PropTypes.bool,
@@ -73,14 +76,16 @@ RepositorySetup.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const account = ownProps.params.account.toLowerCase();
-  const repo = ownProps.params.repo.toLowerCase();
-  const fullName = `${account}/${repo}`;
+  const owner = ownProps.params.owner.toLowerCase();
+  const name = ownProps.params.name.toLowerCase();
+  const fullName = `${owner}/${name}`;
 
   return {
-    account,
-    repo,
-    fullName,
+    repository: {
+      owner,
+      name,
+      fullName
+    },
     webhook: {
       isFetching: state.webhook.isFetching,
       success: state.webhook.success,

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
+import { getGitHubRepoUrl } from '../helpers/github-url';
 import { createWebhook } from '../actions/webhook';
 import { requestBuilds } from '../actions/snap-builds';
 import { Message } from '../components/forms';
@@ -22,12 +23,11 @@ class RepositorySetup extends Component {
   componentDidMount() {
     const { repository, webhook, builds } = this.props;
 
-    // TODO: bartaz - createWebhook and requestBuilds should have same params
     if (!webhook.isFetching) {
       this.props.dispatch(createWebhook(repository.owner, repository.name));
     }
     if (!builds.isFetching) {
-      this.props.dispatch(requestBuilds(repository.fullName));
+      this.props.dispatch(requestBuilds(repository.url));
     }
   }
 
@@ -59,7 +59,8 @@ RepositorySetup.propTypes = {
   repository: PropTypes.shape({
     owner: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
-    fullName: PropTypes.string.isRequired
+    fullName: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
   }),
   webhook: PropTypes.shape({
     isFetching: PropTypes.bool,
@@ -79,23 +80,17 @@ const mapStateToProps = (state, ownProps) => {
   const owner = ownProps.params.owner.toLowerCase();
   const name = ownProps.params.name.toLowerCase();
   const fullName = `${owner}/${name}`;
+  const url = getGitHubRepoUrl(fullName);
 
   return {
     repository: {
       owner,
       name,
-      fullName
+      fullName,
+      url
     },
-    webhook: {
-      isFetching: state.webhook.isFetching,
-      success: state.webhook.success,
-      error: state.webhook.error
-    },
-    builds: {
-      isFetching: state.snapBuilds.isFetching,
-      success: state.snapBuilds.success,
-      error: state.snapBuilds.error
-    }
+    webhook: state.webhook,
+    builds: state.snapBuilds
   };
 };
 

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -13,7 +13,7 @@ import Spinner from '../components/spinner';
 import styles from './container.css';
 
 class RepositorySetup extends Component {
-  componentWillMount() {
+  componentDidMount() {
     if (!this.props.repository && this.props.fullName) {
       this.props.dispatch(setGitHubRepository(this.props.fullName));
     }

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router';
 
 import { createWebhook } from '../actions/webhook';
 import { requestBuilds } from '../actions/snap-builds';
-import { setGitHubRepository } from '../actions/repository-input';
+import withRepository from './with-repository';
 
 import { Message } from '../components/forms';
 import Spinner from '../components/spinner';
@@ -13,11 +13,6 @@ import Spinner from '../components/spinner';
 import styles from './container.css';
 
 class RepositorySetup extends Component {
-  componentDidMount() {
-    if (!this.props.repository && this.props.fullName) {
-      this.props.dispatch(setGitHubRepository(this.props.fullName));
-    }
-  }
 
   componentWillReceiveProps(nextProps) {
     const { repository, webhook, builds } = nextProps;
@@ -43,7 +38,7 @@ class RepositorySetup extends Component {
     return (
       <div className={styles.container}>
         <Helmet
-          title={`Setting up ${this.props.fullName}`}
+          title={`Setting up ${repository.fullName}`}
         />
         { isFetching &&
           <div className={styles.spinner}><Spinner /></div>
@@ -61,13 +56,12 @@ class RepositorySetup extends Component {
 }
 
 RepositorySetup.propTypes = {
-  fullName: PropTypes.string.isRequired,
   repository: PropTypes.shape({
     owner: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     fullName: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired
-  }),
+  }).isRequired,
   webhook: PropTypes.shape({
     isFetching: PropTypes.bool,
     success: PropTypes.bool,
@@ -95,4 +89,4 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-export default connect(mapStateToProps)(withRouter(RepositorySetup));
+export default connect(mapStateToProps)(withRepository(withRouter(RepositorySetup)));

--- a/src/common/containers/with-repository.js
+++ b/src/common/containers/with-repository.js
@@ -18,10 +18,6 @@ function withRepository(WrappedComponent) {
       }
     }
 
-    componentWillUnmount() {
-
-    }
-
     render() {
       const { fullName, ...passThroughProps } = this.props;
       fullName; // just to 'use' this variable

--- a/src/common/containers/with-repository.js
+++ b/src/common/containers/with-repository.js
@@ -1,0 +1,50 @@
+import React, { Component, PropTypes } from 'react';
+
+import { setGitHubRepository } from '../actions/repository-input';
+
+function withRepository(WrappedComponent) {
+
+  class WithRepository extends Component {
+
+    componentDidMount() {
+      if (!this.props.repository && this.props.fullName) {
+        this.props.dispatch(setGitHubRepository(this.props.fullName));
+      }
+    }
+
+    componentWillReceiveProps(nextProps) {
+      if (this.props.fullName !== nextProps.fullName) {
+        this.props.dispatch(setGitHubRepository(nextProps.fullName));
+      }
+    }
+
+    componentWillUnmount() {
+
+    }
+
+    render() {
+      const { fullName, ...passThroughProps } = this.props;
+      fullName; // just to 'use' this variable
+
+      return (this.props.repository
+        ? <WrappedComponent {...passThroughProps} />
+        : null
+      );
+    }
+  }
+  WithRepository.displayName = `WithRepository(${getDisplayName(WrappedComponent)})`;
+
+  WithRepository.propTypes = {
+    fullName: PropTypes.string.isRequired,
+    repository: PropTypes.object,
+    dispatch: PropTypes.func.isRequired
+  };
+
+  return WithRepository;
+}
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export default withRepository;

--- a/src/common/containers/with-repository.js
+++ b/src/common/containers/with-repository.js
@@ -19,8 +19,7 @@ function withRepository(WrappedComponent) {
     }
 
     render() {
-      const { fullName, ...passThroughProps } = this.props;
-      fullName; // just to 'use' this variable
+      const { fullName, ...passThroughProps } = this.props; // eslint-disable-line no-unused-vars
 
       return (this.props.repository
         ? <WrappedComponent {...passThroughProps} />

--- a/src/common/helpers/github-url.js
+++ b/src/common/helpers/github-url.js
@@ -11,6 +11,6 @@ export const parseGitHubRepoUrl = (url) => {
     owner: repo.owner,
     name: repo.name,
     fullName: repo.repo,
-    url: url
+    url: getGitHubRepoUrl(repo.owner, repo.name)
   } : null;
 };

--- a/src/common/helpers/github-url.js
+++ b/src/common/helpers/github-url.js
@@ -1,6 +1,16 @@
-const getGitHubRepoUrl = (owner, name) => {
+import parseGitHubUrl from 'parse-github-url';
+
+export const getGitHubRepoUrl = (owner, name) => {
   let repository = !name ? owner : `${owner}/${name}`;
   return `https://github.com/${repository}`;
 };
 
-export default getGitHubRepoUrl;
+export const parseGitHubRepoUrl = (url) => {
+  const repo = parseGitHubUrl(url);
+  return (repo && repo.repo) ? {
+    owner: repo.owner,
+    name: repo.name,
+    fullName: repo.repo,
+    url: url
+  } : null;
+};

--- a/src/common/reducers/index.js
+++ b/src/common/reducers/index.js
@@ -1,6 +1,7 @@
 import { routerReducer } from 'react-router-redux';
 import { combineReducers } from 'redux';
 
+import * as repository from './repository';
 import * as repositoryInput from './repository-input';
 import * as authError from './auth-error';
 import * as snapBuilds from '../reducers/snap-builds';
@@ -8,6 +9,7 @@ import * as auth from './auth';
 import * as webhook from './webhook';
 
 const rootReducer = combineReducers({
+  ...repository,
   ...repositoryInput,
   ...authError,
   ...snapBuilds,

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -1,10 +1,8 @@
 import * as ActionTypes from '../actions/repository-input';
-import { parseGitHubRepoUrl } from '../helpers/github-url';
 
 export function repositoryInput(state = {
   isFetching: false,
   inputValue: '',
-  repository: null,
   success: false,
   error: false
 }, action) {
@@ -13,7 +11,6 @@ export function repositoryInput(state = {
       return {
         ...state,
         inputValue: action.payload,
-        repository: parseGitHubRepoUrl(action.payload),
         success: false,
         error: false
       };

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -9,8 +9,14 @@ function parseRepository(input) {
 export function repositoryInput(state = {
   isFetching: false,
   inputValue: '',
-  repository: null,
-  repositoryUrl: null,
+  repository: {
+// TODO: bartaz
+// keep also parsed owner and name here?
+//    owner: null,
+//    name: null,
+    fullName: null,
+    url: null
+  },
   success: false,
   error: false
 }, action) {
@@ -19,7 +25,10 @@ export function repositoryInput(state = {
       return {
         ...state,
         inputValue: action.payload,
-        repository: parseRepository(action.payload),
+        repository: {
+          ...state.repository,
+          fullName: parseRepository(action.payload),
+        },
         success: false,
         error: false
       };
@@ -34,7 +43,10 @@ export function repositoryInput(state = {
         isFetching: false,
         success: true,
         error: false,
-        repositoryUrl: action.payload
+        repository: {
+          ...state.repository,
+          url: action.payload,
+        }
       };
     case ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR:
       return {

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -1,21 +1,10 @@
 import * as ActionTypes from '../actions/repository-input';
-import parseGitHubUrl from 'parse-github-url';
-
-function parseRepository(input) {
-  const gitHubRepo = parseGitHubUrl(input);
-  return gitHubRepo ? gitHubRepo.repo : null;
-}
+import { parseGitHubRepoUrl } from '../helpers/github-url';
 
 export function repositoryInput(state = {
   isFetching: false,
   inputValue: '',
-  repository: {
-// TODO: bartaz
-// keep also parsed owner and name here?
-//    owner: null,
-//    name: null,
-    fullName: null
-  },
+  repository: null,
   success: false,
   error: false
 }, action) {
@@ -24,10 +13,7 @@ export function repositoryInput(state = {
       return {
         ...state,
         inputValue: action.payload,
-        repository: {
-          ...state.repository,
-          fullName: parseRepository(action.payload),
-        },
+        repository: parseGitHubRepoUrl(action.payload),
         success: false,
         error: false
       };

--- a/src/common/reducers/repository-input.js
+++ b/src/common/reducers/repository-input.js
@@ -14,8 +14,7 @@ export function repositoryInput(state = {
 // keep also parsed owner and name here?
 //    owner: null,
 //    name: null,
-    fullName: null,
-    url: null
+    fullName: null
   },
   success: false,
   error: false
@@ -32,38 +31,11 @@ export function repositoryInput(state = {
         success: false,
         error: false
       };
-    case ActionTypes.VERIFY_GITHUB_REPOSITORY:
-      return {
-        ...state,
-        isFetching: true
-      };
-    case ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS:
-      return {
-        ...state,
-        isFetching: false,
-        success: true,
-        error: false,
-        repository: {
-          ...state.repository,
-          url: action.payload,
-        }
-      };
-    case ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR:
-      return {
-        ...state,
-        isFetching: false,
-        success: false,
-        error: action.payload
-      };
-    // XXX cjwatson 2016-12-21: Merge with
-    // ActionTypes.VERIFY_GITHUB_REPOSITORY?
     case ActionTypes.CREATE_SNAP:
       return {
         ...state,
         isFetching: true
       };
-    // XXX cjwatson 2016-12-21: Merge with
-    // ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR?
     case ActionTypes.CREATE_SNAP_ERROR:
       return {
         ...state,

--- a/src/common/reducers/repository.js
+++ b/src/common/reducers/repository.js
@@ -1,0 +1,11 @@
+import * as ActionTypes from '../actions/repository-input';
+import { parseGitHubRepoUrl } from '../helpers/github-url';
+
+export function repository(state = null, action) {
+  switch(action.type) {
+    case ActionTypes.SET_GITHUB_REPOSITORY:
+      return parseGitHubRepoUrl(action.payload);
+    default:
+      return state;
+  }
+}

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -12,7 +12,7 @@ export default (
     <Route path="/" component={Home}/>
     <Route path="/:owner/:name/setup" component={RepositorySetup}/>
     <Route path="/:owner/:name/builds" component={Builds}/>
-    <Route path="/:account/:repo/builds/:buildId" component={BuildDetails}/>
+    <Route path="/:owner/:name/builds/:buildId" component={BuildDetails}/>
     <Route path="/login/failed" component={LoginFailed}/>
   </Route>
 );

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -11,7 +11,7 @@ export default (
   <Route component={App}>
     <Route path="/" component={Home}/>
     <Route path="/:owner/:name/setup" component={RepositorySetup}/>
-    <Route path="/:account/:repo/builds" component={Builds}/>
+    <Route path="/:owner/:name/builds" component={Builds}/>
     <Route path="/:account/:repo/builds/:buildId" component={BuildDetails}/>
     <Route path="/login/failed" component={LoginFailed}/>
   </Route>

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -10,7 +10,7 @@ import RepositorySetup from './containers/repository-setup.js';
 export default (
   <Route component={App}>
     <Route path="/" component={Home}/>
-    <Route path="/:account/:repo/setup" component={RepositorySetup}/>
+    <Route path="/:owner/:name/setup" component={RepositorySetup}/>
     <Route path="/:account/:repo/builds" component={Builds}/>
     <Route path="/:account/:repo/builds/:buildId" component={BuildDetails}/>
     <Route path="/login/failed" component={LoginFailed}/>

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -46,11 +46,11 @@ const RESPONSE_CREATED = {
 };
 
 export const createWebhook = (req, res) => {
-  const { account, repo } = req.body;
+  const { owner, name } = req.body;
 
   let secret;
   try {
-    secret = makeWebhookSecret(account, repo);
+    secret = makeWebhookSecret(owner, name);
   } catch (e) {
     return res.status(500).send({
       status: 'error',
@@ -61,8 +61,8 @@ export const createWebhook = (req, res) => {
     });
   }
 
-  const uri = `/repos/${account}/${repo}/hooks`;
-  const options = getRequest(account, repo, req.session.token, secret);
+  const uri = `/repos/${owner}/${name}/hooks`;
+  const options = getRequest(owner, name, req.session.token, secret);
   requestGitHub.post(uri, options)
     .then((response) => {
       if (response.statusCode !== 201) {
@@ -91,7 +91,7 @@ export const createWebhook = (req, res) => {
     });
 };
 
-const getRequest = (account, repo, token, secret) => {
+const getRequest = (owner, name, token, secret) => {
   return {
     token,
     json: {
@@ -101,7 +101,7 @@ const getRequest = (account, repo, token, secret) => {
         'push'
       ],
       config: {
-        url: `${conf.get('BASE_URL')}/${account}/${repo}/webhook/notify`,
+        url: `${conf.get('BASE_URL')}/${owner}/${name}/webhook/notify`,
         content_type: 'json',
         secret
       }

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -7,14 +7,14 @@ import { uncheckedRequestSnapBuilds } from './launchpad';
 
 const logger = logging.getLogger('express');
 
-export const makeWebhookSecret = (account, repo) => {
+export const makeWebhookSecret = (owner, name) => {
   const rootSecret = conf.get('GITHUB_WEBHOOK_SECRET');
   if (!rootSecret) {
     throw new Error('GitHub webhook secret not configured');
   }
   const hmac = createHmac('sha1', rootSecret);
-  hmac.update(account);
-  hmac.update(repo);
+  hmac.update(owner);
+  hmac.update(name);
   return hmac.digest('hex');
 };
 
@@ -22,6 +22,8 @@ export const makeWebhookSecret = (account, repo) => {
 // meaningful codes.
 export const notify = (req, res) => {
   const signature = req.headers['x-hub-signature'];
+  const { owner, name } = req.params;
+
   if (!signature) {
     logger.info('Rejecting unsigned webhook');
     return res.status(400).send();
@@ -35,7 +37,7 @@ export const notify = (req, res) => {
 
   let secret;
   try {
-    secret = makeWebhookSecret(req.params.account, req.params.repo);
+    secret = makeWebhookSecret(owner, name);
   } catch (e) {
     logger.error(e.message);
     return res.status(500).send();
@@ -53,8 +55,7 @@ export const notify = (req, res) => {
   if (req.headers['x-github-event'] === 'ping') {
     return res.status(200).send();
   } else {
-    const repositoryUrl = getGitHubRepoUrl(req.params.account,
-                                           req.params.repo);
+    const repositoryUrl = getGitHubRepoUrl(owner, name);
     return uncheckedRequestSnapBuilds(repositoryUrl)
       .then(() => {
         logger.info(`Requested builds of ${repositoryUrl}.`);

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -1,6 +1,6 @@
 import { createHmac } from 'crypto';
 
-import getGitHubRepoUrl from '../../common/helpers/github-url';
+import { getGitHubRepoUrl } from '../../common/helpers/github-url';
 import { conf } from '../helpers/config';
 import logging from '../logging';
 import { uncheckedRequestSnapBuilds } from './launchpad';

--- a/src/server/routes/webhook.js
+++ b/src/server/routes/webhook.js
@@ -5,8 +5,8 @@ import { text } from 'body-parser';
 const router = Router();
 
 // Really JSON, but we need the raw body to verify its signature.
-router.use('/:account/:repo/webhook/notify',
+router.use('/:owner/:name/webhook/notify',
            text({ type: 'application/json' }));
-router.post('/:account/:repo/webhook/notify', notify);
+router.post('/:owner/:name/webhook/notify', notify);
 
 export default router;

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -20,15 +20,15 @@ describe('The GitHub API endpoint', () => {
     context('when webhook does not already exist', () => {
       beforeEach(() => {
         const hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-        hmac.update('anaccount');
-        hmac.update('arepo');
+        hmac.update('anowner');
+        hmac.update('aname');
         scope = nock(conf.get('GITHUB_API_ENDPOINT'))
-          .post('/repos/anaccount/arepo/hooks', {
+          .post('/repos/anowner/aname/hooks', {
             name: 'web',
             active: true,
             events: ['push'],
             config: {
-              url: `${conf.get('BASE_URL')}/anaccount/arepo/webhook/notify`,
+              url: `${conf.get('BASE_URL')}/anowner/aname/webhook/notify`,
               content_type: 'json',
               secret: hmac.digest('hex')
             }
@@ -43,7 +43,7 @@ describe('The GitHub API endpoint', () => {
       it('should call GitHub API endpoint to create new webhook', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .end((err) => {
             scope.done();
             done(err);
@@ -54,14 +54,14 @@ describe('The GitHub API endpoint', () => {
       it('should return a 201 created response', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(201, done);
       });
 
       it('should return a "success" status', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('success'))
           .end(done);
       });
@@ -69,7 +69,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a "github-webhook-created" message', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-webhook-created'))
           .end(done);
       });
@@ -78,7 +78,7 @@ describe('The GitHub API endpoint', () => {
     context('when webhook already exists', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .post('/repos/anaccount/arepo/hooks')
+          .post('/repos/anowner/aname/hooks')
           .reply(422, { message: 'Validation Failed' });
       });
 
@@ -89,14 +89,14 @@ describe('The GitHub API endpoint', () => {
       it('should return a 422 Unprocessable Entity response', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(422, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -104,7 +104,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a "github-already-created" message', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-already-created'))
           .end(done);
       });
@@ -113,7 +113,7 @@ describe('The GitHub API endpoint', () => {
     context('when repo does not exist', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .post('/repos/anaccount/arepo/hooks')
+          .post('/repos/anowner/aname/hooks')
           .reply(404, { message: 'Not Found' });
       });
 
@@ -124,14 +124,14 @@ describe('The GitHub API endpoint', () => {
       it('should return a 404 Not Found response', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(404, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -139,7 +139,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a "github-repository-not-found" message', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-repository-not-found'))
           .end(done);
       });
@@ -148,7 +148,7 @@ describe('The GitHub API endpoint', () => {
     context('when authentication has failed', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .post('/repos/anaccount/arepo/hooks')
+          .post('/repos/anowner/aname/hooks')
           .reply(401, { message: 'Bad credentials' });
       });
 
@@ -159,14 +159,14 @@ describe('The GitHub API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(401, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -174,7 +174,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a github-authentication-failed message', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-authentication-failed'))
           .end(done);
       });
@@ -183,7 +183,7 @@ describe('The GitHub API endpoint', () => {
     context('when any other response is received', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .post('/repos/anaccount/arepo/hooks')
+          .post('/repos/anowner/aname/hooks')
           .reply(418, { message: 'I\'m a teapot' });
       });
 
@@ -194,14 +194,14 @@ describe('The GitHub API endpoint', () => {
       it('should return a 500 Internal Server Error response', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(500, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -209,7 +209,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a github-error-other message', (done) => {
         supertest(app)
           .post('/github/webhook')
-          .send({ account: 'anaccount', repo: 'arepo' })
+          .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-error-other'))
           .end(done);
       });

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -35,14 +35,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -50,7 +50,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a body with a "not-logged-in" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('not-logged-in'))
           .end(done);
       });
@@ -61,10 +61,10 @@ describe('The Launchpad API endpoint', () => {
 
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: true } });
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo/contents/snapcraft.yaml')
+          .get('/repos/anowner/aname/contents/snapcraft.yaml')
           .reply(200, `name: ${snapName}\n`);
       });
 
@@ -89,14 +89,14 @@ describe('The Launchpad API endpoint', () => {
         it('should return a 400 Bad Request response', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anaccount/arepo' })
+            .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(400, done);
         });
 
         it('should return a "error" status', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anaccount/arepo' })
+            .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasStatus('error'))
             .end(done);
         });
@@ -105,7 +105,7 @@ describe('The Launchpad API endpoint', () => {
            'message', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anaccount/arepo' })
+            .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasMessage(
                 'snap-name-not-registered',
                 'Snap name is not registered in the store'))
@@ -115,7 +115,7 @@ describe('The Launchpad API endpoint', () => {
         it('should include snap name in body', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anaccount/arepo' })
+            .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect((actual) => {
               if (typeof actual.body.payload === 'undefined'
                   || actual.body.payload.snap_name !== snapName) {
@@ -152,14 +152,14 @@ describe('The Launchpad API endpoint', () => {
           it('should return a 400 Bad Request response', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anaccount/arepo' })
+              .send({ repository_url: 'https://github.com/anowner/aname' })
               .expect(400, done);
           });
 
           it('should return a "error" status', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anaccount/arepo' })
+              .send({ repository_url: 'https://github.com/anowner/aname' })
               .expect(hasStatus('error'))
               .end(done);
           });
@@ -167,7 +167,7 @@ describe('The Launchpad API endpoint', () => {
           it('should return a body with an "lp-error" message', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anaccount/arepo' })
+              .send({ repository_url: 'https://github.com/anowner/aname' })
               .expect(hasMessage(
                   'lp-error',
                   'There is already a snap package with the same name and owner.'))
@@ -183,7 +183,7 @@ describe('The Launchpad API endpoint', () => {
             nock(lp_api_url)
               .post('/devel/+snaps', {
                 'ws.op': 'new',
-                git_repository_url: 'https://github.com/anaccount/arepo',
+                git_repository_url: 'https://github.com/anowner/aname',
                 processors: ['/+processors/amd64', '/+processors/armhf'],
                 store_name: snapName
               })
@@ -208,14 +208,14 @@ describe('The Launchpad API endpoint', () => {
           it('should return a 201 Created response', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anaccount/arepo' })
+              .send({ repository_url: 'https://github.com/anowner/aname' })
               .expect(201, done);
           });
 
           it('should return a "success" status', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anaccount/arepo' })
+              .send({ repository_url: 'https://github.com/anowner/aname' })
               .expect(hasStatus('success'))
               .end(done);
           });
@@ -223,7 +223,7 @@ describe('The Launchpad API endpoint', () => {
           it('should return a body with an appropriate caveat ID', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anaccount/arepo' })
+              .send({ repository_url: 'https://github.com/anowner/aname' })
               .expect(hasMessage('snap-created', caveatId))
               .end(done);
           });
@@ -259,7 +259,7 @@ describe('The Launchpad API endpoint', () => {
     context('when user has no admin permissions on GitHub repository', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: false } });
       });
 
@@ -270,14 +270,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -286,7 +286,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-no-admin-permissions'))
           .end(done);
       });
@@ -295,7 +295,7 @@ describe('The Launchpad API endpoint', () => {
     context('when repo does not exist', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(404, { message: 'Not Found' });
       });
 
@@ -306,14 +306,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 Not Found response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(404, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -322,7 +322,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-snapcraft-yaml-not-found'))
           .end(done);
       });
@@ -331,7 +331,7 @@ describe('The Launchpad API endpoint', () => {
     context('when authentication has failed', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(401, { message: 'Bad credentials' });
       });
 
@@ -342,14 +342,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -358,7 +358,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-authentication-failed'))
           .end(done);
       });
@@ -375,7 +375,7 @@ describe('The Launchpad API endpoint', () => {
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
-            url: 'https://github.com/anaccount/arepo'
+            url: 'https://github.com/anowner/aname'
           })
           .reply(200, {
             total_size: 2,
@@ -402,14 +402,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 200 response', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(200, done);
       });
 
       it('should return a "success" status', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('success'))
           .end(done);
       });
@@ -418,7 +418,7 @@ describe('The Launchpad API endpoint', () => {
          'URL', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage(
             'snap-found',
             `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`))
@@ -433,7 +433,7 @@ describe('The Launchpad API endpoint', () => {
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
-            url: 'https://github.com/anaccount/arepo'
+            url: 'https://github.com/anowner/aname'
           })
           .reply(200, {
             total_size: 0,
@@ -449,14 +449,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 response', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(404, done);
       });
 
       it('should return an "error" status', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -464,7 +464,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a body with a "snap-not-found" message', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('snap-not-found'))
           .end(done);
       });
@@ -477,7 +477,7 @@ describe('The Launchpad API endpoint', () => {
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
-            url: 'https://github.com/anaccount/arepo'
+            url: 'https://github.com/anowner/aname'
           })
           .reply(401, 'Bad OAuth token.');
       });
@@ -489,14 +489,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 response', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
 
       it('should return an "error" status', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -504,14 +504,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a body with an "lp-error" message', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('lp-error', 'Bad OAuth token.'))
           .end(done);
       });
     });
 
     context('when repository is memcached', () => {
-      const repositoryUrl = 'https://github.com/anaccount/arepo';
+      const repositoryUrl = 'https://github.com/anowner/aname';
       const snapUrl = `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`;
 
       before(() => {
@@ -526,14 +526,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 200 response', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(200, done);
       });
 
       it('should return a "success" status', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('success'))
           .end(done);
       });
@@ -541,7 +541,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a body with a "snap-found" message with the correct URL', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
-          .query({ repository_url: 'https://github.com/anaccount/arepo' })
+          .query({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('snap-found', snapUrl))
           .end(done);
       });
@@ -822,7 +822,7 @@ describe('The Launchpad API endpoint', () => {
     context('when snap exists', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: true } });
         const lp_api_url = conf.get('LP_API_URL');
         const lp_api_base = `${lp_api_url}/devel`;
@@ -830,7 +830,7 @@ describe('The Launchpad API endpoint', () => {
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
-            url: 'https://github.com/anaccount/arepo'
+            url: 'https://github.com/anowner/aname'
           })
           .reply(200, {
             total_size: 1,
@@ -866,14 +866,14 @@ describe('The Launchpad API endpoint', () => {
       it('returns a 201 Created response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(201, done);
       });
 
       it('returns a "success" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('success'))
           .end(done);
       });
@@ -881,7 +881,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns body with a "snap-builds-requested" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('snap-builds-requested'))
           .end(done);
       });
@@ -890,7 +890,7 @@ describe('The Launchpad API endpoint', () => {
         const lp_api_base = `${conf.get('LP_API_URL')}/devel`;
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect((res) => {
             const buildUrls = res.body.payload.builds.map((entry) => {
               return entry.self_link;
@@ -907,7 +907,7 @@ describe('The Launchpad API endpoint', () => {
     context('when user has no admin permissions on GitHub repository', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: false } });
       });
 
@@ -918,14 +918,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -934,7 +934,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-no-admin-permissions'))
           .end(done);
       });
@@ -943,7 +943,7 @@ describe('The Launchpad API endpoint', () => {
     context('when repo does not exist', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(404, { message: 'Not Found' });
       });
 
@@ -954,14 +954,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 Not Found response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(404, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -970,7 +970,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-snapcraft-yaml-not-found'))
           .end(done);
       });
@@ -979,14 +979,14 @@ describe('The Launchpad API endpoint', () => {
     context('when snap does not exist', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: true } });
         const lp_api_url = conf.get('LP_API_URL');
         nock(lp_api_url)
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
-            url: 'https://github.com/anaccount/arepo'
+            url: 'https://github.com/anowner/aname'
           })
           .reply(200, {
             total_size: 0,
@@ -1002,14 +1002,14 @@ describe('The Launchpad API endpoint', () => {
       it('returns a 404 response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(404, done);
       });
 
       it('returns an "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -1017,7 +1017,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns body with a "snap-not-found" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
-          .send({ repository_url: 'https://github.com/anaccount/arepo' })
+          .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('snap-not-found'))
           .end(done);
       });

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -22,14 +22,14 @@ describe('The WebHook API endpoint', () => {
 
     it('rejects unsigned requests', (done) => {
       supertest(app)
-        .post('/anaccount/arepo/webhook/notify')
+        .post('/anowner/aname/webhook/notify')
         .send({})
         .expect(400, done);
     });
 
     it('rejects requests containing non-object JSON data', (done) => {
       supertest(app)
-        .post('/anaccount/arepo/webhook/notify')
+        .post('/anowner/aname/webhook/notify')
         .type('application/json')
         .set('X-GitHub-Event', 'push')
         .set('X-Hub-Signature', 'dummy')
@@ -40,12 +40,12 @@ describe('The WebHook API endpoint', () => {
     it('rejects requests with a bad signature', (done) => {
       const body = JSON.stringify({ ref: 'refs/heads/master' });
       let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-      hmac.update('anaccount');
-      hmac.update('arepo');
+      hmac.update('anowner');
+      hmac.update('aname');
       hmac = createHmac('sha1', hmac.digest('hex'));
       hmac.update(body + ' ');
       supertest(app)
-        .post('/anaccount/arepo/webhook/notify')
+        .post('/anowner/aname/webhook/notify')
         .type('application/json')
         .set('X-GitHub-Event', 'push')
         .set('X-Hub-Signature', `sha1=${hmac.digest('hex')}`)
@@ -61,7 +61,7 @@ describe('The WebHook API endpoint', () => {
         .get('/devel/+snaps')
         .query({
           'ws.op': 'findByURL',
-          url: 'https://github.com/anaccount/arepo'
+          url: 'https://github.com/anowner/aname'
         })
         .reply(200, {
           total_size: 1,
@@ -95,12 +95,12 @@ describe('The WebHook API endpoint', () => {
 
       const body = JSON.stringify({ ref: 'refs/heads/master' });
       let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-      hmac.update('anaccount');
-      hmac.update('arepo');
+      hmac.update('anowner');
+      hmac.update('aname');
       hmac = createHmac('sha1', hmac.digest('hex'));
       hmac.update(body);
       supertest(app)
-        .post('/anaccount/arepo/webhook/notify')
+        .post('/anowner/aname/webhook/notify')
         .type('application/json')
         .set('X-GitHub-Event', 'push')
         .set('X-Hub-Signature', `sha1=${hmac.digest('hex')}`)
@@ -117,7 +117,7 @@ describe('The WebHook API endpoint', () => {
         .get('/devel/+snaps')
         .query({
           'ws.op': 'findByURL',
-          url: 'https://github.com/anaccount/arepo'
+          url: 'https://github.com/anowner/aname'
         })
         .reply(200, {
           total_size: 0,
@@ -127,12 +127,12 @@ describe('The WebHook API endpoint', () => {
 
       const body = JSON.stringify({ ref: 'refs/heads/master' });
       let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-      hmac.update('anaccount');
-      hmac.update('arepo');
+      hmac.update('anowner');
+      hmac.update('aname');
       hmac = createHmac('sha1', hmac.digest('hex'));
       hmac.update(body);
       supertest(app)
-        .post('/anaccount/arepo/webhook/notify')
+        .post('/anowner/aname/webhook/notify')
         .type('application/json')
         .set('X-GitHub-Event', 'push')
         .set('X-Hub-Signature', `sha1=${hmac.digest('hex')}`)
@@ -151,12 +151,12 @@ describe('The WebHook API endpoint', () => {
 
       const body = JSON.stringify({ ref: 'refs/heads/master' });
       let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-      hmac.update('anaccount');
-      hmac.update('arepo');
+      hmac.update('anowner');
+      hmac.update('aname');
       hmac = createHmac('sha1', hmac.digest('hex'));
       hmac.update(body);
       supertest(app)
-        .post('/anaccount/arepo/webhook/notify')
+        .post('/anowner/aname/webhook/notify')
         .type('application/json')
         .set('X-GitHub-Event', 'ping')
         .set('X-Hub-Signature', `sha1=${hmac.digest('hex')}`)

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -8,10 +8,7 @@ import url from 'url';
 import {
   createSnap,
   createSnapError,
-  setGitHubRepository,
-  verifyGitHubRepository,
-  verifyGitHubRepositorySuccess,
-  verifyGitHubRepositoryError
+  setGitHubRepository
 } from '../../../../../src/common/actions/repository-input';
 import * as ActionTypes from '../../../../../src/common/actions/repository-input';
 import conf from '../../../../../src/common/helpers/config';
@@ -24,8 +21,7 @@ describe('repository input actions', () => {
     isFetching: false,
     inputValue: '',
     repository: {
-      fullName: null,
-      url: null
+      fullName: null
     },
     statusMessage: '',
     success: false,
@@ -58,93 +54,6 @@ describe('repository input actions', () => {
 
     it('should create a valid flux standard action', () => {
       expect(isFSA(action)).toBe(true);
-    });
-  });
-
-  context('verifyGitHubRepositorySuccess', () => {
-    let payload = 'http://github.com/foo/bar.git';
-
-    beforeEach(() => {
-      action = verifyGitHubRepositorySuccess(payload);
-    });
-
-    it('should create an action to save github repo url on success', () => {
-      const expectedAction = {
-        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
-        payload
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('should create a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
-  });
-
-  context('verifyGitHubRepositoryError', () => {
-    let payload = 'Something went wrong!';
-
-    beforeEach(() => {
-      action = verifyGitHubRepositoryError(payload);
-    });
-
-    it('should create an action to store github repo error on failure', () => {
-      const expectedAction = {
-        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR,
-        error: true,
-        payload
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('should create a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
-  });
-
-  context('verifyGitHubRepository', () => {
-    const GITHUB_API_ENDPOINT = conf.get('GITHUB_API_ENDPOINT');
-    let scope;
-
-    beforeEach(() => {
-      scope = nock(GITHUB_API_ENDPOINT);
-    });
-
-    afterEach(() => {
-      nock.cleanAll();
-    });
-
-    it('should save GitHub repo on successful verification', () => {
-      scope.get('/repos/foo/bar/contents/snapcraft.yaml')
-        .reply(200, {
-          'name': 'snapcraft.yaml'
-        });
-
-      return store.dispatch(verifyGitHubRepository('foo/bar'))
-        .then(() => {
-          expect(store.getActions()).toHaveActionOfType(
-            ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS
-          );
-        });
-    });
-
-    it('should store error on GitHub verification failure', () => {
-      scope.get('/repos/foo/bar/contents/snapcraft.yaml')
-        .reply(404, {
-          'message': 'Not Found',
-          'documentation_url': 'https://developer.github.com/v3'
-        });
-
-      return store.dispatch(verifyGitHubRepository('foo/bar'))
-        .then(() => {
-          expect(store.getActions()).toHaveActionOfType(
-            ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR
-          );
-        });
     });
   });
 

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -23,8 +23,10 @@ describe('repository input actions', () => {
   const initialState = {
     isFetching: false,
     inputValue: '',
-    repository: null,
-    repositoryUrl: null,
+    repository: {
+      fullName: null,
+      url: null
+    },
     statusMessage: '',
     success: false,
     error: false

--- a/test/unit/src/common/actions/t_repository-input.js
+++ b/test/unit/src/common/actions/t_repository-input.js
@@ -58,6 +58,7 @@ describe('repository input actions', () => {
   });
 
   context('createSnap', () => {
+    const repositoryUrl = 'https://github.com/foo/bar';
     const BASE_URL = conf.get('BASE_URL');
     let scope;
 
@@ -80,7 +81,7 @@ describe('repository input actions', () => {
         });
 
       const location = {};
-      return store.dispatch(createSnap('foo/bar', location))
+      return store.dispatch(createSnap(repositoryUrl, location))
         .then(() => {
           expect(url.parse(location.href, true)).toMatch({
             path: '/login/authenticate',
@@ -103,7 +104,7 @@ describe('repository input actions', () => {
         });
 
       const location = {};
-      return store.dispatch(createSnap('foo/bar', location))
+      return store.dispatch(createSnap(repositoryUrl, location))
         .then(() => {
           expect(location).toExcludeKey('href');
           expect(store.getActions()).toHaveActionOfType(

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -162,7 +162,7 @@ describe('snap builds actions', () => {
           }
         });
 
-      return store.dispatch(fetchSnap('foo/bar'))
+      return store.dispatch(fetchSnap(repositoryUrl))
         .then(() => {
           api.done();
           expect(store.getActions()).toHaveActionOfType(
@@ -224,7 +224,7 @@ describe('snap builds actions', () => {
       });
 
       it('should dispatch error action', () => {
-        return store.dispatch(fetchSnap(badRepo))
+        return store.dispatch(fetchSnap(repositoryUrl))
           .then(() => {
             expect(store.getActions()).toHaveActionOfType(
               ActionTypes.FETCH_BUILDS_ERROR
@@ -233,7 +233,7 @@ describe('snap builds actions', () => {
       });
 
       it('should pass error message from repsponse to action', () => {
-        return store.dispatch(fetchSnap(badRepo))
+        return store.dispatch(fetchSnap(repositoryUrl))
           .then(() => {
             const action = store.getActions().filter(a => a.type === ActionTypes.FETCH_BUILDS_ERROR)[0];
             expect(action.payload.message).toBe('Bad repo URL');

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -270,7 +270,7 @@ describe('snap builds actions', () => {
           }
         });
 
-      return store.dispatch(requestBuilds(repo))
+      return store.dispatch(requestBuilds(repositoryUrl))
         .then(() => {
           api.done();
           expect(store.getActions()).toHaveActionOfType(
@@ -292,7 +292,7 @@ describe('snap builds actions', () => {
           }
         });
 
-      return store.dispatch(requestBuilds(repo))
+      return store.dispatch(requestBuilds(repositoryUrl))
         .then(() => {
           expect(store.getActions()).toHaveActionOfType(
             ActionTypes.FETCH_BUILDS_ERROR

--- a/test/unit/src/common/components/repository-input/t_repository-input.js
+++ b/test/unit/src/common/components/repository-input/t_repository-input.js
@@ -16,9 +16,9 @@ const baseProps = {
   },
   repositoryInput: {
     success: false,
-    repository: null,
     inputValue: '',
   },
+  repository: null,
   webhook: {
     error: false
   },
@@ -91,12 +91,12 @@ describe('The RepositoryInput component', () => {
           repositoryInput: {
             ...baseProps.repositoryInput,
             inputValue: 'example/example',
-            repository: {
-              fullName: 'example/example',
-              url: 'https://github.com/example/example'
-            },
             success: true
-          }
+          },
+          repository: {
+            fullName: 'example/example',
+            url: 'https://github.com/example/example'
+          },
         };
         const store = mockStore(props);
         component = shallow(<RepositoryInput { ...props } store={ store } />);
@@ -134,11 +134,11 @@ describe('The RepositoryInput component', () => {
             ...baseProps.repositoryInput,
             success: true,
             inputValue: 'test-owner/test-name',
-            repository: {
-              fullName: 'test-owner/test-name',
-              url: 'https://github.com/test-owner/test-name'
-            },
           },
+          repository: {
+            fullName: 'test-owner/test-name',
+            url: 'https://github.com/test-owner/test-name'
+          }
         };
         store = mockStore(props);
 

--- a/test/unit/src/common/components/repository-input/t_repository-input.js
+++ b/test/unit/src/common/components/repository-input/t_repository-input.js
@@ -132,10 +132,10 @@ describe('The RepositoryInput component', () => {
           repositoryInput: {
             ...baseProps.repositoryInput,
             success: true,
-            inputValue: 'account/repo',
+            inputValue: 'test-owner/test-name',
             repository: {
               ...baseProps.repositoryInput.repository,
-              fullName: 'account/repo'
+              fullName: 'test-owner/test-name'
             }
           },
         };

--- a/test/unit/src/common/components/repository-input/t_repository-input.js
+++ b/test/unit/src/common/components/repository-input/t_repository-input.js
@@ -16,10 +16,7 @@ const baseProps = {
   },
   repositoryInput: {
     success: false,
-    repository: {
-      fullName: null,
-      url: null
-    },
+    repository: null,
     inputValue: '',
   },
   webhook: {
@@ -94,6 +91,10 @@ describe('The RepositoryInput component', () => {
           repositoryInput: {
             ...baseProps.repositoryInput,
             inputValue: 'example/example',
+            repository: {
+              fullName: 'example/example',
+              url: 'https://github.com/example/example'
+            },
             success: true
           }
         };
@@ -134,9 +135,9 @@ describe('The RepositoryInput component', () => {
             success: true,
             inputValue: 'test-owner/test-name',
             repository: {
-              ...baseProps.repositoryInput.repository,
-              fullName: 'test-owner/test-name'
-            }
+              fullName: 'test-owner/test-name',
+              url: 'https://github.com/test-owner/test-name'
+            },
           },
         };
         store = mockStore(props);

--- a/test/unit/src/common/components/repository-input/t_repository-input.js
+++ b/test/unit/src/common/components/repository-input/t_repository-input.js
@@ -16,6 +16,10 @@ const baseProps = {
   },
   repositoryInput: {
     success: false,
+    repository: {
+      fullName: null,
+      url: null
+    },
     inputValue: '',
   },
   webhook: {
@@ -88,6 +92,7 @@ describe('The RepositoryInput component', () => {
         const props = {
           ...baseProps,
           repositoryInput: {
+            ...baseProps.repositoryInput,
             inputValue: 'example/example',
             success: true
           }
@@ -125,9 +130,13 @@ describe('The RepositoryInput component', () => {
         const props = {
           ...baseProps,
           repositoryInput: {
+            ...baseProps.repositoryInput,
             success: true,
             inputValue: 'account/repo',
-            repository: 'account/repo'
+            repository: {
+              ...baseProps.repositoryInput.repository,
+              fullName: 'account/repo'
+            }
           },
         };
         store = mockStore(props);

--- a/test/unit/src/common/helpers/t_github-url.js
+++ b/test/unit/src/common/helpers/t_github-url.js
@@ -25,6 +25,15 @@ describe('parseGitHubRepoUrl helper', () => {
     });
   });
 
+  it('should return repo data for valid owner/repo pair', () => {
+    expect(parseGitHubRepoUrl('foo/bar')).toEqual({
+      owner: 'foo',
+      name: 'bar',
+      fullName: 'foo/bar',
+      url: 'https://github.com/foo/bar'
+    });
+  });
+
   it('should return null for null', () => {
     expect(parseGitHubRepoUrl(null)).toBe(null);
   });

--- a/test/unit/src/common/helpers/t_github-url.js
+++ b/test/unit/src/common/helpers/t_github-url.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 
-import getGitHubRepoUrl from '../../../../../src/common/helpers/github-url';
+import { getGitHubRepoUrl, parseGitHubRepoUrl } from '../../../../../src/common/helpers/github-url';
 
 describe('getGitHubRepoUrl helper', () => {
 
@@ -10,6 +10,27 @@ describe('getGitHubRepoUrl helper', () => {
 
   it('should return GH repo url when passed user and repo strings', () => {
     expect(getGitHubRepoUrl('foo', 'bar')).toEqual('https://github.com/foo/bar');
+  });
+
+});
+
+describe('parseGitHubRepoUrl helper', () => {
+
+  it('should return repo data for valid url', () => {
+    expect(parseGitHubRepoUrl('https://github.com/foo/bar')).toEqual({
+      owner: 'foo',
+      name: 'bar',
+      fullName: 'foo/bar',
+      url: 'https://github.com/foo/bar'
+    });
+  });
+
+  it('should return null for null', () => {
+    expect(parseGitHubRepoUrl(null)).toBe(null);
+  });
+
+  it('should return null for invalid GH url', () => {
+    expect(parseGitHubRepoUrl('something foo bar')).toBe(null);
   });
 
 });

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -7,9 +7,7 @@ describe('repositoryInput reducers', () => {
   const initialState = {
     isFetching: false,
     inputValue: '',
-    repository: {
-      fullName: null
-    },
+    repository: null,
     success: false,
     error: false
   };
@@ -23,7 +21,8 @@ describe('repositoryInput reducers', () => {
 
     beforeEach(() => {
       action = {
-        type: ActionTypes.SET_GITHUB_REPOSITORY
+        type: ActionTypes.SET_GITHUB_REPOSITORY,
+        payload: ''
       };
     });
 
@@ -51,17 +50,15 @@ describe('repositoryInput reducers', () => {
       });
     });
 
-    it('should clear repository name for invalid input', () => {
+    it('should clear repository for invalid input', () => {
       action.payload = 'foo bar';
 
       const state = {
         ...initialState,
-        repository: 'foo/bar'
+        repository: { fullName: 'foo/bar' }
       };
 
-      expect(repositoryInput(state, action).repository).toInclude({
-        fullName: null
-      });
+      expect(repositoryInput(state, action).repository).toBe(null);
     });
 
     it('should reset error status', () => {

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -7,7 +7,6 @@ describe('repositoryInput reducers', () => {
   const initialState = {
     isFetching: false,
     inputValue: '',
-    repository: null,
     success: false,
     error: false
   };
@@ -32,33 +31,6 @@ describe('repositoryInput reducers', () => {
       expect(repositoryInput(initialState, action)).toInclude({
         inputValue: 'foo'
       });
-    });
-
-    it('should save repository name for valid user/repo pair', () => {
-      action.payload = 'foo/bar';
-
-      expect(repositoryInput(initialState, action).repository).toInclude({
-        fullName: 'foo/bar'
-      });
-    });
-
-    it('should save repository name for valid repo URL', () => {
-      action.payload = 'http://github.com/foo/bar';
-
-      expect(repositoryInput(initialState, action).repository).toInclude({
-        fullName: 'foo/bar'
-      });
-    });
-
-    it('should clear repository for invalid input', () => {
-      action.payload = 'foo bar';
-
-      const state = {
-        ...initialState,
-        repository: { fullName: 'foo/bar' }
-      };
-
-      expect(repositoryInput(state, action).repository).toBe(null);
     });
 
     it('should reset error status', () => {
@@ -98,10 +70,6 @@ describe('repositoryInput reducers', () => {
     it('handles snap creation failure', () => {
       const state = {
         ...initialState,
-        repository: {
-          ...initialState.repository,
-          fullName: 'dummy/repo'
-        },
         isFetching: true
       };
 

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -8,8 +8,7 @@ describe('repositoryInput reducers', () => {
     isFetching: false,
     inputValue: '',
     repository: {
-      fullName: null,
-      url: null
+      fullName: null
     },
     success: false,
     error: false
@@ -81,86 +80,6 @@ describe('repositoryInput reducers', () => {
       };
 
       expect(repositoryInput(state, action).success).toBe(false);
-    });
-  });
-
-  context('VERIFY_GITHUB_REPOSITORY', () => {
-    it('should store fetching status when repository is verified via GH API', () => {
-      const action = {
-        type: ActionTypes.VERIFY_GITHUB_REPOSITORY,
-        payload: 'dummy/repo'
-      };
-
-      expect(repositoryInput(initialState, action)).toEqual({
-        ...initialState,
-        isFetching: true
-      });
-    });
-  });
-
-  context('VERIFY_GITHUB_REPOSITORY_SUCCESS', () => {
-    it('should handle verify repo success', () => {
-      const state = {
-        ...initialState,
-        repository: {
-          ...initialState.repository,
-          fullName: 'dummy/repo'
-        },
-        isFetching: true
-      };
-
-      const action = {
-        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
-        payload: 'http://github.com/dummy/repo.git'
-      };
-
-      expect(repositoryInput(state, action)).toEqual({
-        ...state,
-        isFetching: false,
-        repository: {
-          ...state.repository,
-          url: 'http://github.com/dummy/repo.git'
-        },
-        success: true
-      });
-    });
-
-    it('should clean error', () => {
-      const state = {
-        ...initialState,
-        repository: 'dummy/repo',
-        error: new Error('Previous error')
-      };
-
-      const action = {
-        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_SUCCESS,
-        payload: 'http://github.com/dummy/repo.git'
-      };
-
-      expect(repositoryInput(state, action).error).toBe(false);
-    });
-  });
-
-  context('VERIFY_GITHUB_REPOSITORY_ERROR', () => {
-    it('should handle verify repo failure', () => {
-      const state = {
-        ...initialState,
-        repository: 'dummy/repo',
-        isFetching: true
-      };
-
-      const action = {
-        type: ActionTypes.VERIFY_GITHUB_REPOSITORY_ERROR,
-        payload: new Error('Something went wrong!'),
-        error: true
-      };
-
-      expect(repositoryInput(state, action)).toEqual({
-        ...state,
-        isFetching: false,
-        success: false,
-        error: action.payload
-      });
     });
   });
 

--- a/test/unit/src/common/reducers/t_repository-input.js
+++ b/test/unit/src/common/reducers/t_repository-input.js
@@ -7,8 +7,10 @@ describe('repositoryInput reducers', () => {
   const initialState = {
     isFetching: false,
     inputValue: '',
-    repository: null,
-    repositoryUrl: null,
+    repository: {
+      fullName: null,
+      url: null
+    },
     success: false,
     error: false
   };
@@ -37,16 +39,16 @@ describe('repositoryInput reducers', () => {
     it('should save repository name for valid user/repo pair', () => {
       action.payload = 'foo/bar';
 
-      expect(repositoryInput(initialState, action)).toInclude({
-        repository: 'foo/bar'
+      expect(repositoryInput(initialState, action).repository).toInclude({
+        fullName: 'foo/bar'
       });
     });
 
     it('should save repository name for valid repo URL', () => {
       action.payload = 'http://github.com/foo/bar';
 
-      expect(repositoryInput(initialState, action)).toInclude({
-        repository: 'foo/bar'
+      expect(repositoryInput(initialState, action).repository).toInclude({
+        fullName: 'foo/bar'
       });
     });
 
@@ -58,8 +60,8 @@ describe('repositoryInput reducers', () => {
         repository: 'foo/bar'
       };
 
-      expect(repositoryInput(state, action)).toInclude({
-        repository: null
+      expect(repositoryInput(state, action).repository).toInclude({
+        fullName: null
       });
     });
 
@@ -100,7 +102,10 @@ describe('repositoryInput reducers', () => {
     it('should handle verify repo success', () => {
       const state = {
         ...initialState,
-        repository: 'dummy/repo',
+        repository: {
+          ...initialState.repository,
+          fullName: 'dummy/repo'
+        },
         isFetching: true
       };
 
@@ -112,7 +117,10 @@ describe('repositoryInput reducers', () => {
       expect(repositoryInput(state, action)).toEqual({
         ...state,
         isFetching: false,
-        repositoryUrl: 'http://github.com/dummy/repo.git',
+        repository: {
+          ...state.repository,
+          url: 'http://github.com/dummy/repo.git'
+        },
         success: true
       });
     });
@@ -174,7 +182,10 @@ describe('repositoryInput reducers', () => {
     it('handles snap creation failure', () => {
       const state = {
         ...initialState,
-        repository: 'dummy/repo',
+        repository: {
+          ...initialState.repository,
+          fullName: 'dummy/repo'
+        },
         isFetching: true
       };
 

--- a/test/unit/src/common/reducers/t_repository.js
+++ b/test/unit/src/common/reducers/t_repository.js
@@ -1,0 +1,51 @@
+import expect from 'expect';
+
+import { repository } from '../../../../../src/common/reducers/repository';
+import * as ActionTypes from '../../../../../src/common/actions/repository-input';
+
+describe('repository reducers', () => {
+  const initialState = null;
+
+  it('should return the initial state', () => {
+    expect(repository(undefined, {})).toEqual(initialState);
+  });
+
+  context('SET_GITHUB_REPOSITORY', () => {
+    let action;
+
+    beforeEach(() => {
+      action = {
+        type: ActionTypes.SET_GITHUB_REPOSITORY,
+        payload: ''
+      };
+    });
+
+    it('should save repository name for valid user/repo pair', () => {
+      action.payload = 'foo/bar';
+
+      expect(repository(initialState, action)).toInclude({
+        fullName: 'foo/bar'
+      });
+    });
+
+    it('should save repository name for valid repo URL', () => {
+      action.payload = 'http://github.com/foo/bar';
+
+      expect(repository(initialState, action)).toInclude({
+        fullName: 'foo/bar'
+      });
+    });
+
+    it('should clear repository for invalid input', () => {
+      action.payload = 'foo bar';
+
+      const state = {
+        fullName: 'foo/bar'
+      };
+
+      expect(repository(state, action)).toBe(null);
+    });
+
+  });
+
+});

--- a/test/unit/src/server/handlers/t_launchpad.js
+++ b/test/unit/src/server/handlers/t_launchpad.js
@@ -12,7 +12,7 @@ describe('completeSnapAuthorization', () => {
 
     beforeEach(() => {
       nock(conf.get('GITHUB_API_ENDPOINT'))
-        .get('/repos/anaccount/arepo')
+        .get('/repos/anowner/aname')
         .reply(200, { permissions: { admin: true } });
       const lp_api_url = conf.get('LP_API_URL');
       const lp_api_base = `${lp_api_url}/devel`;
@@ -20,7 +20,7 @@ describe('completeSnapAuthorization', () => {
         .get('/devel/+snaps')
         .query({
           'ws.op': 'findByURL',
-          url: 'https://github.com/anaccount/arepo'
+          url: 'https://github.com/anowner/aname'
         })
         .reply(200, {
           total_size: 1,
@@ -49,7 +49,7 @@ describe('completeSnapAuthorization', () => {
 
     it('completes the authorization', () => {
       return completeSnapAuthorization(
-          session, 'https://github.com/anaccount/arepo', 'dummy-discharge')
+          session, 'https://github.com/anowner/aname', 'dummy-discharge')
         .then(() => completeAuthorizationScope.done());
     });
   });
@@ -57,14 +57,14 @@ describe('completeSnapAuthorization', () => {
   context('when snap does not exist', () => {
     beforeEach(() => {
       nock(conf.get('GITHUB_API_ENDPOINT'))
-        .get('/repos/anaccount/arepo')
+        .get('/repos/anowner/aname')
         .reply(200, { permissions: { admin: true } });
       const lp_api_url = conf.get('LP_API_URL');
       nock(lp_api_url)
         .get('/devel/+snaps')
         .query({
           'ws.op': 'findByURL',
-          url: 'https://github.com/anaccount/arepo'
+          url: 'https://github.com/anowner/aname'
         })
         .reply(200, {
           total_size: 0,
@@ -79,7 +79,7 @@ describe('completeSnapAuthorization', () => {
 
     it('returns a "snap-not-found" error', () => {
       return completeSnapAuthorization(
-          session, 'https://github.com/anaccount/arepo', 'dummy-discharge')
+          session, 'https://github.com/anowner/aname', 'dummy-discharge')
         .then(() => expect('unexpected success').toNotExist())
         .catch((error) => expect(error).toMatch({
           status: 404,
@@ -91,7 +91,7 @@ describe('completeSnapAuthorization', () => {
   context('when user has no admin permissions on GitHub repository', () => {
     beforeEach(() => {
       nock(conf.get('GITHUB_API_ENDPOINT'))
-        .get('/repos/anaccount/arepo')
+        .get('/repos/anowner/aname')
         .reply(200, { permissions: { admin: false } });
     });
 
@@ -101,7 +101,7 @@ describe('completeSnapAuthorization', () => {
 
     it('returns a "github-no-admin-permissions" error', () => {
       return completeSnapAuthorization(
-          session, 'https://github.com/anaccount/arepo', 'dummy-discharge')
+          session, 'https://github.com/anowner/aname', 'dummy-discharge')
         .then(() => expect('unexpected success').toNotExist())
         .catch((error) => expect(error).toMatch({
           status: 401,

--- a/test/unit/src/server/handlers/t_login.js
+++ b/test/unit/src/server/handlers/t_login.js
@@ -87,7 +87,7 @@ describe('processVerifiedAssertion', () => {
 
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: true } });
         const lp_api_url = conf.get('LP_API_URL');
         const lp_api_base = `${lp_api_url}/devel`;
@@ -95,7 +95,7 @@ describe('processVerifiedAssertion', () => {
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURL',
-            url: 'https://github.com/anaccount/arepo'
+            url: 'https://github.com/anowner/aname'
           })
           .reply(200, {
             total_size: 1,
@@ -125,7 +125,7 @@ describe('processVerifiedAssertion', () => {
       it('completes the authorization', () => {
         const req = {
           session,
-          query: { repository_url: 'https://github.com/anaccount/arepo' }
+          query: { repository_url: 'https://github.com/anowner/aname' }
         };
         const result = { authenticated: true, discharge: 'dummy-discharge' };
         return processVerifiedAssertion(req, res, next, null, result)
@@ -135,7 +135,7 @@ describe('processVerifiedAssertion', () => {
       it('redirects', () => {
         const req = {
           session,
-          query: { repository_url: 'https://github.com/anaccount/arepo' }
+          query: { repository_url: 'https://github.com/anowner/aname' }
         };
         const result = { authenticated: true, discharge: 'dummy-discharge' };
         return processVerifiedAssertion(req, res, next, null, result)
@@ -146,7 +146,7 @@ describe('processVerifiedAssertion', () => {
     context('when completing authorization throws an error', () => {
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anaccount/arepo')
+          .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: false } });
       });
 
@@ -157,7 +157,7 @@ describe('processVerifiedAssertion', () => {
       it('passes through error', () => {
         const req = {
           session,
-          query: { repository_url: 'https://github.com/anaccount/arepo' }
+          query: { repository_url: 'https://github.com/anowner/aname' }
         };
         const result = { authenticated: true, discharge: 'dummy-discharge' };
         return processVerifiedAssertion(req, res, next, null, result)


### PR DESCRIPTION
More consistent naming of GH repo related values.

Currently for example repository `canonical-ols/build.snapcraft.io` we have:

```js
{
  owner: 'canonical-ols',
  name: 'build.snapcraft.io',
  fullName 'canonical-ols/build.snapcraft.io',
  url: 'https://github.com/canonical-ols/buildsnapcraft.io'
}
```

This PR is mostly a lot of renaming. Some other points of interest where commented separately inline (see comments below).