### PR TITLE
58: Refactor configuration

### DIFF
--- a/mocks/service/index.js
+++ b/mocks/service/index.js
@@ -1,3 +1,4 @@
 require('babel-polyfill');
 require('babel-register');
+require('babel-polyfill');
 require('./server');

--- a/mocks/service/index.js
+++ b/mocks/service/index.js
@@ -1,4 +1,3 @@
 require('babel-polyfill');
 require('babel-register');
-require('babel-polyfill');
 require('./server');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -29,9 +29,6 @@
     "assert-plus": {
       "version": "0.2.0"
     },
-    "async": {
-      "version": "1.5.2"
-    },
     "asynckit": {
       "version": "0.4.0"
     },
@@ -79,7 +76,8 @@
       "version": "1.3.3"
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "optional": true
     },
     "big.js": {
       "version": "3.1.3"
@@ -95,11 +93,14 @@
     "boom": {
       "version": "2.10.1"
     },
+    "builtin-modules": {
+      "version": "1.1.1"
+    },
     "bytes": {
       "version": "2.4.0"
     },
     "camelcase": {
-      "version": "2.1.1"
+      "version": "3.0.0"
     },
     "camelize": {
       "version": "1.0.0"
@@ -223,7 +224,8 @@
       "version": "2.0.0"
     },
     "ecc-jsbn": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1"
@@ -236,6 +238,9 @@
     },
     "encoding": {
       "version": "0.1.12"
+    },
+    "error-ex": {
+      "version": "1.3.0"
     },
     "error-stack-parser": {
       "version": "1.3.6"
@@ -301,6 +306,9 @@
     "finalhandler": {
       "version": "0.5.0"
     },
+    "find-up": {
+      "version": "1.1.2"
+    },
     "forever-agent": {
       "version": "0.6.1"
     },
@@ -322,6 +330,9 @@
     "generic-names": {
       "version": "1.0.2"
     },
+    "get-caller-file": {
+      "version": "1.0.2"
+    },
     "getpass": {
       "version": "0.1.6",
       "dependencies": {
@@ -338,6 +349,9 @@
     },
     "globals": {
       "version": "9.14.0"
+    },
+    "graceful-fs": {
+      "version": "4.1.11"
     },
     "graceful-readlink": {
       "version": "1.0.1"
@@ -378,6 +392,9 @@
     "hoist-non-react-statics": {
       "version": "1.2.0"
     },
+    "hosted-git-info": {
+      "version": "2.1.5"
+    },
     "hpkp": {
       "version": "2.0.0"
     },
@@ -402,14 +419,14 @@
     "images-require-hook": {
       "version": "1.0.3"
     },
+    "immutable": {
+      "version": "3.8.1"
+    },
     "in-publish": {
       "version": "2.0.0"
     },
     "inherits": {
       "version": "2.0.3"
-    },
-    "ini": {
-      "version": "1.3.4"
     },
     "invariant": {
       "version": "2.2.2"
@@ -419,6 +436,12 @@
     },
     "ipaddr.js": {
       "version": "1.1.1"
+    },
+    "is-arrayish": {
+      "version": "0.2.1"
+    },
+    "is-builtin-module": {
+      "version": "1.0.0"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0"
@@ -435,6 +458,9 @@
     "is-typedarray": {
       "version": "1.0.0"
     },
+    "is-utf8": {
+      "version": "0.2.1"
+    },
     "isomorphic-fetch": {
       "version": "2.2.1"
     },
@@ -445,7 +471,8 @@
       "version": "0.0.6"
     },
     "jodid25519": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "optional": true
     },
     "js-base64": {
       "version": "2.1.9"
@@ -457,7 +484,8 @@
       "version": "3.7.0"
     },
     "jsbn": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "optional": true
     },
     "jsesc": {
       "version": "0.5.0"
@@ -479,6 +507,14 @@
     },
     "lcid": {
       "version": "1.0.0"
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0"
+        }
+      }
     },
     "loader-utils": {
       "version": "0.2.16"
@@ -555,12 +591,6 @@
     "ms": {
       "version": "0.7.1"
     },
-    "nconf": {
-      "version": "0.8.4"
-    },
-    "nconf-yaml": {
-      "version": "1.0.2"
-    },
     "negotiator": {
       "version": "0.6.1"
     },
@@ -569,6 +599,9 @@
     },
     "node-fetch": {
       "version": "1.6.3"
+    },
+    "normalize-package-data": {
+      "version": "2.3.5"
     },
     "normalize.css": {
       "version": "5.0.0"
@@ -600,11 +633,23 @@
     "parse-github-url": {
       "version": "0.3.2"
     },
+    "parse-json": {
+      "version": "2.2.0"
+    },
     "parseurl": {
       "version": "1.3.1"
     },
+    "path-exists": {
+      "version": "2.1.0"
+    },
     "path-to-regexp": {
       "version": "0.1.7"
+    },
+    "path-type": {
+      "version": "1.1.0"
+    },
+    "pify": {
+      "version": "2.3.0"
     },
     "pinkie": {
       "version": "2.0.4"
@@ -709,6 +754,12 @@
         }
       }
     },
+    "read-pkg": {
+      "version": "1.1.0"
+    },
+    "read-pkg-up": {
+      "version": "1.0.1"
+    },
     "redbox-react": {
       "version": "1.3.3"
     },
@@ -744,20 +795,29 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1"
+    },
+    "require-main-filename": {
+      "version": "1.0.1"
+    },
     "retry": {
       "version": "0.6.0"
     },
-    "secure-keys": {
-      "version": "1.0.0"
-    },
     "seekout": {
       "version": "1.0.2"
+    },
+    "semver": {
+      "version": "5.3.0"
     },
     "send": {
       "version": "0.14.1"
     },
     "serve-static": {
       "version": "1.11.1"
+    },
+    "set-blocking": {
+      "version": "2.0.0"
     },
     "setprototypeof": {
       "version": "1.0.2"
@@ -773,6 +833,15 @@
     },
     "source-map": {
       "version": "0.4.4"
+    },
+    "spdx-correct": {
+      "version": "1.0.2"
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4"
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2"
     },
     "sprintf-js": {
       "version": "1.0.3"
@@ -822,7 +891,8 @@
       "version": "0.4.3"
     },
     "tweetnacl": {
-      "version": "0.14.3"
+      "version": "0.14.3",
+      "optional": true
     },
     "type-is": {
       "version": "1.6.14"
@@ -842,6 +912,9 @@
     "uuid": {
       "version": "3.0.0"
     },
+    "validate-npm-package-license": {
+      "version": "3.0.1"
+    },
     "vary": {
       "version": "1.1.0"
     },
@@ -854,8 +927,11 @@
     "whatwg-fetch": {
       "version": "2.0.1"
     },
+    "which-module": {
+      "version": "1.0.0"
+    },
     "window-size": {
-      "version": "0.1.4"
+      "version": "0.2.0"
     },
     "winston": {
       "version": "2.3.0",
@@ -881,7 +957,10 @@
       "version": "3.2.1"
     },
     "yargs": {
-      "version": "3.32.0"
+      "version": "6.4.0"
+    },
+    "yargs-parser": {
+      "version": "4.2.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,12 +41,11 @@
     "express-winston": "^2.0.0",
     "helmet": "^3.1.0",
     "images-require-hook": "^1.0.3",
+    "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.7.0",
     "memcached": "^2.2.2",
     "moment": "^2.17.1",
-    "nconf": "^0.8.4",
-    "nconf-yaml": "^1.0.2",
     "normalize.css": "^5.0.0",
     "oauth": "^0.9.14",
     "openid": "^2.0.6",
@@ -64,7 +63,8 @@
     "redux-thunk": "^2.1.0",
     "request": "^2.79.0",
     "winston": "^2.3.0",
-    "winston-daily-rotate-file": "^1.4.2"
+    "winston-daily-rotate-file": "^1.4.2",
+    "yargs": "^6.4.0"
   },
   "devDependencies": {
     "assets-webpack-plugin": "^3.5.0",

--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 
-import conf from '../helpers/config';
+import { conf } from '../helpers/config';
 import { parseGitHubRepoUrl } from '../helpers/github-url';
 
 const BASE_URL = conf.get('BASE_URL');

--- a/src/common/actions/repositories.js
+++ b/src/common/actions/repositories.js
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 
-import conf from '../helpers/config';
+import { conf } from '../helpers/config';
 
 const BASE_URL = conf.get('BASE_URL');
 

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 
-import conf from '../helpers/config';
+import { conf } from '../helpers/config';
 
 const BASE_URL = conf.get('BASE_URL');
 

--- a/src/common/helpers/config.js
+++ b/src/common/helpers/config.js
@@ -1,40 +1,12 @@
-export class Config {
-  constructor(config) {
-    // https://github.com/purposeindustries/window-or-global/blob/master/lib/index.js
-    // Establish the root object, `window` in the browser, or `global` on the server.
-    let root = typeof self == 'object' && self.Object == Object && self;
-    // root is window, we expect it to have config
-    if (root && !root.__CONFIG__) {
-      throw new ReferenceError('Client config: no config defined.');
-    }
-    // root is not window; test for node global and assign to avoid ref error
-    // we don't expect config here, this is client side only, but we can set it
-    // for unit tests
-    root = root || (typeof global == 'object' && global.Object == Object && global);
+import { Map } from 'immutable';
 
-    this._store = config || root.__CONFIG__;
-  }
+export const conf = Map(getGlobal().__CONFIG__);
 
-  get(key) {
-    let target = this._store;
-    const path = this._path(key);
-
-    while (path.length > 0) {
-      key = path.shift();
-
-      if (target && target.hasOwnProperty(key)) {
-        target = target[key];
-        continue;
-      }
-      return undefined;
-    }
-
-    return target;
-  }
-
-  _path(key) {
-    return (key == null) ? [] : key.split(':');
-  }
+function getGlobal() {
+  // window-or-global helper:
+  // returns global in Node.JS, returns window in browser
+  // https://github.com/purposeindustries/window-or-global/blob/master/lib/index.js
+  return (typeof self === 'object' && self.self === self && self) ||
+    (typeof global === 'object' && global.global === global && global) ||
+    this;
 }
-
-export default new Config();

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -1,0 +1,19 @@
+export default {
+  HOST: '0.0.0.0',
+  PORT: '8000',
+  BASE_URL: 'http://localhost:8000',
+  WEBPACK_DEV_URL: 'http://localhost:8001',
+  NODE_ENV: 'development',
+  UBUNTU_SSO_URL: 'https://login.ubuntu.com',
+  OPENID_VERIFY_URL: 'http://localhost:8000/login/verify',
+  LP_API_URL: 'https://api.launchpad.net',
+  STORE_API_URL: 'https://myapps.developer.ubuntu.com/dev/api',
+  STORE_DEVPORTAL_URL: 'https://myapps.developer.ubuntu.com/dev',
+  GITHUB_API_ENDPOINT: 'http://localhost:4000/github',
+  GITHUB_AUTH_LOGIN_URL: 'http://localhost:4000/github/login/oauth/authorize',
+  GITHUB_AUTH_VERIFY_URL: 'http://localhost:4000/github/login/oauth/access_token',
+  GITHUB_AUTH_REDIRECT_URL: 'http://localhost:8000/auth/verify',
+  GITHUB_AUTH_CLIENT_ID: '389a7b4c2ade662c0bf4',
+  GITHUB_AUTH_CLIENT_SECRET: 'ea482b47a4830d38a838f48be43ab28002c33187',
+  GITHUB_WEBHOOK_SECRET: 'dummy-webhook-secret'
+};

--- a/src/server/dev-server.js
+++ b/src/server/dev-server.js
@@ -2,7 +2,7 @@ require('css-modules-require-hook/preset');
 const clearRequireCache = require('./helpers/hot-load').clearRequireCache;
 const chokidar = require('chokidar');
 
-const conf = require('./helpers/config').conf;
+const { conf } = require('./helpers/config');
 const WEBPACK_DEV_URL = conf.get('WEBPACK_DEV_URL') || '';
 require('images-require-hook')('.svg', `${WEBPACK_DEV_URL}/static/icons`);
 

--- a/src/server/handlers/login.js
+++ b/src/server/handlers/login.js
@@ -61,6 +61,7 @@ export const processVerifiedAssertion = (req, res, next, error, result) => {
       (!result.teams || !result.teams.some(team => {
         return OPENID_TEAMS.indexOf(team) != -1;
       }))) {
+
     return next(new Error(`${constants.E_UNAUTHORIZED}`));
   }
 

--- a/src/server/handlers/universal.js
+++ b/src/server/handlers/universal.js
@@ -3,12 +3,11 @@ import { match, RouterContext } from 'react-router';
 import { renderToString } from 'react-dom/server';
 
 import Html from '../helpers/html';
-import { conf, getClientConfig } from '../helpers/config';
+import { getClientConfig, conf } from '../helpers/config';
 import configureStore from '../../common/store/configureStore';
+import assets from '../../../webpack-assets.json';
 
 let routes = require('../../common/routes').default;
-
-import assets from '../../../webpack-assets.json';
 
 export const universal = (req, res, next) => {
   if (process.env.NODE_ENV === 'development') {
@@ -55,25 +54,23 @@ export const handleMatch = (req, res, error, redirectLocation, renderProps) => {
 
     const store = configureStore(initialState);
 
-   /**
-    * IMPORTANT:
-    * Config data MUST pass through getClientConfig
-    * whitelist in order to be exposed to the client side
-    */
-    const config = getClientConfig();
-
     // You can also check renderProps.components or renderProps.routes for
     // your "not found" component or route respectively, and send a 404 as
     // below, if you're using a catch-all route.
     const component = <RouterContext {...renderProps} />;
 
+    /**
+     * IMPORTANT:
+     * Config data MUST pass through getClientConfig
+     * whitelist in order to be exposed to the client side
+     */
     res.status(200);
     res.send('<!doctype html>\n' +
       renderToString(
         <Html
           store={ store }
           component={ component }
-          config={ config }
+          config={ getClientConfig(conf) }
           assets={ assets }
         />
       ));

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,4 +1,6 @@
 import expect from 'expect';
+import proxyquire from 'proxyquire';
+import { Map } from 'immutable';
 
 // Custom assertions
 expect.extend({
@@ -14,3 +16,12 @@ expect.extend({
     return this;
   }
 });
+
+export function requireWithMockConfigHelper(requirePath, modulePath, stub) {
+  return proxyquire(requirePath, {
+    [modulePath]: {
+      conf: Map(stub),
+      '@noCallThru': true
+    }
+  });
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,6 +7,6 @@ require.extensions['.png'] = () => 'example.png';
 require.extensions['.gif'] = () => 'example.gif';
 require.extensions['.jpg', '.jpeg'] = () => 'example.jpg';
 
-import { getClientConfig } from '../src/server/helpers/config';
+import { conf, getClientConfig } from '../src/server/helpers/config';
 
-global.__CONFIG__ = getClientConfig();
+global.__CONFIG__ = getClientConfig(conf);

--- a/test/unit/src/common/actions/t_create-snap.js
+++ b/test/unit/src/common/actions/t_create-snap.js
@@ -11,7 +11,7 @@ import {
   setGitHubRepository
 } from '../../../../../src/common/actions/create-snap';
 import * as ActionTypes from '../../../../../src/common/actions/create-snap';
-import conf from '../../../../../src/common/helpers/config';
+import { conf } from '../../../../../src/common/helpers/config';
 
 const middlewares = [ thunk ];
 const mockStore = configureMockStore(middlewares);

--- a/test/unit/src/server/handlers/t_login.js
+++ b/test/unit/src/server/handlers/t_login.js
@@ -1,9 +1,15 @@
 import expect from 'expect';
 import nock from 'nock';
+import { Map } from 'immutable';
+import proxyquire from 'proxyquire';
 
 import constants from '../../../../../src/server/constants';
-import { processVerifiedAssertion } from '../../../../../src/server/handlers/login';
-import { conf } from '../../../../../src/server/helpers/config.js';
+
+const UBUNTU_SSO_URL = 'https://login.ubuntu.com';
+const OPENID_VERIFY_URL = 'http://localhost:8000/login/verify';
+const OPENID_TEAMS = ['team-name'];
+const GITHUB_API_ENDPOINT = 'http://localhost:4000/github';
+const LP_API_URL = 'http://localhost:4000/launchpad';
 
 describe('processVerifiedAssertion', () => {
   const res = {
@@ -23,31 +29,19 @@ describe('processVerifiedAssertion', () => {
     processedError = null;
   });
 
-  it('passes through verification errors', () => {
-    const error = new Error('test');
-    processVerifiedAssertion({}, res, next, error);
-    expect(processedError).toBe(error);
-  });
+  context('when OPENID_TEAMS are configured', () => {
+    let processVerifiedAssertion;
 
-  it('produces E_SSO_FAIL error if not authenticated', () => {
-    processVerifiedAssertion({}, res, next, null, { 'authenticated': false });
-    expect(processedError.message).toBe(constants.E_SSO_FAIL);
-  });
-
-  it('produces E_NO_SESSION error if the request has no session', () => {
-    processVerifiedAssertion({}, res, next, null, { 'authenticated': true });
-    expect(processedError.message).toBe(constants.E_NO_SESSION);
-  });
-
-  context('with OPENID_TEAMS', () => {
-    before(() => {
-      const overrides = conf.stores['test-overrides'];
-      overrides.set('OPENID_TEAMS', ['team-name']);
-    });
-
-    after(() => {
-      const overrides = conf.stores['test-overrides'];
-      overrides.clear('OPENID_TEAMS');
+    beforeEach(() => {
+      processVerifiedAssertion = proxyquire(
+        '../../../../../src/server/handlers/login',
+        {
+          '../helpers/config': {
+            conf: Map({ UBUNTU_SSO_URL, OPENID_VERIFY_URL, OPENID_TEAMS, GITHUB_API_ENDPOINT }),
+            '@noCallThru': true
+          }
+        }
+      ).processVerifiedAssertion;
     });
 
     it('produces E_UNAUTHORIZED error if not in any of required teams', () => {
@@ -65,104 +59,135 @@ describe('processVerifiedAssertion', () => {
     });
   });
 
-  it('redirects to / if starting_url is not given', () => {
-    const req = { session: {}, query: {} };
-    const result = { authenticated: true };
-    return processVerifiedAssertion(req, res, next, null, result)
-      .then(() => expect(res.redirectedUrl).toBe('/'));
-  });
+  context('when no OPENID_TEAMS are configured', () => {
+    let processVerifiedAssertion;
 
-  it('redirects to starting_url if given', () => {
-    const req = { session: {}, query: { starting_url: '/success' } };
-    const result = { authenticated: true };
-    return processVerifiedAssertion(req, res, next, null, result)
-      .then(() => expect(res.redirectedUrl).toBe('/success'));
-  });
-
-  context('with discharge macaroon', () => {
-    const session = { 'token': 'secret' };
-
-    context('when snap exists', () => {
-      let completeAuthorizationScope;
-
-      beforeEach(() => {
-        nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anowner/aname')
-          .reply(200, { permissions: { admin: true } });
-        const lp_api_url = conf.get('LP_API_URL');
-        const lp_api_base = `${lp_api_url}/devel`;
-        nock(lp_api_url)
-          .get('/devel/+snaps')
-          .query({
-            'ws.op': 'findByURL',
-            url: 'https://github.com/anowner/aname'
-          })
-          .reply(200, {
-            total_size: 1,
-            start: 0,
-            entries: [
-              {
-                resource_type_link: `${lp_api_base}/#snap`,
-                self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
-                owner_link: `${lp_api_base}/~test-user`
-              }
-            ]
-          });
-        completeAuthorizationScope = nock(lp_api_url)
-          .post('/devel/~test-user/+snap/test-snap', {
-            'ws.op': 'completeAuthorization',
-            'discharge_macaroon': 'dummy-discharge'
-          })
-          .reply(200, 'null', {
-            'Content-Type': 'application/json'
-          });
-      });
-
-      afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('completes the authorization', () => {
-        const req = {
-          session,
-          query: { repository_url: 'https://github.com/anowner/aname' }
-        };
-        const result = { authenticated: true, discharge: 'dummy-discharge' };
-        return processVerifiedAssertion(req, res, next, null, result)
-          .then(() => completeAuthorizationScope.done());
-      });
-
-      it('redirects', () => {
-        const req = {
-          session,
-          query: { repository_url: 'https://github.com/anowner/aname' }
-        };
-        const result = { authenticated: true, discharge: 'dummy-discharge' };
-        return processVerifiedAssertion(req, res, next, null, result)
-          .then(() => expect(res.redirectedUrl).toBe('/'));
-      });
+    beforeEach(() => {
+      processVerifiedAssertion = proxyquire(
+        '../../../../../src/server/handlers/login',
+        {
+          '../helpers/config': {
+            conf: Map({ UBUNTU_SSO_URL, OPENID_VERIFY_URL, GITHUB_API_ENDPOINT }),
+            '@noCallThru': true
+          }
+        }
+      ).processVerifiedAssertion;
     });
 
-    context('when completing authorization throws an error', () => {
-      beforeEach(() => {
-        nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anowner/aname')
-          .reply(200, { permissions: { admin: false } });
+    it('passes through verification errors', () => {
+      const error = new Error('test');
+      processVerifiedAssertion({}, res, next, error);
+      expect(processedError).toBe(error);
+    });
+
+    it('produces E_SSO_FAIL error if not authenticated', () => {
+      processVerifiedAssertion({}, res, next, null, { 'authenticated': false });
+      expect(processedError.message).toBe(constants.E_SSO_FAIL);
+    });
+
+    it('produces E_NO_SESSION error if the request has no session', () => {
+      processVerifiedAssertion({}, res, next, null, { 'authenticated': true });
+      expect(processedError.message).toBe(constants.E_NO_SESSION);
+    });
+
+    it('redirects to / if starting_url is not given', () => {
+      const req = { session: {}, query: {} };
+      const result = { authenticated: true };
+      return processVerifiedAssertion(req, res, next, null, result)
+        .then(() => expect(res.redirectedUrl).toBe('/'));
+    });
+
+    it('redirects to starting_url if given', () => {
+      const req = { session: {}, query: { starting_url: '/success' } };
+      const result = { authenticated: true };
+      return processVerifiedAssertion(req, res, next, null, result)
+        .then(() => expect(res.redirectedUrl).toBe('/success'));
+    });
+
+    context('with discharge macaroon', () => {
+      const session = { 'token': 'secret' };
+
+      context('when snap exists', () => {
+        let completeAuthorizationScope;
+
+        beforeEach(() => {
+          nock(GITHUB_API_ENDPOINT)
+            .get('/repos/anowner/aname')
+            .reply(200, { permissions: { admin: true } });
+          const lp_api_base = `${LP_API_URL}/devel`;
+          nock(LP_API_URL)
+            .get('/devel/+snaps')
+            .query({
+              'ws.op': 'findByURL',
+              url: 'https://github.com/anowner/aname'
+            })
+            .reply(200, {
+              total_size: 1,
+              start: 0,
+              entries: [
+                {
+                  resource_type_link: `${lp_api_base}/#snap`,
+                  self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
+                  owner_link: `${lp_api_base}/~test-user`
+                }
+              ]
+            });
+          completeAuthorizationScope = nock(LP_API_URL)
+            .post('/devel/~test-user/+snap/test-snap', {
+              'ws.op': 'completeAuthorization',
+              'discharge_macaroon': 'dummy-discharge'
+            })
+            .reply(200, 'null', {
+              'Content-Type': 'application/json'
+            });
+        });
+
+        afterEach(() => {
+          nock.cleanAll();
+        });
+
+        it('completes the authorization', () => {
+          const req = {
+            session,
+            query: { repository_url: 'https://github.com/anowner/aname' }
+          };
+          const result = { authenticated: true, discharge: 'dummy-discharge' };
+          return processVerifiedAssertion(req, res, next, null, result)
+            .then(() => completeAuthorizationScope.done());
+        });
+
+        it('redirects', () => {
+          const req = {
+            session,
+            query: { repository_url: 'https://github.com/anowner/aname' }
+          };
+          const result = { authenticated: true, discharge: 'dummy-discharge' };
+          return processVerifiedAssertion(req, res, next, null, result)
+            .then(() => expect(res.redirectedUrl).toBe('/'));
+        });
       });
 
-      afterEach(() => {
-        nock.cleanAll();
-      });
+      context('when completing authorization throws an error', () => {
+        beforeEach(() => {
+          nock(GITHUB_API_ENDPOINT)
+            .get('/repos/anowner/aname')
+            .reply(200, { permissions: { admin: false } });
+        });
 
-      it('passes through error', () => {
-        const req = {
-          session,
-          query: { repository_url: 'https://github.com/anowner/aname' }
-        };
-        const result = { authenticated: true, discharge: 'dummy-discharge' };
-        return processVerifiedAssertion(req, res, next, null, result)
-          .then(() => expect(processedError.message).toBe(
-            'You do not have admin permissions for this GitHub repository'));
+        afterEach(() => {
+          nock.cleanAll();
+        });
+
+        it('passes through error', () => {
+          const req = {
+            session,
+            query: { repository_url: 'https://github.com/anowner/aname' }
+          };
+          const result = { authenticated: true, discharge: 'dummy-discharge' };
+          return processVerifiedAssertion(req, res, next, null, result)
+            .then(() => expect(processedError.message).toBe(
+              'You do not have admin permissions for this GitHub repository'));
+        });
       });
     });
   });

--- a/test/unit/src/server/handlers/t_login.js
+++ b/test/unit/src/server/handlers/t_login.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import nock from 'nock';
-import { Map } from 'immutable';
-import proxyquire from 'proxyquire';
+import { requireWithMockConfigHelper } from '../../../../helpers';
+import path from 'path';
 
 import constants from '../../../../../src/server/constants';
 
@@ -10,6 +10,11 @@ const OPENID_VERIFY_URL = 'http://localhost:8000/login/verify';
 const OPENID_TEAMS = ['team-name'];
 const GITHUB_API_ENDPOINT = 'http://localhost:4000/github';
 const LP_API_URL = 'http://localhost:4000/launchpad';
+const requireWithMockConfig = requireWithMockConfigHelper.bind(
+  null,
+  path.resolve(__dirname, '../../../../../src/server/handlers/login'),
+  '../helpers/config'
+);
 
 describe('processVerifiedAssertion', () => {
   const res = {
@@ -33,15 +38,12 @@ describe('processVerifiedAssertion', () => {
     let processVerifiedAssertion;
 
     beforeEach(() => {
-      processVerifiedAssertion = proxyquire(
-        '../../../../../src/server/handlers/login',
-        {
-          '../helpers/config': {
-            conf: Map({ UBUNTU_SSO_URL, OPENID_VERIFY_URL, OPENID_TEAMS, GITHUB_API_ENDPOINT }),
-            '@noCallThru': true
-          }
-        }
-      ).processVerifiedAssertion;
+      ({ processVerifiedAssertion } = requireWithMockConfig({
+        UBUNTU_SSO_URL,
+        OPENID_VERIFY_URL,
+        OPENID_TEAMS,
+        GITHUB_API_ENDPOINT
+      }));
     });
 
     it('produces E_UNAUTHORIZED error if not in any of required teams', () => {
@@ -63,15 +65,11 @@ describe('processVerifiedAssertion', () => {
     let processVerifiedAssertion;
 
     beforeEach(() => {
-      processVerifiedAssertion = proxyquire(
-        '../../../../../src/server/handlers/login',
-        {
-          '../helpers/config': {
-            conf: Map({ UBUNTU_SSO_URL, OPENID_VERIFY_URL, GITHUB_API_ENDPOINT }),
-            '@noCallThru': true
-          }
-        }
-      ).processVerifiedAssertion;
+      ({ processVerifiedAssertion } = requireWithMockConfig({
+        UBUNTU_SSO_URL,
+        OPENID_VERIFY_URL,
+        GITHUB_API_ENDPOINT
+      }));
     });
 
     it('passes through verification errors', () => {

--- a/test/unit/src/server/handlers/t_login.js
+++ b/test/unit/src/server/handlers/t_login.js
@@ -1,8 +1,8 @@
 import expect from 'expect';
 import nock from 'nock';
-import { requireWithMockConfigHelper } from '../../../../helpers';
 import path from 'path';
 
+import { requireWithMockConfigHelper } from '../../../../helpers';
 import constants from '../../../../../src/server/constants';
 
 const UBUNTU_SSO_URL = 'https://login.ubuntu.com';

--- a/test/unit/src/server/helpers/t_config.js
+++ b/test/unit/src/server/helpers/t_config.js
@@ -1,0 +1,114 @@
+import expect from 'expect';
+import proxyquire from 'proxyquire';
+import { Map } from 'immutable';
+
+import { getClientConfig } from '../../../../../src/server/helpers/config';
+
+const pq = proxyquire.bind(null, '../../../../../src/server/helpers/config');
+
+describe('The config helper conf.get method', () => {
+  context('when EXAMPLE_CONFIG_KEY is "http://defaults.com" in the defaults file', () => {
+    let mocks = {};
+
+    beforeEach(() => {
+      mocks['../../config/defaults'] = {
+        default: {
+          EXAMPLE_CONFIG_KEY: 'http://defaults.com'
+        },
+        '@noCallThru': true
+      };
+    });
+
+    it('should return "http://defaults.com"', () => {
+      expect(pq(mocks).conf.get('EXAMPLE_CONFIG_KEY')).toEqual('http://defaults.com');
+    });
+
+    context('and EXAMPLE_CONFIG_KEY is "http://process.env.com" in process.env', () => {
+      beforeEach(() => {
+        process.env.EXAMPLE_CONFIG_KEY = 'http://process.env.com';
+      });
+
+      afterEach(() => {
+        process.env.EXAMPLE_CONFIG_KEY = undefined;
+      });
+
+      it('should return "http://process.env.com"', () => {
+        expect(pq(mocks).conf.get('EXAMPLE_CONFIG_KEY')).toEqual('http://process.env.com');
+      });
+    });
+  });
+
+  context('when EXAMPLE_CONFIG_KEY is "http://process.env.com" in process.env', () => {
+    beforeEach(() => {
+      process.env.EXAMPLE_CONFIG_KEY = 'http://process.env.com';
+    });
+
+    afterEach(() => {
+      process.env.EXAMPLE_CONFIG_KEY = undefined;
+    });
+
+    it('should reuturn "http://process.env.com"', () => {
+      expect(pq({}).conf.get('EXAMPLE_CONFIG_KEY')).toEqual('http://process.env.com');
+    });
+
+    context('and EXAMPLE_CONFIG_KEY is "http://argv.com" in argv', () => {
+      let mocks = {};
+
+      beforeEach(() => {
+        mocks['yargs'] = {
+          argv: {
+            EXAMPLE_CONFIG_KEY: 'http://argv.com'
+          },
+          '@noCallThru': true
+        };
+      });
+
+      it('should reuturn "http://argv.com"', () => {
+        expect(pq(mocks).conf.get('EXAMPLE_CONFIG_KEY')).toEqual('http://argv.com');
+      });
+    });
+  });
+
+  context('when EXAMPLE_CONFIG_KEY is "http://argv.com" in argv', () => {
+    let mocks = {};
+
+    beforeEach(() => {
+      mocks['yargs'] = {
+        argv: {
+          EXAMPLE_CONFIG_KEY: 'http://argv.com'
+        },
+        '@noCallThru': true
+      };
+    });
+
+    it('should reuturn "http://argv.com"', () => {
+      expect(pq(mocks).conf.get('EXAMPLE_CONFIG_KEY')).toEqual('http://argv.com');
+    });
+  });
+});
+
+describe('The getClientConfig helper', () => {
+  context('when passed "BASE_URL"', () => {
+    let conf;
+
+    beforeEach(() => {
+      conf = getClientConfig(Map({ BASE_URL: 'http://blah.com' }));
+    });
+
+    it('should not filter "BASE_URL"', () => {
+      expect(conf.BASE_URL).toEqual('http://blah.com');
+    });
+  });
+
+  context('when passed "NON_WHITELISTED_KEY"', () => {
+    let conf;
+
+    beforeEach(() => {
+      conf = getClientConfig(Map({ NON_WHITELISTED_KEY: 'http://blah.com' }));
+    });
+
+    it('should filter "NON_WHITELISTED_KEY"', () => {
+      expect(conf.NON_WHITELISTED_KEY).toEqual(undefined);
+    });
+  });
+});

--- a/test/unit/src/server/openid/t_relyingparty.js
+++ b/test/unit/src/server/openid/t_relyingparty.js
@@ -1,6 +1,8 @@
 import expect from 'expect';
+import proxyquire from 'proxyquire';
+import { Map } from 'immutable';
 import { conf } from '../../../../../src/server/helpers/config';
-import RelyingPartyFactory, {
+import {
   saveAssociation,
   loadAssociation,
   removeAssociation
@@ -13,6 +15,7 @@ describe('RelyingParty', () => {
   let rp;
 
   before(() => {
+    const RelyingPartyFactory = require('../../../../../src/server/openid/relyingparty').default;
     rp = RelyingPartyFactory({}, VERIFY_URL);
   });
 
@@ -37,12 +40,19 @@ describe('RelyingParty default extensions', () => {
   let rp;
 
   before(() => {
-    conf.stores['test-overrides'].set('OPENID_TEAMS', 'null');
-    rp = RelyingPartyFactory({}, VERIFY_URL);
-  });
+    const RelyingPartyFactory = proxyquire(
+      '../../../../../src/server/openid/relyingparty',
+      {
+        '../helpers/config': {
+          conf: Map({
+            OPENID_TEAMS: null
+          }),
+          '@noCallThru': true
+        }
+      }
+    ).default;
 
-  after(() => {
-    conf.stores['test-overrides'].clear('OPENID_TEAMS');
+    rp = RelyingPartyFactory({}, VERIFY_URL);
   });
 
   it('should not include teams extension if no teams set in config', () => {
@@ -56,12 +66,19 @@ describe('RelyingParty with teams extension', () => {
   let rp;
 
   before(() => {
-    conf.stores['test-overrides'].set('OPENID_TEAMS', '["test1", "test2"]');
-    rp = RelyingPartyFactory({}, VERIFY_URL);
-  });
+    const RelyingPartyFactory = proxyquire(
+      '../../../../../src/server/openid/relyingparty',
+      {
+        '../helpers/config': {
+          conf: Map({
+            OPENID_TEAMS: '["test1", "test2"]'
+          }),
+          '@noCallThru': true
+        }
+      }
+    ).default;
 
-  after(() => {
-    conf.stores['test-overrides'].clear('OPENID_TEAMS');
+    rp = RelyingPartyFactory({}, VERIFY_URL);
   });
 
   it('should add teams extension if teams set in config', () => {

--- a/test/unit/src/server/openid/t_relyingparty.js
+++ b/test/unit/src/server/openid/t_relyingparty.js
@@ -1,15 +1,21 @@
 import expect from 'expect';
-import proxyquire from 'proxyquire';
-import { Map } from 'immutable';
+import path from 'path';
+
 import { conf } from '../../../../../src/server/helpers/config';
 import {
   saveAssociation,
   loadAssociation,
   removeAssociation
 } from '../../../../../src/server/openid/relyingparty';
+import { requireWithMockConfigHelper } from '../../../../helpers';
 
 const VERIFY_URL = conf.get('OPENID_VERIFY_URL');
 const BASE_URL = conf.get('BASE_URL');
+const requireWithMockConfig = requireWithMockConfigHelper.bind(
+  null,
+  path.resolve(__dirname, '../../../../../src/server/openid/relyingparty'),
+  '../helpers/config'
+);
 
 describe('RelyingParty', () => {
   let rp;
@@ -40,18 +46,7 @@ describe('RelyingParty default extensions', () => {
   let rp;
 
   before(() => {
-    const RelyingPartyFactory = proxyquire(
-      '../../../../../src/server/openid/relyingparty',
-      {
-        '../helpers/config': {
-          conf: Map({
-            OPENID_TEAMS: null
-          }),
-          '@noCallThru': true
-        }
-      }
-    ).default;
-
+    const RelyingPartyFactory = requireWithMockConfig({ OPENID_TEAMS: null }).default;
     rp = RelyingPartyFactory({}, VERIFY_URL);
   });
 
@@ -66,17 +61,9 @@ describe('RelyingParty with teams extension', () => {
   let rp;
 
   before(() => {
-    const RelyingPartyFactory = proxyquire(
-      '../../../../../src/server/openid/relyingparty',
-      {
-        '../helpers/config': {
-          conf: Map({
-            OPENID_TEAMS: '["test1", "test2"]'
-          }),
-          '@noCallThru': true
-        }
-      }
-    ).default;
+    const RelyingPartyFactory = requireWithMockConfig({
+      OPENID_TEAMS: '["test1", "test2"]'
+    }).default;
 
     rp = RelyingPartyFactory({}, VERIFY_URL);
   });

--- a/webpack/build-config.js
+++ b/webpack/build-config.js
@@ -8,6 +8,7 @@ const autoprefixer = require('autoprefixer');
 
 const sharedVars = require('../src/common/style/variables');
 
+
 module.exports = {
   context: path.resolve(__dirname, '..'),
   entry: [
@@ -29,7 +30,9 @@ module.exports = {
     }),
     new AssetsPlugin(),
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production')
+      'process.env': {
+        'NODE_ENV': JSON.stringify('production')
+      }
     })
   ],
   module: {

--- a/webpack/build-config.js
+++ b/webpack/build-config.js
@@ -1,3 +1,4 @@
+require('babel-register');
 const path = require('path');
 const webpack = require('webpack');
 const AssetsPlugin = require('assets-webpack-plugin');
@@ -6,7 +7,6 @@ const vars = require('postcss-simple-vars');
 const autoprefixer = require('autoprefixer');
 
 const sharedVars = require('../src/common/style/variables');
-
 
 module.exports = {
   context: path.resolve(__dirname, '..'),
@@ -29,9 +29,7 @@ module.exports = {
     }),
     new AssetsPlugin(),
     new webpack.DefinePlugin({
-      'process.env': {
-        'NODE_ENV': JSON.stringify('production')
-      }
+      'process.env.NODE_ENV': JSON.stringify('production')
     })
   ],
   module: {

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -5,11 +5,9 @@ const webpack = require('webpack');
 const url = require('url');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware  = require('webpack-hot-middleware');
-
 const webpackConfig = require('./dev-config');
 const { conf } = require('../src/server/helpers/config');
 const logging = require('../src/server/logging').default;
-
 const logger = logging.getLogger('webpack');
 const webpackDevUrl = url.parse(conf.get('WEBPACK_DEV_URL'));
 const app = Express();


### PR DESCRIPTION
- nconf removed due to unavoidable dependency on the Node fs API
- Rewritten config helper exposing an immutable config object
- Added "baked in" config to JS bundle, using WebPack.DefinePlugin to
  replace process.env
- Added environment variables to Makefile
- Removed runtime config from HTML helper component