### PR TITLE
fix proptype validation for repo-row error message

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -34,7 +34,7 @@ const RepositoryRow = (props) => {
 };
 
 RepositoryRow.propTypes = {
-  errorMsg: PropTypes.string,
+  errorMsg: PropTypes.node,
   repository: PropTypes.shape({
     fullName: PropTypes.string
   }),


### PR DESCRIPTION
can be either a react element (name not registered case) or a string (every other case)