### PR TITLE
67: Repo pagination

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -115,7 +115,11 @@ To get a list of repositories for current user (user needs to be authorised to G
     Cookie: <session cookie>
     Accept: application/json
 
-On success, returns the following where the items in `repos` are GitHub repositories as returned by [GitHub API](https://developer.github.com/v3/repos/#list-your-repositories):
+    GET /api/github/repos/page/1
+    Cookie: <session cookie>
+    Accept: application/json
+
+On success, returns the following where the items in `repos` are GitHub repositories as returned by [GitHub API](https://developer.github.com/v3/repos/#list-your-repositories). Pagination parameter is optional. `pageLinks` for first, previous, next and last pages are supplied if results are paginated by the GitHub API. This happens when more than 30 repositories are returned.
 
     HTTP/1.1 200 OK
     Content-Type: application/json
@@ -135,5 +139,11 @@ On success, returns the following where the items in `repos` are GitHub reposito
             ...
           }
         ]
+      },
+      pageLinks: {
+        first: 1,
+        prev: 1,
+        next: 3,
+        last: 3
       }
     }

--- a/mocks/service/github/index.js
+++ b/mocks/service/github/index.js
@@ -24,7 +24,11 @@ router.get('/repos/:owner/:name/contents/snapcraft.yaml', (req, res) => {
 });
 
 router.get('/user/repos', (req, res) => {
-  res.status(200).send([
+  const headers = {
+    Link: ''
+  };
+
+  res.set(headers).status(200).send([
     {
       full_name: 'anowner/aname',
       name: 'aname',

--- a/src/common/actions/repositories.js
+++ b/src/common/actions/repositories.js
@@ -8,7 +8,7 @@ export const FETCH_REPOSITORIES = 'FETCH_REPOSITORIES';
 export const FETCH_REPOSITORIES_SUCCESS = 'FETCH_REPOSITORIES_SUCCESS';
 export const FETCH_REPOSITORIES_ERROR = 'FETCH_REPOSITORIES_ERROR';
 export const SET_REPOSITORIES = 'SET_REPOSITORIES';
-export const SET_PAGE_LINKS = 'SET_REPOSITORY_PAGE_LINKS';
+export const SET_REPOSITORY_PAGE_LINKS = 'SET_REPOSITORY_PAGE_LINKS';
 
 export function setRepositories(repos) {
   return {
@@ -89,7 +89,7 @@ export function fetchRepositoriesError(error) {
 
 export function setPageLinks(pageLinks) {
   return {
-    type: SET_PAGE_LINKS,
+    type: SET_REPOSITORY_PAGE_LINKS,
     payload: pageLinks
   };
 }

--- a/src/common/actions/repositories.js
+++ b/src/common/actions/repositories.js
@@ -5,8 +5,10 @@ import { conf } from '../helpers/config';
 const BASE_URL = conf.get('BASE_URL');
 
 export const FETCH_REPOSITORIES = 'FETCH_REPOSITORIES';
+export const FETCH_REPOSITORIES_SUCCESS = 'FETCH_REPOSITORIES_SUCCESS';
 export const FETCH_REPOSITORIES_ERROR = 'FETCH_REPOSITORIES_ERROR';
 export const SET_REPOSITORIES = 'SET_REPOSITORIES';
+export const SET_PAGE_LINKS = 'SET_REPOSITORY_PAGE_LINKS';
 
 export function setRepositories(repos) {
   return {
@@ -35,14 +37,21 @@ function checkStatus(response) {
   }
 }
 
-export function fetchUserRepositories() {
+export function fetchUserRepositories(pageNumber) {
   return (dispatch) => {
+    let urlParts = [BASE_URL, 'api/github/repos'];
+
+    if (pageNumber) {
+      urlParts.push('page/' + pageNumber);
+    }
 
     dispatch({
       type: FETCH_REPOSITORIES
     });
 
-    return fetch(`${BASE_URL}/api/github/repos`, {
+    dispatch(setRepositories([]));
+
+    return fetch(urlParts.join('/'), {
       headers: { 'Content-Type': 'application/json' },
       credentials: 'same-origin'
     })
@@ -53,9 +62,20 @@ export function fetchUserRepositories() {
             throw getError(response, result);
           }
           dispatch(setRepositories(result.payload.repos));
+          dispatch(fetchRepositoriesSuccess());
+
+          if (result.pageLinks) {
+            dispatch(setPageLinks(result.pageLinks));
+          }
         });
       })
       .catch(error => dispatch(fetchRepositoriesError(error)));
+  };
+}
+
+export function fetchRepositoriesSuccess() {
+  return {
+    type: FETCH_REPOSITORIES_SUCCESS
   };
 }
 
@@ -64,5 +84,12 @@ export function fetchRepositoriesError(error) {
     type: FETCH_REPOSITORIES_ERROR,
     payload: error,
     error: true
+  };
+}
+
+export function setPageLinks(pageLinks) {
+  return {
+    type: SET_PAGE_LINKS,
+    payload: pageLinks
   };
 }

--- a/src/common/components/page-links/index.js
+++ b/src/common/components/page-links/index.js
@@ -1,0 +1,63 @@
+import React, { Component, PropTypes } from 'react';
+
+import styles from './styles.css';
+
+const LINK_LABEL_OPTIONS = ['first', 'prev', 'next', 'last'];
+
+export default class PageLinks extends Component {
+
+  render() {
+    const renderLink = this.renderLink.bind(this);
+
+    let links = LINK_LABEL_OPTIONS.map((item) => {
+      return renderLink(
+        this.props[item],
+        item
+      );
+    });
+
+    return (
+      <ul className={ styles.container }>
+        { links }
+      </ul>
+    );
+  }
+
+  renderLink(item, label) {
+    let url;
+
+    if (typeof item == 'string') {
+      url = item;
+    }
+
+    if (typeof item == 'undefined') {
+      return (
+        <li key={ label } className={ styles.link }>
+          <div>
+            { label }
+          </div>
+        </li>
+      );
+    }
+
+    return (
+      <li key={ label } className={ styles.link }>
+        <a href={ url } onClick={ this.onClick.bind(this, item) }>
+          { label }
+        </a>
+      </li>
+    );
+  }
+
+  onClick(item) {
+    this.props.onClick(item);
+  }
+}
+
+PageLinks.propTypes = {
+  first: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  prev: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  next: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  last: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onClick: PropTypes.func
+};

--- a/src/common/components/page-links/index.js
+++ b/src/common/components/page-links/index.js
@@ -26,10 +26,16 @@ export default class PageLinks extends Component {
   renderLink(item, label) {
     let url;
 
+    // If item is a string, treat it as a URL and
+    // add it to the href attribute on the anchor.
+    // This will also be suppled to the onClick
+    // handler when a link is clicked.
     if (typeof item == 'string') {
       url = item;
     }
 
+    // If item is undefined, show only an unlinked
+    // label
     if (typeof item == 'undefined') {
       return (
         <li key={ label } className={ styles.link }>

--- a/src/common/components/page-links/styles.css
+++ b/src/common/components/page-links/styles.css
@@ -1,0 +1,26 @@
+.container {
+  display: inline-block;
+}
+
+.link {
+  display: inline-block;
+}
+
+.link::after {
+  content: "|";
+}
+
+.link:last-child::after {
+  content: "";
+}
+
+.link * {
+  display: inline-block;
+  margin: 0 3px;
+  padding: 0 3px;
+  text-transform: capitalize;
+}
+
+a {
+  cursor: pointer;
+}

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -5,9 +5,12 @@ import { conf } from '../../helpers/config';
 import { createSnap } from '../../actions/create-snap';
 import RepositoryRow from '../repository-row';
 import Spinner from '../spinner';
+import PageLinks from '../page-links';
+import { fetchUserRepositories } from '../../actions/repositories';
+import styles from './styles.css';
 
 // loading container styles not to duplicate .spinner class
-import styles from '../../containers/container.css';
+import { spinner as spinnerStyles } from '../../containers/container.css';
 
 const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
 
@@ -59,16 +62,33 @@ class RepositoriesList extends Component {
     }
   }
 
+  onPageLinkClick(pageNumber) {
+    this.props.dispatch(fetchUserRepositories(pageNumber));
+  }
+
   render() {
     const isLoading = this.props.repositories.isFetching;
+    const pageLinks = this.props.repositories.pageLinks;
 
     return (
       <div>
+        { this.props.repositories.success && pageLinks &&
+          <div className={ styles['page-links-container'] }>
+            Pages: <PageLinks { ...pageLinks } onClick={ this.onPageLinkClick.bind(this) } />
+          </div>
+        }
         { isLoading &&
-          <div className={styles.spinner}><Spinner /></div>
+          <div className={ spinnerStyles }>
+            <Spinner />
+          </div>
         }
         { this.props.repositories.success &&
           this.props.repositories.repos.map(this.renderRepository.bind(this))
+        }
+        { this.props.repositories.success && pageLinks &&
+          <div className={ styles['page-links-container'] }>
+            Pages: <PageLinks { ...pageLinks } onClick={ this.onPageLinkClick.bind(this) } />
+          </div>
         }
       </div>
     );

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -74,7 +74,7 @@ class RepositoriesList extends Component {
       <div>
         { this.props.repositories.success && pageLinks &&
           <div className={ styles['page-links-container'] }>
-            Pages: <PageLinks { ...pageLinks } onClick={ this.onPageLinkClick.bind(this) } />
+            <PageLinks { ...pageLinks } onClick={ this.onPageLinkClick.bind(this) } />
           </div>
         }
         { isLoading &&

--- a/src/common/components/repositories-list/styles.css
+++ b/src/common/components/repositories-list/styles.css
@@ -1,0 +1,5 @@
+.page-links-container {
+  margin: 20px auto;
+  display: flex;
+  justify-content: center;
+}

--- a/src/common/reducers/repositories.js
+++ b/src/common/reducers/repositories.js
@@ -5,7 +5,8 @@ export function repositories(state = {
   isFetching: false,
   success: false,
   error: null,
-  repos: null
+  repos: null,
+  pageLinks: {}
 }, action) {
   switch(action.type) {
     case ActionTypes.FETCH_REPOSITORIES:
@@ -16,9 +17,6 @@ export function repositories(state = {
     case ActionTypes.SET_REPOSITORIES:
       return {
         ...state,
-        isFetching: false,
-        success: true,
-        error: null,
         repos: action.payload.map((repo) => {
           return {
             // parse repository info to keep consistent data format
@@ -28,12 +26,24 @@ export function repositories(state = {
           };
         })
       };
+    case ActionTypes.FETCH_REPOSITORIES_SUCCESS:
+      return {
+        ...state,
+        isFetching: false,
+        success: true,
+        error: null
+      };
     case ActionTypes.FETCH_REPOSITORIES_ERROR:
       return {
         ...state,
         isFetching: false,
         success: false,
         error: action.payload
+      };
+    case ActionTypes.SET_PAGE_LINKS:
+      return {
+        ...state,
+        pageLinks: action.payload
       };
     default:
       return state;

--- a/src/common/reducers/repositories.js
+++ b/src/common/reducers/repositories.js
@@ -40,7 +40,7 @@ export function repositories(state = {
         success: false,
         error: action.payload
       };
-    case ActionTypes.SET_PAGE_LINKS:
+    case ActionTypes.SET_REPOSITORY_PAGE_LINKS:
       return {
         ...state,
         pageLinks: action.payload

--- a/src/server/routes/github.js
+++ b/src/server/routes/github.js
@@ -10,5 +10,6 @@ router.post('/github/webhook', createWebhook);
 
 router.use('/github/repos', json());
 router.get('/github/repos', listRepositories);
+router.get('/github/repos/page/:page', listRepositories);
 
 export default router;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,6 +17,20 @@ expect.extend({
   }
 });
 
+expect.extend({
+  notToHaveActionOfType(expected) {
+    expect.assert(
+      this.actual.filter((action) => {
+        return action.type === expected;
+      }).length === 0,
+      'Expected dispatched actions not to have action %s',
+      expected
+    );
+
+    return this;
+  }
+});
+
 export function requireWithMockConfigHelper(requirePath, modulePath, stub) {
   return proxyquire(requirePath, {
     [modulePath]: {

--- a/test/unit/src/common/actions/t_repositories.js
+++ b/test/unit/src/common/actions/t_repositories.js
@@ -87,25 +87,68 @@ describe('repositories actions', () => {
       nock.cleanAll();
     });
 
-    it('should store repositories on fetch success', () => {
+    context('when repository data successfully retrieved', () => {
+      beforeEach(() => {
+        api.get('/api/github/repos')
+          .reply(200, {
+            status: 'success',
+            payload: {
+              code: 'snap-builds-found',
+              repos: []
+            },
+            pageLinks: {
+              first: '1',
+              prev: '1',
+              next: '3',
+              last: '3'
+            }
+          });
+      });
 
-      api.get('/api/github/repos')
-        .reply(200, {
-          status: 'success',
-          payload: {
-            code: 'snap-builds-found',
-            repos: []
-          }
-        });
+      it('should store repositories on fetch success', () => {
+        return store.dispatch(fetchUserRepositories())
+          .then(() => {
+            api.done();
+            expect(store.getActions()).toHaveActionOfType(
+              ActionTypes.SET_REPOSITORIES
+            );
+          });
+      });
 
-      return store.dispatch(fetchUserRepositories())
-        .then(() => {
-          api.done();
-          expect(store.getActions()).toHaveActionOfType(
-            ActionTypes.SET_REPOSITORIES
-          );
-        });
+      it('should store pageLinks', () => {
+        return store.dispatch(fetchUserRepositories())
+          .then(() => {
+            api.done();
+            expect(store.getActions()).toHaveActionOfType(
+              ActionTypes.SET_PAGE_LINKS
+            );
+          });
+      });
     });
+
+    context('when one page of repo data successfully retrieved', () => {
+      beforeEach(() => {
+        api.get('/api/github/repos')
+          .reply(200, {
+            status: 'success',
+            payload: {
+              code: 'snap-builds-found',
+              repos: []
+            }
+          });
+      });
+
+      it('should store no pageLinks', () => {
+        return store.dispatch(fetchUserRepositories())
+          .then(() => {
+            api.done();
+            expect(store.getActions()).notToHaveActionOfType(
+              ActionTypes.SET_PAGE_LINKS
+            );
+          });
+      });
+    });
+
 
     it('should store error on Launchpad request failure', () => {
 

--- a/test/unit/src/common/actions/t_repositories.js
+++ b/test/unit/src/common/actions/t_repositories.js
@@ -120,7 +120,7 @@ describe('repositories actions', () => {
           .then(() => {
             api.done();
             expect(store.getActions()).toHaveActionOfType(
-              ActionTypes.SET_PAGE_LINKS
+              ActionTypes.SET_REPOSITORY_PAGE_LINKS
             );
           });
       });
@@ -143,7 +143,7 @@ describe('repositories actions', () => {
           .then(() => {
             api.done();
             expect(store.getActions()).notToHaveActionOfType(
-              ActionTypes.SET_PAGE_LINKS
+              ActionTypes.SET_REPOSITORY_PAGE_LINKS
             );
           });
       });

--- a/test/unit/src/common/components/page-links/t_page-links.js
+++ b/test/unit/src/common/components/page-links/t_page-links.js
@@ -1,0 +1,74 @@
+import expect from 'expect';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import PageLinks from '../../../../../../src/common/components/page-links';
+
+describe('The PageLinks component', () => {
+  let props;
+
+  beforeEach(() => {
+    props = {};
+  });
+
+  context('when a link prop is the string "/pages/2"', () => {
+    beforeEach(() => {
+      props['first'] = '/pages/2';
+    });
+
+    it('should render a link with an href "/pages/2"', () => {
+      let component = shallow(<PageLinks { ...props} />);
+      expect(component.find('a[href="/pages/2"]').length).toBe(1);
+    });
+
+    context('and when supplied an onClick callback prop', () => {
+      let callbackSpy = expect.createSpy();
+
+      beforeEach(() => {
+        props['onClick'] = callbackSpy;
+      });
+
+      it('should call onClick with "/pages/2" when link is clicked', () => {
+        let component = shallow(<PageLinks { ...props} />);
+        component.instance().onClick('/pages/2');
+        expect(callbackSpy).toHaveBeenCalledWith('/pages/2');
+      });
+    });
+  });
+
+  context('when a link prop is the number "3"', () => {
+    beforeEach(() => {
+      props['first'] = 3;
+    });
+
+    it('should render without an href attribute', () => {
+      let component = shallow(<PageLinks { ...props} />);
+      expect(component.find('a[href]').length).toBe(0);
+    });
+
+    context('and when supplied an onClick callback prop', () => {
+      let callbackSpy = expect.createSpy();
+
+      beforeEach(() => {
+        props['onClick'] = callbackSpy;
+      });
+
+      it('should call onClick with "3" when link is clicked', () => {
+        let component = shallow(<PageLinks { ...props} />);
+        component.instance().onClick(3);
+        expect(callbackSpy).toHaveBeenCalledWith(3);
+      });
+    });
+  });
+
+  context('when a link prop is not set', () => {
+    beforeEach(() => {
+      props['first'] = undefined;
+    });
+
+    it('should render an unclickable label', () => {
+      let component = shallow(<PageLinks { ...props } />);
+      expect(component.containsMatchingElement(<div>first</div>));
+    });
+  });
+});

--- a/test/unit/src/common/reducers/t_repositories.js
+++ b/test/unit/src/common/reducers/t_repositories.js
@@ -8,6 +8,7 @@ describe('repositories reducers', () => {
   const initialState = {
     isFetching: false,
     success: false,
+    pageLinks: {},
     error: null,
     repos: null
   };
@@ -53,10 +54,6 @@ describe('repositories reducers', () => {
       payload: REPOS
     };
 
-    it('should stop fetching', () => {
-      expect(repositories(state, action).isFetching).toBe(false);
-    });
-
     it('should store parsed repository data', () => {
       repositories(state, action).repos.forEach((repo, i) => {
         expect(repo.fullName).toEqual(REPOS[i].full_name);
@@ -70,6 +67,22 @@ describe('repositories reducers', () => {
         expect(repo.repo).toEqual(REPOS[i]);
       });
     });
+  });
+
+  context('FETCH_REPOSITORIES_SUCCESS', () => {
+    const state = {
+      ...initialState,
+      isFetching: true,
+      error: 'Previous error'
+    };
+
+    const action = {
+      type: ActionTypes.FETCH_REPOSITORIES_SUCCESS
+    };
+
+    it('should stop fetching', () => {
+      expect(repositories(state, action).isFetching).toBe(false);
+    });
 
     it('should store success state', () => {
       expect(repositories(state, action).success).toBe(true);
@@ -79,6 +92,7 @@ describe('repositories reducers', () => {
       expect(repositories(state, action).error).toBe(null);
     });
   });
+
 
   context('FETCH_REPOSITORIES_ERROR', () => {
     const state = {


### PR DESCRIPTION
- New PageLinks component
- Added feature to fetchRepositories handler to transform and pass on
  page links from GitHub API
- Split FETCH_REPOSITORIES_SUCCESS from SET_REPOSITORIES to clean up a
  side-effect
- Repositories are now cleared from store when loading new pages
- New and updated unit tests