### PR TITLE
Restrict store macaroons to the edge channel

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -219,7 +219,8 @@ const verifySnapNameRegistered = (name) => {
     },
     body: JSON.stringify({
       packages: [{ name: name, series: STORE_SERIES }],
-      permissions: ['package_upload']
+      permissions: ['package_upload'],
+      channels: STORE_CHANNELS
     })
   }).then((response) => response.json().then((json) => {
     if (response.status === 200 && json.macaroon) {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -77,8 +77,9 @@ describe('The Launchpad API endpoint', () => {
         beforeEach(() => {
           nock(conf.get('STORE_API_URL'))
             .post('/acl/', {
-              'packages': [{ 'name': snapName, 'series': '16' }],
-              'permissions': ['package_upload']
+              packages: [{ 'name': snapName, 'series': '16' }],
+              permissions: ['package_upload'],
+              channels: ['edge']
             })
             .reply(404, {
               status: 404,
@@ -132,8 +133,9 @@ describe('The Launchpad API endpoint', () => {
         beforeEach(() => {
           nock(conf.get('STORE_API_URL'))
             .post('/acl/', {
-              'packages': [{ 'name': snapName, 'series': '16' }],
-              'permissions': ['package_upload']
+              packages: [{ 'name': snapName, 'series': '16' }],
+              permissions: ['package_upload'],
+              channels: ['edge']
             })
             .reply(200, { macaroon: 'successfull-macaroon' });
         });


### PR DESCRIPTION
We don't need anything else, and this reduces risk in the event of a
macaroon leaking.