### PR TITLE
Check snapcraft.yaml existence in webhook

### DIFF
--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -53,119 +53,244 @@ describe('The WebHook API endpoint', () => {
         .expect(400, done);
     });
 
-    it('returns 200 OK and requests builds if the signature is ' +
-       'good', (done) => {
+    describe('with a good signature', () => {
       const lp_api_url = conf.get('LP_API_URL');
       const lp_api_base = `${lp_api_url}/devel`;
-      const findByURL = nock(lp_api_url)
-        .get('/devel/+snaps')
-        .query({
-          'ws.op': 'findByURL',
-          url: 'https://github.com/anowner/aname'
-        })
-        .reply(200, {
-          total_size: 1,
-          start: 0,
-          entries: [
-            {
+      const body = JSON.stringify({ ref: 'refs/heads/master' });
+      let signature;
+
+      before(() => {
+        let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
+        hmac.update('anowner');
+        hmac.update('aname');
+        hmac = createHmac('sha1', hmac.digest('hex'));
+        hmac.update(body);
+        signature = hmac.digest('hex');
+      });
+
+      describe('if auto_build is true', () => {
+        let findByURL;
+        let getSnap;
+
+        beforeEach(() => {
+          findByURL = nock(lp_api_url)
+            .get('/devel/+snaps')
+            .query({
+              'ws.op': 'findByURL',
+              url: 'https://github.com/anowner/aname'
+            })
+            .reply(200, {
+              total_size: 1,
+              start: 0,
+              entries: [
+                {
+                  resource_type_link: `${lp_api_base}/#snap`,
+                  self_link: `${lp_api_base}${lp_snap_path}`,
+                  owner_link: `${lp_api_base}/~${lp_snap_user}`
+                }
+              ]
+            });
+          getSnap = nock(lp_api_url)
+            .get(`/devel${lp_snap_path}`)
+            .reply(200, {
               resource_type_link: `${lp_api_base}/#snap`,
               self_link: `${lp_api_base}${lp_snap_path}`,
-              owner_link: `${lp_api_base}/~${lp_snap_user}`
-            }
-          ]
-        });
-      const requestAutoBuilds = nock(lp_api_url)
-        .post(`/devel${lp_snap_path}`, {
-          'ws.op': 'requestAutoBuilds'
-        })
-        .reply(200, {
-          total_size: 2,
-          start: 0,
-          entries: [
-            {
-              resource_type_link: `${lp_api_base}/#snap_build`,
-              self_link: `${lp_api_base}${lp_snap_path}/+build/1`
-            },
-            {
-              resource_type_link: `${lp_api_base}/#snap_build`,
-              self_link: `${lp_api_base}${lp_snap_path}/+build/2`
-            }
-          ]
+              auto_build: true
+            });
         });
 
-      const body = JSON.stringify({ ref: 'refs/heads/master' });
-      let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-      hmac.update('anowner');
-      hmac.update('aname');
-      hmac = createHmac('sha1', hmac.digest('hex'));
-      hmac.update(body);
-      supertest(app)
-        .post('/anowner/aname/webhook/notify')
-        .type('application/json')
-        .set('X-GitHub-Event', 'push')
-        .set('X-Hub-Signature', `sha1=${hmac.digest('hex')}`)
-        .send(body)
-        .expect(200, (err) => {
-          findByURL.done();
-          requestAutoBuilds.done();
-          done(err);
+        it('returns 200 OK and requests builds', (done) => {
+          const requestAutoBuilds = nock(lp_api_url)
+            .post(`/devel${lp_snap_path}`, { 'ws.op': 'requestAutoBuilds' })
+            .reply(200, {
+              total_size: 2,
+              start: 0,
+              entries: [
+                {
+                  resource_type_link: `${lp_api_base}/#snap_build`,
+                  self_link: `${lp_api_base}${lp_snap_path}/+build/1`
+                },
+                {
+                  resource_type_link: `${lp_api_base}/#snap_build`,
+                  self_link: `${lp_api_base}${lp_snap_path}/+build/2`
+                }
+              ]
+            });
+
+          supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-GitHub-Event', 'push')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body)
+            .expect(200, (err) => {
+              findByURL.done();
+              getSnap.done();
+              requestAutoBuilds.done();
+              done(err);
+            });
         });
-    });
+      });
 
-    it('returns 500 if it fails to request builds', (done) => {
-      nock(conf.get('LP_API_URL'))
-        .get('/devel/+snaps')
-        .query({
-          'ws.op': 'findByURL',
-          url: 'https://github.com/anowner/aname'
-        })
-        .reply(200, {
-          total_size: 0,
-          start: 0,
-          entries: []
+      describe('if auto_build is false', () => {
+        let findByURL;
+        let getSnap;
+
+        beforeEach(() => {
+          findByURL = nock(lp_api_url)
+            .get('/devel/+snaps')
+            .query({
+              'ws.op': 'findByURL',
+              url: 'https://github.com/anowner/aname'
+            })
+            .reply(200, {
+              total_size: 1,
+              start: 0,
+              entries: [
+                {
+                  resource_type_link: `${lp_api_base}/#snap`,
+                  self_link: `${lp_api_base}${lp_snap_path}`,
+                  owner_link: `${lp_api_base}/~${lp_snap_user}`
+                }
+              ]
+            });
+          getSnap = nock(lp_api_url)
+            .get(`/devel${lp_snap_path}`)
+            .reply(200, {
+              resource_type_link: `${lp_api_base}/#snap`,
+              self_link: `${lp_api_base}${lp_snap_path}`,
+              auto_build: false
+            });
         });
 
-      const body = JSON.stringify({ ref: 'refs/heads/master' });
-      let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-      hmac.update('anowner');
-      hmac.update('aname');
-      hmac = createHmac('sha1', hmac.digest('hex'));
-      hmac.update(body);
-      supertest(app)
-        .post('/anowner/aname/webhook/notify')
-        .type('application/json')
-        .set('X-GitHub-Event', 'push')
-        .set('X-Hub-Signature', `sha1=${hmac.digest('hex')}`)
-        .send(body)
-        .expect(500, done);
-    });
+        describe('if snapcraft.yaml is missing', () => {
+          let getSnapcraftYaml;
 
-    it('returns 200 but does not request builds for a ping event', (done) => {
-      const lp_api_url = conf.get('LP_API_URL');
-      const findByURL = nock(lp_api_url)
-        .get('/devel/+snaps')
-        .reply(500);
-      const requestAutoBuilds = nock(lp_api_url)
-        .post(`/devel${lp_snap_path}`)
-        .reply(500);
+          beforeEach(() => {
+            getSnapcraftYaml = nock(conf.get('GITHUB_API_ENDPOINT'))
+              .get('/repos/anowner/aname/contents/snapcraft.yaml')
+              .query({
+                client_id: conf.get('GITHUB_AUTH_CLIENT_ID'),
+                client_secret: conf.get('GITHUB_AUTH_CLIENT_SECRET')
+              })
+              .reply(404, { message: 'Not Found' });
+          });
 
-      const body = JSON.stringify({ ref: 'refs/heads/master' });
-      let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
-      hmac.update('anowner');
-      hmac.update('aname');
-      hmac = createHmac('sha1', hmac.digest('hex'));
-      hmac.update(body);
-      supertest(app)
-        .post('/anowner/aname/webhook/notify')
-        .type('application/json')
-        .set('X-GitHub-Event', 'ping')
-        .set('X-Hub-Signature', `sha1=${hmac.digest('hex')}`)
-        .send(body)
-        .expect(200, (err) => {
-          expect(findByURL.isDone()).toBe(false);
-          expect(requestAutoBuilds.isDone()).toBe(false);
-          done(err);
+          it('returns 500', (done) => {
+            supertest(app)
+              .post('/anowner/aname/webhook/notify')
+              .type('application/json')
+              .set('X-GitHub-Event', 'push')
+              .set('X-Hub-Signature', `sha1=${signature}`)
+              .send(body)
+              .expect(500, (err) => {
+                findByURL.done();
+                getSnap.done();
+                getSnapcraftYaml.done();
+                done(err);
+              });
+          });
         });
+
+        describe('if snapcraft.yaml is present', () => {
+          let getSnapcraftYaml;
+
+          beforeEach(() => {
+            getSnapcraftYaml = nock(conf.get('GITHUB_API_ENDPOINT'))
+              .get('/repos/anowner/aname/contents/snapcraft.yaml')
+              .query({
+                client_id: conf.get('GITHUB_AUTH_CLIENT_ID'),
+                client_secret: conf.get('GITHUB_AUTH_CLIENT_SECRET')
+              })
+              .reply(200, 'name: dummy-test-snap\n');
+          });
+
+          it('returns 200 OK and requests builds', (done) => {
+            const patchSnapAutoBuild = nock(lp_api_url)
+              .post(`/devel${lp_snap_path}`, { auto_build: true })
+              .reply(200, {
+                resource_type_link: `${lp_api_base}/#snap`,
+                self_link: `${lp_api_base}${lp_snap_path}`,
+                auto_build: true
+              });
+            const requestAutoBuilds = nock(lp_api_url)
+              .post(`/devel${lp_snap_path}`, { 'ws.op': 'requestAutoBuilds' })
+              .reply(200, {
+                total_size: 2,
+                start: 0,
+                entries: [
+                  {
+                    resource_type_link: `${lp_api_base}/#snap_build`,
+                    self_link: `${lp_api_base}${lp_snap_path}/+build/1`
+                  },
+                  {
+                    resource_type_link: `${lp_api_base}/#snap_build`,
+                    self_link: `${lp_api_base}${lp_snap_path}/+build/2`
+                  }
+                ]
+              });
+
+            supertest(app)
+              .post('/anowner/aname/webhook/notify')
+              .type('application/json')
+              .set('X-GitHub-Event', 'push')
+              .set('X-Hub-Signature', `sha1=${signature}`)
+              .send(body)
+              .expect(200, (err) => {
+                findByURL.done();
+                getSnap.done();
+                getSnapcraftYaml.done();
+                patchSnapAutoBuild.done();
+                requestAutoBuilds.done();
+                done(err);
+              });
+          });
+        });
+      });
+
+      it('returns 500 if it fails to request builds', (done) => {
+        nock(lp_api_url)
+          .get('/devel/+snaps')
+          .query({
+            'ws.op': 'findByURL',
+            url: 'https://github.com/anowner/aname'
+          })
+          .reply(200, {
+            total_size: 0,
+            start: 0,
+            entries: []
+          });
+
+        supertest(app)
+          .post('/anowner/aname/webhook/notify')
+          .type('application/json')
+          .set('X-GitHub-Event', 'push')
+          .set('X-Hub-Signature', `sha1=${signature}`)
+          .send(body)
+          .expect(500, done);
+      });
+
+      it('returns 200 but does not request builds for a ping ' +
+         'event', (done) => {
+        const findByURL = nock(lp_api_url)
+          .get('/devel/+snaps')
+          .reply(500);
+        const requestAutoBuilds = nock(lp_api_url)
+          .post(`/devel${lp_snap_path}`)
+          .reply(500);
+
+        supertest(app)
+          .post('/anowner/aname/webhook/notify')
+          .type('application/json')
+          .set('X-GitHub-Event', 'ping')
+          .set('X-Hub-Signature', `sha1=${signature}`)
+          .send(body)
+          .expect(200, (err) => {
+            expect(findByURL.isDone()).toBe(false);
+            expect(requestAutoBuilds.isDone()).toBe(false);
+            done(err);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
We want to move to creating the snap in Launchpad somewhat earlier,
before snapcraft.yaml necessarily exists.  As a prerequisite for this,
the webhook needs to check whether snapcraft.yaml exists before
dispatching builds.

The `auto_build` flag on snaps, previously unused in this workflow, is
now used to indicate whether the snap has been sufficiently set up for
builds to be dispatched.  This lets us minimise the number of GitHub
queries we make from the webhook, which is important since that doesn't
have user authorisation available to it.