### PR TITLE
Separating landing and dashboard routes and containers

### DIFF
--- a/src/common/containers/dashboard.js
+++ b/src/common/containers/dashboard.js
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import RepositoriesHome from '../components/repositories-home';
 import styles from './container.css';
 
-class Home extends Component {
+class Dashboard extends Component {
   render() {
     return (
       <div className={ styles.container }>
@@ -17,4 +17,4 @@ class Home extends Component {
   }
 }
 
-export default Home;
+export default Dashboard;

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -1,0 +1,43 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+
+import { Anchor } from '../components/button';
+
+import styles from './container.css';
+
+class Landing extends Component {
+  componentWillMount() {
+    if (this.props.auth.authenticated) {
+      this.props.router.replace('/repos');
+    }
+  }
+
+  render() {
+    return (
+      <div className={ styles.container }>
+        <h2>Auto-build and publish software for any Linux system.</h2>
+        <p>Just a placeholder landing page...</p>
+        <Anchor href="/auth/authenticate">Set Up in Minutes</Anchor>
+      </div>
+    );
+  }
+}
+
+Landing.propTypes = {
+  children: PropTypes.node,
+  auth: PropTypes.object,
+  router: PropTypes.object
+};
+
+function mapStateToProps(state) {
+  const {
+    auth
+  } = state;
+
+  return {
+    auth
+  };
+}
+
+export default connect(mapStateToProps)(withRouter(Landing));

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -1,18 +1,11 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 
 import { Anchor } from '../components/button';
 
 import styles from './container.css';
 
 class Landing extends Component {
-  componentWillMount() {
-    if (this.props.auth.authenticated) {
-      this.props.router.replace('/repos');
-    }
-  }
-
   render() {
     return (
       <div className={ styles.container }>
@@ -40,4 +33,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(withRouter(Landing));
+export default connect(mapStateToProps)(Landing);

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -3,13 +3,15 @@ import { Route } from 'react-router';
 import App from './containers/app.js';
 import Builds from './containers/builds.js';
 import BuildDetails from './containers/build-details.js';
-import Home from './containers/home.js';
+import Dashboard from './containers/dashboard.js';
+import Landing from './containers/landing.js';
 import LoginFailed from './containers/login-failed.js';
 import RepositorySetup from './containers/repository-setup.js';
 
 export default (
   <Route component={App}>
-    <Route path="/" component={Home}/>
+    <Route path="/" component={Landing}/>
+    <Route path="/repos" component={Dashboard}/>
     <Route path="/:owner/:name/setup" component={RepositorySetup}/>
     <Route path="/:owner/:name/builds" component={Builds}/>
     <Route path="/:owner/:name/builds/:buildId" component={BuildDetails}/>

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -11,7 +11,7 @@ import RepositorySetup from './containers/repository-setup.js';
 export default (
   <Route component={App}>
     <Route path="/" component={Landing}/>
-    <Route path="/repos" component={Dashboard}/>
+    <Route path="/dashboard" component={Dashboard}/>
     <Route path="/:owner/:name/setup" component={RepositorySetup}/>
     <Route path="/:owner/:name/builds" component={Builds}/>
     <Route path="/:owner/:name/builds/:buildId" component={BuildDetails}/>

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -66,7 +66,7 @@ export const verify = (req, res, next) => {
     logger.info('User successfully authenticated');
 
     // Redirect to logged in URL
-    res.redirect('/');
+    res.redirect('/dashboard');
   });
 };
 

--- a/test/routes/src/server/routes/t_github-auth.js
+++ b/test/routes/src/server/routes/t_github-auth.js
@@ -105,14 +105,14 @@ describe('The login route', () => {
         );
       });
 
-      it('should redirect request to site homepage', (done) => {
+      it('should redirect request to dashboard', (done) => {
         supertest(app)
           .get('/auth/verify')
           .query({ code: 'foo', state: 'bar' })
           .send()
           .end((err, res) => {
             expect(res.statusCode).toEqual(302);
-            expect(res.headers.location).toEqual('/');
+            expect(res.headers.location).toEqual('/dashboard');
             done(err);
           });
       });


### PR DESCRIPTION
Added separate landing container.

With this PR:

- Repository listing is moved to new `/dashboard` route (URL will likely to be changed later).
- `build.snapcraft.io` renders landing container.
- When user signs in, GitHub redirects back to `/dashboard`.