### PR TITLE
Refactor common API helper methods into one place

### DIFF
--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -1,5 +1,6 @@
 import 'isomorphic-fetch';
 
+import { checkStatus, getError } from '../helpers/api';
 import { conf } from '../helpers/config';
 import { parseGitHubRepoUrl } from '../helpers/github-url';
 
@@ -14,24 +15,6 @@ export function setGitHubRepository(value) {
     type: SET_GITHUB_REPOSITORY,
     payload: value
   };
-}
-
-export function getError(response, json) {
-  const message = (json.payload && json.payload.message) || response.statusText;
-  const error = new Error(message);
-  error.response = response;
-  error.json = json;
-  return error;
-}
-
-function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
-    return response;
-  } else {
-    return response.json().then((json) => {
-      throw getError(response, json);
-    });
-  }
 }
 
 export function createSnap(repositoryUrl, location) { // location for tests

--- a/src/common/actions/repositories.js
+++ b/src/common/actions/repositories.js
@@ -1,5 +1,6 @@
 import 'isomorphic-fetch';
 
+import { checkStatus, getError } from '../helpers/api';
 import { conf } from '../helpers/config';
 
 const BASE_URL = conf.get('BASE_URL');
@@ -15,26 +16,6 @@ export function setRepositories(repos) {
     type: SET_REPOSITORIES,
     payload: repos
   };
-}
-
-// TODO bartaz: same as in other actions (share in some helper?)
-export function getError(response, json) {
-  const message = (json.payload && json.payload.message) || response.statusText;
-  const error = new Error(message);
-  error.response = response;
-  error.json = json;
-  return error;
-}
-
-// TODO bartaz: same as in other actions (share in some helper?)
-function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
-    return response;
-  } else {
-    return response.json().then((json) => {
-      throw getError(response, json);
-    });
-  }
 }
 
 export function fetchUserRepositories(pageNumber) {

--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -1,5 +1,6 @@
 import 'isomorphic-fetch';
 
+import { checkStatus } from '../helpers/api';
 import { conf } from '../helpers/config';
 
 const BASE_URL = conf.get('BASE_URL');
@@ -30,20 +31,6 @@ export function fetchBuildsError(error) {
     payload: error,
     error: true
   };
-}
-
-function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
-    return response;
-  } else {
-    return response.json().then((json) => {
-      // throw an error based on message from response body or status text
-      const error = new Error(json.payload.message || response.statusText);
-      error.status = response.status;
-      error.response = response;
-      throw error;
-    });
-  }
 }
 
 // Fetch snap info (self_link) for given repository

--- a/src/common/helpers/api.js
+++ b/src/common/helpers/api.js
@@ -1,0 +1,18 @@
+export function getError(response, json) {
+  const message = (json.payload && json.payload.message) ||
+                  response.statusText;
+  const error = new Error(message);
+  error.response = response;
+  error.json = json;
+  return error;
+}
+
+export function checkStatus(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  } else {
+    return response.json().then((json) => {
+      throw getError(response, json);
+    });
+  }
+}


### PR DESCRIPTION
`getError` and `checkStatus` have the same implementation for anything
that consumes internal APIs.