### PR TITLE
Initiate the snapcraft.yaml check from the client

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -17,6 +17,9 @@ To create a snap:
 
     {
       "repository_url": "https://github.com/:owner/:name"
+      "snap_name": ":snap-name",
+      "series": ":series",
+      "channels": [":channel", ...]
     }
 
 On success, returns:
@@ -145,5 +148,30 @@ On success, returns the following where the items in `repos` are GitHub reposito
         prev: 1,
         next: 3,
         last: 3
+      }
+    }
+
+### Getting snapcraft.yaml
+
+To get a parsed version of the `snapcraft.yaml` file in a GitHub repository:
+
+    GET /api/github/snapcraft-yaml/:owner/:name
+    Cookie: <session cookie>
+    Accept: application/json
+
+On success, returns the following, where `contents` is a JSON representation
+of the parsed YAML file:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "status": "success",
+      "payload": {
+        "code": "github-snapcraft-yaml-found",
+        "contents": {
+          "name": ":snap-name",
+          ...
+        }
       }
     }

--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -8,7 +8,13 @@ const BASE_URL = conf.get('BASE_URL');
 
 export const SET_GITHUB_REPOSITORY = 'SET_GITHUB_REPOSITORY';
 export const CREATE_SNAP = 'CREATE_SNAP';
+export const CREATE_SNAP_SUCCESS = 'CREATE_SNAP_SUCCESS';
 export const CREATE_SNAP_ERROR = 'CREATE_SNAP_ERROR';
+
+// XXX cjwatson 2017-02-08: Hardcoded for now, but should eventually be
+// configurable.
+export const STORE_SERIES = '16';
+export const STORE_CHANNELS = ['edge'];
 
 export function setGitHubRepository(value) {
   return {
@@ -17,24 +23,60 @@ export function setGitHubRepository(value) {
   };
 }
 
+// Just enough to satisfy higher-level code that might receive errors from
+// our internal API or errors thrown directly from here.
+function throwAPICompatibleError(payload) {
+  const error = new Error(payload.message);
+  error.json = { status: 'error', payload };
+  throw error;
+}
+
+function getSnapName(owner, name) {
+  return fetch(`${BASE_URL}/api/github/snapcraft-yaml/${owner}/${name}`, {
+    headers: { 'Accept': 'application/json' },
+    credentials: 'same-origin'
+  })
+    .then(checkStatus)
+    .then((response) => response.json().then((json) => {
+      if (json.status !== 'success' ||
+          json.payload.code !== 'snapcraft-yaml-found') {
+        throw getError(response, json);
+      }
+      const snapcraftYaml = json.payload.contents;
+      if (!('name' in snapcraftYaml)) {
+        throwAPICompatibleError({
+          code: 'snapcraft-yaml-no-name',
+          message: 'snapcraft.yaml has no top-level "name" attribute'
+        });
+      }
+      return snapcraftYaml.name;
+    }));
+}
+
 export function createSnap(repositoryUrl, location) { // location for tests
   return (dispatch) => {
     if (repositoryUrl) {
-      const { fullName } = parseGitHubRepoUrl(repositoryUrl);
+      const { owner, name, fullName } = parseGitHubRepoUrl(repositoryUrl);
 
       dispatch({
         type: CREATE_SNAP,
-        payload: {
-          id: fullName
-        }
+        payload: { id: fullName }
       });
 
-      return fetch(`${BASE_URL}/api/launchpad/snaps`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ repository_url: repositoryUrl }),
-        credentials: 'same-origin'
-      })
+      return getSnapName(owner, name)
+        .then((snapName) => {
+          return fetch(`${BASE_URL}/api/launchpad/snaps`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              repository_url: repositoryUrl,
+              snap_name: snapName,
+              series: STORE_SERIES,
+              channels: STORE_CHANNELS
+            }),
+            credentials: 'same-origin'
+          });
+        })
         .then(checkStatus)
         .then(response => {
           return response.json().then(result => {

--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -25,10 +25,11 @@ export function setGitHubRepository(value) {
 
 // Just enough to satisfy higher-level code that might receive errors from
 // our internal API or errors thrown directly from here.
-function throwAPICompatibleError(payload) {
-  const error = new Error(payload.message);
-  error.json = { status: 'error', payload };
-  throw error;
+class APICompatibleError extends Error {
+  constructor(payload) {
+    super(payload.message);
+    this.json = { status: 'error', payload };
+  }
 }
 
 function getSnapName(owner, name) {
@@ -44,7 +45,7 @@ function getSnapName(owner, name) {
       }
       const snapcraftYaml = json.payload.contents;
       if (!('name' in snapcraftYaml)) {
-        throwAPICompatibleError({
+        throw new APICompatibleError({
           code: 'snapcraft-yaml-no-name',
           message: 'snapcraft.yaml has no top-level "name" attribute'
         });

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -4,7 +4,7 @@ import { getGitHubRepoUrl } from '../../common/helpers/github-url';
 import { conf } from '../helpers/config';
 import getLaunchpad from '../launchpad';
 import logging from '../logging';
-import { getSnapcraftYaml, internalFindSnap } from './launchpad';
+import { internalFindSnap, internalGetSnapcraftYaml } from './launchpad';
 
 const logger = logging.getLogger('express');
 
@@ -62,7 +62,7 @@ export const notify = (req, res) => {
       .then((snapUrl) => lpClient.get(snapUrl))
       .then((snap) => {
         if (!snap.auto_build) {
-          return getSnapcraftYaml(owner, name)
+          return internalGetSnapcraftYaml(owner, name)
             .then(() => {
               snap.auto_build = true;
               return snap.lp_save();

--- a/src/server/routes/github.js
+++ b/src/server/routes/github.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { json } from 'body-parser';
 
 import { createWebhook, listRepositories } from '../handlers/github';
+import { getSnapcraftYaml } from '../handlers/launchpad';
 
 const router = Router();
 
@@ -11,5 +12,8 @@ router.post('/github/webhook', createWebhook);
 router.use('/github/repos', json());
 router.get('/github/repos', listRepositories);
 router.get('/github/repos/page/:page', listRepositories);
+
+router.use('/github/snapcraft-yaml/:owner/:name', json());
+router.get('/github/snapcraft-yaml/:owner/:name', getSnapcraftYaml);
 
 export default router;

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -60,16 +60,13 @@ describe('The Launchpad API endpoint', () => {
       });
     });
 
-    context('when repo contains valid snapcraft.yaml', () => {
+    context('when user has admin permissions on repository', () => {
       const snapName = 'dummy-test-snap';
 
       beforeEach(() => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
           .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: true } });
-        nock(conf.get('GITHUB_API_ENDPOINT'))
-          .get('/repos/anowner/aname/contents/snapcraft.yaml')
-          .reply(200, `name: ${snapName}\n`);
       });
 
       afterEach(() => {
@@ -94,14 +91,24 @@ describe('The Launchpad API endpoint', () => {
         it('should return a 400 Bad Request response', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anowner/aname' })
+            .send({
+              repository_url: 'https://github.com/anowner/aname',
+              snap_name: snapName,
+              series: '16',
+              channels: ['edge']
+            })
             .expect(400, done);
         });
 
         it('should return a "error" status', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anowner/aname' })
+            .send({
+              repository_url: 'https://github.com/anowner/aname',
+              snap_name: snapName,
+              series: '16',
+              channels: ['edge']
+            })
             .expect(hasStatus('error'))
             .end(done);
         });
@@ -110,7 +117,12 @@ describe('The Launchpad API endpoint', () => {
            'message', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anowner/aname' })
+            .send({
+              repository_url: 'https://github.com/anowner/aname',
+              snap_name: snapName,
+              series: '16',
+              channels: ['edge']
+            })
             .expect(hasMessage(
                 'snap-name-not-registered',
                 'Snap name is not registered in the store'))
@@ -120,7 +132,12 @@ describe('The Launchpad API endpoint', () => {
         it('should include snap name in body', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
-            .send({ repository_url: 'https://github.com/anowner/aname' })
+            .send({
+              repository_url: 'https://github.com/anowner/aname',
+              snap_name: snapName,
+              series: '16',
+              channels: ['edge']
+            })
             .expect((actual) => {
               if (typeof actual.body.payload === 'undefined'
                   || actual.body.payload.snap_name !== snapName) {
@@ -158,14 +175,24 @@ describe('The Launchpad API endpoint', () => {
           it('should return a 400 Bad Request response', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anowner/aname' })
+              .send({
+                repository_url: 'https://github.com/anowner/aname',
+                snap_name: snapName,
+                series: '16',
+                channels: ['edge']
+              })
               .expect(400, done);
           });
 
           it('should return a "error" status', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anowner/aname' })
+              .send({
+                repository_url: 'https://github.com/anowner/aname',
+                snap_name: snapName,
+                series: '16',
+                channels: ['edge']
+              })
               .expect(hasStatus('error'))
               .end(done);
           });
@@ -173,7 +200,12 @@ describe('The Launchpad API endpoint', () => {
           it('should return a body with an "lp-error" message', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anowner/aname' })
+              .send({
+                repository_url: 'https://github.com/anowner/aname',
+                snap_name: snapName,
+                series: '16',
+                channels: ['edge']
+              })
               .expect(hasMessage(
                   'lp-error',
                   'There is already a snap package with the same name and owner.'))
@@ -191,7 +223,9 @@ describe('The Launchpad API endpoint', () => {
                 'ws.op': 'new',
                 git_repository_url: 'https://github.com/anowner/aname',
                 processors: ['/+processors/amd64', '/+processors/armhf'],
-                store_name: snapName
+                store_series: '/+snappy-series/16',
+                store_name: snapName,
+                store_channels: 'edge'
               })
               .reply(201, 'Created', {
                 Location: `${lp_api_url}/devel/~test-user/+snap/${snapName}`
@@ -214,14 +248,24 @@ describe('The Launchpad API endpoint', () => {
           it('should return a 201 Created response', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anowner/aname' })
+              .send({
+                repository_url: 'https://github.com/anowner/aname',
+                snap_name: snapName,
+                series: '16',
+                channels: ['edge']
+              })
               .expect(201, done);
           });
 
           it('should return a "success" status', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anowner/aname' })
+              .send({
+                repository_url: 'https://github.com/anowner/aname',
+                snap_name: snapName,
+                series: '16',
+                channels: ['edge']
+              })
               .expect(hasStatus('success'))
               .end(done);
           });
@@ -229,7 +273,12 @@ describe('The Launchpad API endpoint', () => {
           it('should return a body with an appropriate caveat ID', (done) => {
             supertest(app)
               .post('/launchpad/snaps')
-              .send({ repository_url: 'https://github.com/anowner/aname' })
+              .send({
+                repository_url: 'https://github.com/anowner/aname',
+                snap_name: snapName,
+                series: '16',
+                channels: ['edge']
+              })
               .expect(hasMessage('snap-created', caveatId))
               .end(done);
           });

--- a/test/unit/src/common/actions/t_create-snap.js
+++ b/test/unit/src/common/actions/t_create-snap.js
@@ -71,7 +71,21 @@ describe('repository input actions', () => {
     });
 
     it('redirects to /login/authenticate on successful creation', () => {
-      scope.post('/api/launchpad/snaps')
+      scope.get('/api/github/snapcraft-yaml/foo/bar')
+        .reply(200, {
+          status: 'success',
+          payload: {
+            code: 'snapcraft-yaml-found',
+            contents: { name: 'test-snap' }
+          }
+        });
+      scope
+        .post('/api/launchpad/snaps', {
+          repository_url: repositoryUrl,
+          snap_name: 'test-snap',
+          series: '16',
+          channels: ['edge']
+        })
         .reply(201, {
           status: 'success',
           payload: {


### PR DESCRIPTION
We'll soon need to move the process of getting a package_upload macaroon
to the client side, which means that the client will need to know the
snap name when it's creating a snap.  Add an
`/api/github/snapcraft-yaml/:owner/:name` route to fetch the parsed
file, and change `/api/launchpad/snaps` to take the snap name, series,
and channels as parameters; this lets us control more of the data flow
from the client side.