### PR TITLE
Add /api/launchpad/snaps/authorize route

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -16,7 +16,7 @@ To create a snap:
     Accept: application/json
 
     {
-      "repository_url": "https://github.com/:owner/:name"
+      "repository_url": "https://github.com/:owner/:name",
       "snap_name": ":snap-name",
       "series": ":series",
       "channels": [":channel", ...]
@@ -39,6 +39,34 @@ The caller should proceed to authorize the snap using an OpenID exchange,
 using `:caveat-id` as the parameter to the Macaroon extension.  If
 successful, the result of this OpenID exchange will be a discharge macaroon,
 which the `/login/verify` handler will store in Launchpad.
+
+We're moving to a slightly different arrangement for authorizing snaps.  In
+this, the caller should acquire a pre-authorized macaroon from the store (on
+the authority of a `package_upload_request` macaroon which has itself been
+authorized using OpenID) and tell Launchpad to use that for uploads.  This
+can be done using this API method:
+
+    POST /api/launchpad/snaps/authorize
+    Cookie: <session cookie>
+    Content-Type: application/json
+
+    {
+      "repository_url": "https://github.com/:owner/:name",
+      "macaroon": ":macaroon"
+    }
+
+On success, returns:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "status": "success",
+      "payload": {
+        "code": "snap-authorized",
+        "message": "Snap uploads authorized"
+      }
+    }
 
 To search for an existing snap:
 

--- a/mocks/service/launchpad/index.js
+++ b/mocks/service/launchpad/index.js
@@ -19,6 +19,8 @@ router.post('/~:owner/+snap/:name', (req, res) => {
   const base = `${req.protocol}://${req.hostname}${req.baseUrl}`;
   if (req.query['ws.op'] == 'beginAuthorization') {
     res.status(200).json(`${base}${req.url}/+authorize/+login`);
+  } else if (req.query['ws.op'] == 'completeAuthorization') {
+    res.status(200).json(null);
   } else {
     res.status(400).send(`No such operation: ${req.query['ws.op']}`);
   }

--- a/src/server/routes/launchpad.js
+++ b/src/server/routes/launchpad.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { json } from 'body-parser';
 
 import {
+  authorizeSnap,
   findSnap,
   findSnaps,
   getSnapBuilds,
@@ -17,6 +18,9 @@ router.get('/launchpad/snaps', findSnap);
 
 router.use('/launchpad/snaps/list', json());
 router.get('/launchpad/snaps/list', findSnaps);
+
+router.use('/launchpad/snaps/authorize', json());
+router.post('/launchpad/snaps/authorize', authorizeSnap);
 
 router.use('/launchpad/builds', json());
 router.get('/launchpad/builds', getSnapBuilds);

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -866,6 +866,127 @@ describe('The Launchpad API endpoint', () => {
 
   });
 
+  describe('authorize snap route', () => {
+    context('when snap exists', () => {
+      let completeAuthorizationScope;
+
+      beforeEach(() => {
+        nock(conf.get('GITHUB_API_ENDPOINT'))
+          .get('/repos/anowner/aname')
+          .reply(200, { permissions: { admin: true } });
+        const lp_api_url = conf.get('LP_API_URL');
+        const lp_api_base = `${lp_api_url}/devel`;
+        nock(lp_api_url)
+          .get('/devel/+snaps')
+          .query({
+            'ws.op': 'findByURL',
+            url: 'https://github.com/anowner/aname'
+          })
+          .reply(200, {
+            total_size: 1,
+            start: 0,
+            entries: [
+              {
+                resource_type_link: `${lp_api_base}/#snap`,
+                self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
+                owner_link: `${lp_api_base}/~test-user`
+              }
+            ]
+          });
+        completeAuthorizationScope = nock(lp_api_url)
+          .post('/devel/~test-user/+snap/test-snap', {
+            'ws.op': 'completeAuthorization',
+            'root_macaroon': 'dummy-macaroon'
+          })
+          .reply(200, 'null', {
+            'Content-Type': 'application/json'
+          });
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      it('completes the authorization', (done) => {
+        supertest(app)
+          .post('/launchpad/snaps/authorize')
+          .send({
+            repository_url: 'https://github.com/anowner/aname',
+            macaroon: 'dummy-macaroon'
+          })
+          .expect(200, (err) => {
+            completeAuthorizationScope.done();
+            done(err);
+          });
+      });
+    });
+
+    context('when snap does not exist', () => {
+      beforeEach(() => {
+        nock(conf.get('GITHUB_API_ENDPOINT'))
+          .get('/repos/anowner/aname')
+          .reply(200, { permissions: { admin: true } });
+        const lp_api_url = conf.get('LP_API_URL');
+        nock(lp_api_url)
+          .get('/devel/+snaps')
+          .query({
+            'ws.op': 'findByURL',
+            url: 'https://github.com/anowner/aname'
+          })
+          .reply(200, {
+            total_size: 0,
+            start: 0,
+            entries: []
+          });
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      it('returns a "snap-not-found" error', (done) => {
+        supertest(app)
+          .post('/launchpad/snaps/authorize')
+          .send({
+            repository_url: 'https://github.com/anowner/aname',
+            macaroon: 'dummy-macaroon'
+          })
+          .expect((res) => {
+            expect(res.statusCode).toEqual(404);
+            expect(res.body.payload.code).toEqual('snap-not-found');
+          })
+          .end(done);
+      });
+    });
+
+    context('when user has no admin permissions on GitHub repository', () => {
+      beforeEach(() => {
+        nock(conf.get('GITHUB_API_ENDPOINT'))
+          .get('/repos/anowner/aname')
+          .reply(200, { permissions: { admin: false } });
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      it('returns a "github-no-admin-permissions" error', (done) => {
+        supertest(app)
+          .post('/launchpad/snaps/authorize')
+          .send({
+            repository_url: 'https://github.com/anowner/aname',
+            macaroon: 'dummy-macaroon'
+          })
+          .expect((res) => {
+            expect(res.statusCode).toEqual(401);
+            expect(res.body.payload.code)
+              .toEqual('github-no-admin-permissions');
+          })
+          .end(done);
+      });
+    });
+  });
+
   describe('get snap builds route', () => {
     const lp_snap_user = 'test-snap-user';
     const lp_snap_name = 'test-snap-name';


### PR DESCRIPTION
This isn't used yet, but it will be used by the new authz workflow to
send pre-authorized `package_upload` macaroons to Launchpad.