### PR TITLE
Getting GitHub user info to the app

### DIFF
--- a/src/common/actions/user.js
+++ b/src/common/actions/user.js
@@ -1,0 +1,46 @@
+import 'isomorphic-fetch';
+
+import { checkStatus, getError } from '../helpers/api';
+import { conf } from '../helpers/config';
+
+const BASE_URL = conf.get('BASE_URL');
+
+export const FETCH_USER = 'FETCH_USER';
+export const SET_USER = 'SET_USER';
+export const FETCH_USER_ERROR = 'FETCH_USER_ERROR';
+
+export function setUser(user) {
+  return {
+    type: SET_USER,
+    payload: user
+  };
+}
+
+export function fetchUserError(error) {
+  return {
+    type: FETCH_USER_ERROR,
+    payload: error,
+    error: true
+  };
+}
+
+export function fetchUser() {
+  return (dispatch) => {
+    dispatch({ type: FETCH_USER });
+
+    return fetch(`${BASE_URL}/api/github/user`, {
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin'
+    })
+      .then(checkStatus)
+      .then((response) => {
+        return response.json().then(result => {
+          if (result.status !== 'success') {
+            throw getError(response, result);
+          }
+          dispatch(setUser(result.payload.user));
+        });
+      })
+      .catch((error) => dispatch(fetchUserError(error)));
+  };
+}

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -5,18 +5,26 @@ import styles from './header.css';
 
 export default class Header extends Component {
   render() {
+    const { authenticated, user } = this.props;
+
     return (
       <div className={ styles.header }>
         <nav className={ styles.container }>
           <Link className={ styles.logo } to="/">
             Snapcraft
           </Link>
-          <div className={ styles.sideNav }>
-            { this.props.authenticated
-              ? <a href="/auth/logout" className={ styles.link }>Log out</a>
-              : <a href="/auth/authenticate" className={ styles.link }>Log in</a>
-            }
-          </div>
+          { authenticated
+            ?
+              <div className={ styles.sideNav }>
+                { user && <a href={user.html_url} className={ styles.link }>{user.name}</a> }
+                <Link to="/dashboard" className={ styles.link }>Dashboard</Link>
+                <a href="/auth/logout" className={ styles.link }>Log out</a>
+              </div>
+            :
+              <div className={ styles.sideNav }>
+                <a href="/auth/authenticate" className={ styles.link }>Log in</a>
+              </div>
+          }
         </nav>
       </div>
     );
@@ -24,5 +32,9 @@ export default class Header extends Component {
 }
 
 Header.propTypes = {
-  authenticated: PropTypes.bool
+  authenticated: PropTypes.bool,
+  user: PropTypes.object({
+    login: PropTypes.string,
+    name: PropTypes.string
+  })
 };

--- a/src/common/containers/app.js
+++ b/src/common/containers/app.js
@@ -5,7 +5,23 @@ import Helmet from 'react-helmet';
 import Header from '../components/header';
 import Footer from '../components/footer';
 
+import { fetchUser } from '../actions/user';
+
 export class App extends Component {
+  fetchData(props) {
+    if (props.auth.authenticated && !props.user.user && !props.user.isFetching) {
+      this.props.dispatch(fetchUser());
+    }
+  }
+
+  componentDidMount() {
+    this.fetchData(this.props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.fetchData(nextProps);
+  }
+
   render() {
     return (
       <div>
@@ -17,7 +33,10 @@ export class App extends Component {
             { 'name': 'description', 'content': 'build.snapcraft.io' },
           ]}
         />
-        <Header authenticated={this.props.auth.authenticated}/>
+        <Header
+          authenticated={this.props.auth.authenticated}
+          user={this.props.user.user}
+        />
         { this.props.children }
         <Footer />
       </div>
@@ -27,16 +46,20 @@ export class App extends Component {
 
 App.propTypes = {
   children: PropTypes.node,
-  auth: PropTypes.object
+  auth: PropTypes.object,
+  user: PropTypes.object,
+  dispatch: PropTypes.func
 };
 
 function mapStateToProps(state) {
   const {
-    auth
+    auth,
+    user
   } = state;
 
   return {
-    auth
+    auth,
+    user
   };
 }
 

--- a/src/common/reducers/index.js
+++ b/src/common/reducers/index.js
@@ -8,6 +8,7 @@ import * as authError from './auth-error';
 import * as selectRepositoriesForm from './select-repositories-form';
 import * as snapBuilds from './snap-builds';
 import * as snaps from './snaps';
+import * as user from './user';
 import * as auth from './auth';
 import * as webhook from './webhook';
 
@@ -19,6 +20,7 @@ const rootReducer = combineReducers({
   ...selectRepositoriesForm,
   ...snapBuilds,
   ...snaps,
+  ...user,
   ...auth,
   ...webhook,
   routing: routerReducer

--- a/src/common/reducers/user.js
+++ b/src/common/reducers/user.js
@@ -1,0 +1,34 @@
+import * as ActionTypes from '../actions/user';
+
+export function user(state = {
+  isFetching: false,
+  user: null,
+  success: false,
+  error: null
+}, action) {
+  switch (action.type) {
+    case ActionTypes.FETCH_USER:
+      return {
+        ...state,
+        isFetching: true
+      };
+    case ActionTypes.SET_USER:
+      return {
+        ...state,
+        isFetching: false,
+        success: true,
+        user: action.payload,
+        error: null
+      };
+    case ActionTypes.FETCH_USER_ERROR:
+      return {
+        ...state,
+        isFetching: false,
+        success: false,
+        user: null,
+        error: action.payload
+      };
+    default:
+      return state;
+  }
+}

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -49,6 +49,33 @@ const RESPONSE_CREATED = {
   }
 };
 
+export const getUser = (req, res) => {
+  if (!req.session || !req.session.token) {
+    return res.status(401).send(RESPONSE_AUTHENTICATION_FAILED);
+  }
+
+  requestGitHub.get('/user', { token: req.session.token, json: true })
+    .then((response) => {
+      if (response.statusCode !== 200) {
+        return res.status(response.statusCode).send({
+          status: 'error',
+          payload: {
+            code: 'github-user-error',
+            message: response.body.message
+          }
+        });
+      }
+
+      res.status(response.statusCode).send({
+        status: 'success',
+        payload: {
+          code: 'github-user',
+          repos: response.body
+        }
+      });
+    });
+};
+
 export const listRepositories = (req, res) => {
   const params = {
     affiliation: 'owner'

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -70,7 +70,7 @@ export const getUser = (req, res) => {
         status: 'success',
         payload: {
           code: 'github-user',
-          repos: response.body
+          user: response.body
         }
       });
     });

--- a/src/server/routes/github.js
+++ b/src/server/routes/github.js
@@ -1,13 +1,20 @@
 import { Router } from 'express';
 import { json } from 'body-parser';
 
-import { createWebhook, listRepositories } from '../handlers/github';
+import {
+  getUser,
+  createWebhook,
+  listRepositories
+} from '../handlers/github';
 import { getSnapcraftYaml } from '../handlers/launchpad';
 
 const router = Router();
 
 router.use('/github/webhook', json());
 router.post('/github/webhook', createWebhook);
+
+router.use('/github/user', json());
+router.get('/github/user', getUser);
 
 router.use('/github/repos', json());
 router.get('/github/repos', listRepositories);

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -19,6 +19,127 @@ describe('The GitHub API endpoint', () => {
   });
   app.use(github);
 
+  describe('get user route', () => {
+
+    context('when user is not logged in', () => {
+      const oldToken = session.token;
+
+      before(() => {
+        delete session.token;
+      });
+
+      after(() => {
+        session.token = oldToken;
+      });
+
+      it('should return a 401 Unauthorized response', (done) => {
+        supertest(app)
+          .get('/github/user')
+          .expect(401, done);
+      });
+
+      it('should return a "error" status', (done) => {
+        supertest(app)
+          .get('/github/user')
+          .expect(hasStatus('error'))
+          .end(done);
+      });
+
+      it('should return a body with a "github-authentication-failed" message', (done) => {
+        supertest(app)
+          .get('/github/repos')
+          .expect(hasMessage('github-authentication-failed'))
+          .end(done);
+      });
+    });
+
+    context('when user is logged in', () => {
+
+      context('when GitHub returns an error', () => {
+        const errorCode = 404;
+        const errorMessage = 'Test error message';
+
+        beforeEach(() => {
+          scope = nock(conf.get('GITHUB_API_ENDPOINT'))
+            .get('/user')
+            .reply(errorCode, { message: errorMessage });
+        });
+
+        afterEach(() => {
+          nock.cleanAll();
+        });
+
+        it('should return with same error code', (done) => {
+          supertest(app)
+          .post('/github/user')
+          .expect(errorCode, done);
+        });
+
+        it('should return a "error" status', (done) => {
+          supertest(app)
+            .get('/github/user')
+            .expect(hasStatus('error'))
+            .end(done);
+        });
+
+        it('should return a body with a error message from GitHub', (done) => {
+          supertest(app)
+            .get('/github/user')
+            .expect(hasMessage('github-user-error', errorMessage))
+            .end(done);
+        });
+      });
+
+      context('when GitHub returns user data', () => {
+        const user = {
+          id: 1234,
+          login: 'johndoe',
+          name: 'John Doe'
+        };
+
+        beforeEach(() => {
+          scope = nock(conf.get('GITHUB_API_ENDPOINT'))
+            .get('/user')
+            .reply(200, user);
+        });
+
+        afterEach(() => {
+          nock.cleanAll();
+        });
+
+        it('should return with 200', (done) => {
+          supertest(app)
+          .get('/github/user')
+          .expect(200, done);
+        });
+
+        it('should return a "success" status', (done) => {
+          supertest(app)
+            .get('/github/user')
+            .expect(hasStatus('success'))
+            .end(done);
+        });
+
+        it('should return a body with a "github-user" code', (done) => {
+          supertest(app)
+            .get('/github/user')
+            .expect(hasMessage('github-user'))
+            .end(done);
+        });
+
+        it('should return user', (done) => {
+          supertest(app)
+            .get('/github/user')
+            .end((err, res) => {
+              expect(res.body.payload.repos).toEqual(user);
+              done(err);
+            });
+        });
+
+      });
+    });
+  });
+
   describe('list repositories route', () => {
 
     context('when user is not logged in', () => {

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -131,7 +131,7 @@ describe('The GitHub API endpoint', () => {
           supertest(app)
             .get('/github/user')
             .end((err, res) => {
-              expect(res.body.payload.repos).toEqual(user);
+              expect(res.body.payload.user).toEqual(user);
               done(err);
             });
         });

--- a/test/unit/src/common/actions/t_user.js
+++ b/test/unit/src/common/actions/t_user.js
@@ -1,0 +1,139 @@
+import expect from 'expect';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import nock from 'nock';
+import { isFSA } from 'flux-standard-action';
+
+import { conf } from '../../../../../src/server/helpers/config';
+
+import {
+  fetchUser,
+  setUser,
+  fetchUserError
+} from '../../../../../src/common/actions/user';
+import * as ActionTypes from '../../../../../src/common/actions/user';
+
+const middlewares = [ thunk ];
+const mockStore = configureMockStore(middlewares);
+
+describe('repositories actions', () => {
+  const initialState = {
+    isFetching: false,
+    success: false,
+    error: null,
+    user: null
+  };
+
+  let store;
+  let action;
+
+  beforeEach(() => {
+    store = mockStore(initialState);
+  });
+
+  context('setUser', () => {
+    let payload = {
+      login: 'johndoe',
+      name: 'John Doe'
+    };
+
+    beforeEach(() => {
+      action = setUser(payload);
+    });
+
+    it('should create an action to store user', () => {
+      const expectedAction = {
+        type: ActionTypes.SET_USER,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('fetchUserError', () => {
+    let payload = 'Something went wrong!';
+
+    beforeEach(() => {
+      action = fetchUserError(payload);
+    });
+
+    it('should create an action to store request error on failure', () => {
+      const expectedAction = {
+        type: ActionTypes.FETCH_USER_ERROR,
+        error: true,
+        payload
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should create a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('fetchUser', () => {
+    let api;
+
+    beforeEach(() => {
+      api = nock(conf.get('BASE_URL'));
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    context('when user data successfully retrieved', () => {
+      beforeEach(() => {
+        api.get('/api/github/user')
+          .reply(200, {
+            status: 'success',
+            payload: {
+              code: 'github-user',
+              user: { login: 'johndoe' }
+            }
+          });
+      });
+
+      it('should store user on fetch success', () => {
+        return store.dispatch(fetchUser())
+          .then(() => {
+            api.done();
+            expect(store.getActions()).toHaveActionOfType(
+              ActionTypes.SET_USER
+            );
+          });
+      });
+
+    });
+
+    it('should store error on GitHub request failure', () => {
+
+      api.get('/api/github/user')
+        .reply(404, {
+          status: 'error',
+          payload: {
+            code: 'gh-error',
+            message: 'Something went wrong'
+          }
+        });
+
+      return store.dispatch(fetchUser())
+        .then(() => {
+          api.done();
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.FETCH_USER_ERROR
+          );
+        });
+    });
+
+  });
+
+});

--- a/test/unit/src/common/reducers/t_user.js
+++ b/test/unit/src/common/reducers/t_user.js
@@ -1,0 +1,89 @@
+import expect from 'expect';
+
+import { user } from '../../../../../src/common/reducers/user';
+import * as ActionTypes from '../../../../../src/common/actions/user';
+
+describe('user reducers', () => {
+  const initialState = {
+    isFetching: false,
+    success: false,
+    error: null,
+    user: null,
+  };
+
+  const USER = {
+    login: 'johndoe',
+    name: 'John Doe',
+  };
+
+  it('should return the initial state', () => {
+    expect(user(undefined, {})).toEqual(initialState);
+  });
+
+  context('FETCH_SNAPS', () => {
+    const action = {
+      type: ActionTypes.FETCH_USER
+    };
+
+    it('should store fetching status when fetching builds', () => {
+      expect(user(initialState, action)).toEqual({
+        ...initialState,
+        isFetching: true
+      });
+    });
+  });
+
+  context('SET_USER', () => {
+    const state = {
+      ...initialState,
+      isFetching: true,
+      error: 'Previous error'
+    };
+
+    const action = {
+      type: ActionTypes.SET_USER,
+      payload: USER
+    };
+
+    it('should stop fetching', () => {
+      expect(user(state, action).isFetching).toBe(false);
+    });
+
+    it('should store success state', () => {
+      expect(user(state, action).success).toBe(true);
+    });
+
+    it('should clean error', () => {
+      expect(user(state, action).error).toBe(null);
+    });
+
+    it('should store user data', () => {
+      expect(user(state, action).user).toEqual(USER);
+    });
+  });
+
+
+  context('FETCH_USER_ERROR', () => {
+    const state = {
+      ...initialState,
+      success: true,
+      repos: USER,
+      isFetching: true
+    };
+
+    const action = {
+      type: ActionTypes.FETCH_USER_ERROR,
+      payload: 'Something went wrong!',
+      error: true
+    };
+
+    it('should handle fetch failure', () => {
+      expect(user(state, action)).toEqual({
+        ...state,
+        isFetching: false,
+        success: false,
+        error: action.payload
+      });
+    });
+  });
+});


### PR DESCRIPTION
API route and redux actions/reducer to fetch current user data from GH.

GH OAuth verify only sends token, not any other user info, so we need to fetch it from API.
It's not perfect when we do it from client side, because it means we know user is authenticated (from session) but still have to wait for user data API call.

I guess other option would be to do the API call on server side (in verify handler), and keep user data in session once we get it from GH (and only then redirect back to app, with user data injected into state).