### PR TITLE
Fix incorrect PropTypes in Header

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -33,7 +33,7 @@ export default class Header extends Component {
 
 Header.propTypes = {
   authenticated: PropTypes.bool,
-  user: PropTypes.object({
+  user: PropTypes.shape({
     login: PropTypes.string,
     name: PropTypes.string
   })


### PR DESCRIPTION
Declaring an object with a particular shape is done using
`PropTypes.shape`, not `PropTypes.object`.