### PR TITLE
Explicitly inject NODE_ENV=development in webpack

### DIFF
--- a/webpack/dev-config.js
+++ b/webpack/dev-config.js
@@ -28,7 +28,12 @@ module.exports = {
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new ExtractTextPlugin('style.css', { allChunks: true }),
-    new AssetsPlugin()
+    new AssetsPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify('development')
+      }
+    })
   ],
   module: {
     // https://github.com/localForage/localForage/issues/577


### PR DESCRIPTION
Doing this explicitly in the development config results in many fewer
errors in the browser console, which makes it easier to spot real
problems.