### PR TITLE
Add actions for checking store sign-in

### DIFF
--- a/src/common/reducers/auth-store.js
+++ b/src/common/reducers/auth-store.js
@@ -3,7 +3,7 @@ import * as ActionTypes from '../actions/auth-store';
 export function authStore(state = {
   isFetching: false,
   hasDischarge: false,
-  authenticated: false,
+  authenticated: null,
   error: null
 }, action) {
   switch (action.type) {
@@ -43,6 +43,25 @@ export function authStore(state = {
         ...state,
         isFetching: false,
         hasDischarge: false,
+        error: action.payload
+      };
+    case ActionTypes.CHECK_SIGNED_INTO_STORE:
+      return {
+        ...state,
+        isFetching: true
+      };
+    case ActionTypes.CHECK_SIGNED_INTO_STORE_SUCCESS:
+      return {
+        ...state,
+        isFetching: false,
+        authenticated: action.payload,
+        error: null
+      };
+    case ActionTypes.CHECK_SIGNED_INTO_STORE_ERROR:
+      return {
+        ...state,
+        isFetching: false,
+        authenticated: false,
         error: action.payload
       };
     default:

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -48,7 +48,12 @@ export function makeLocalForageStub() {
       return new Promise((resolve) => setTimeout(resolve, 1))
         .then(() => {
           if (key in store) {
-            return store[key];
+            const value = store[key];
+            if (value instanceof Error) {
+              throw value;
+            } else {
+              return value;
+            }
           } else {
             return null;
           }

--- a/test/unit/src/common/reducers/t_auth-store.js
+++ b/test/unit/src/common/reducers/t_auth-store.js
@@ -7,7 +7,7 @@ describe('authStore reducers', () => {
   const initialState = {
     isFetching: false,
     hasDischarge: false,
-    authenticated: false,
+    authenticated: null,
     error: null
   };
 
@@ -52,6 +52,77 @@ describe('authStore reducers', () => {
     };
     const action = {
       type: ActionTypes.GET_SSO_DISCHARGE_ERROR,
+      payload: 'Something went wrong!',
+      error: true
+    };
+
+    it('clears fetching status', () => {
+      expect(authStore(state, action).isFetching).toBe(false);
+    });
+
+    it('clears has-discharge status', () => {
+      expect(authStore(state, action).hasDischarge).toBe(false);
+    });
+
+    it('stores error', () => {
+      expect(authStore(state, action).error).toEqual(action.payload);
+    });
+  });
+
+  context('CHECK_SIGNED_INTO_STORE', () => {
+    it('sets fetching status', () => {
+      const action = { type: ActionTypes.CHECK_SIGNED_INTO_STORE };
+      expect(authStore(initialState, action)).toEqual({
+        ...initialState,
+        isFetching: true
+      });
+    });
+  });
+
+  context('CHECK_SIGNED_INTO_STORE_SUCCESS', () => {
+    const state = {
+      ...initialState,
+      isFetching: true
+    };
+
+    context('if not authenticated', () => {
+      const action = {
+        type: ActionTypes.CHECK_SIGNED_INTO_STORE_SUCCESS,
+        payload: false
+      };
+
+      it('clears fetching status', () => {
+        expect(authStore(state, action).isFetching).toBe(false);
+      });
+
+      it('clears authenticated status', () => {
+        expect(authStore(state, action).authenticated).toBe(false);
+      });
+    });
+
+    context('if authenticated', () => {
+      const action = {
+        type: ActionTypes.CHECK_SIGNED_INTO_STORE_SUCCESS,
+        payload: true
+      };
+
+      it('clears fetching status', () => {
+        expect(authStore(state, action).isFetching).toBe(false);
+      });
+
+      it('sets authenticated status', () => {
+        expect(authStore(state, action).authenticated).toBe(true);
+      });
+    });
+  });
+
+  context('CHECK_SIGNED_INTO_STORE_ERROR', () => {
+    const state = {
+      ...initialState,
+      isFetching: true
+    };
+    const action = {
+      type: ActionTypes.CHECK_SIGNED_INTO_STORE_ERROR,
       payload: 'Something went wrong!',
       error: true
     };


### PR DESCRIPTION
We need to be able to check whether the user is already signed into the
store; the existing actions only arrange to set authStore.authenticated
on the first page load.  These new actions check local storage for
existing macaroons.

We should check the expires caveat on existing macaroons; this is
compounded by us not yet clearing local storage when the user signs out
(#125).  In the short term a workaround is to delete entries from
storage manually using devtools.