### PR TITLE
Use package_upload_request macaroons for authz

### DIFF
--- a/src/common/reducers/repositories-status.js
+++ b/src/common/reducers/repositories-status.js
@@ -5,10 +5,13 @@ export function repositoriesStatus(state = {}, action) {
 
   const initialStatus = {
     isFetching: false,
+    success: false,
     error: null
   };
 
   switch(action.type) {
+    case ActionTypes.CREATE_SNAPS_START:
+      return {};
     case ActionTypes.CREATE_SNAP:
       return {
         ...state,
@@ -18,11 +21,21 @@ export function repositoriesStatus(state = {}, action) {
           isFetching: true
         }
       };
+    case ActionTypes.CREATE_SNAP_SUCCESS:
+      return {
+        ...state,
+        [payload.id]: {
+          ...state[payload.id],
+          isFetching: false,
+          success: true,
+          error: null
+        }
+      };
     case ActionTypes.CREATE_SNAP_ERROR:
       return {
         ...state,
         [payload.id]: {
-          ... state[payload.id],
+          ...state[payload.id],
           isFetching: false,
           success: false,
           error: payload.error

--- a/test/unit/src/common/actions/t_create-snap.js
+++ b/test/unit/src/common/actions/t_create-snap.js
@@ -1,17 +1,26 @@
 import expect from 'expect';
+import { isFSA } from 'flux-standard-action';
+import nock from 'nock';
+import { MacaroonsBuilder } from 'macaroons.js';
+import proxyquire from 'proxyquire';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import nock from 'nock';
-import { isFSA } from 'flux-standard-action';
-import url from 'url';
 
-import {
+import { conf } from '../../../../../src/common/helpers/config';
+import { makeLocalForageStub } from '../../../../helpers';
+
+const localForageStub = makeLocalForageStub();
+const createSnapModule = proxyquire.noCallThru().load(
+  '../../../../../src/common/actions/create-snap',
+  { 'localforage': localForageStub }
+);
+const {
   createSnaps,
   createSnapError,
+  createSnapSuccess,
   setGitHubRepository
-} from '../../../../../src/common/actions/create-snap';
-import * as ActionTypes from '../../../../../src/common/actions/create-snap';
-import { conf } from '../../../../../src/common/helpers/config';
+} = createSnapModule;
+const ActionTypes = createSnapModule;
 
 const middlewares = [ thunk ];
 const mockStore = configureMockStore(middlewares);
@@ -33,6 +42,10 @@ describe('repository input actions', () => {
 
   beforeEach(() => {
     store = mockStore(initialState);
+  });
+
+  afterEach(() => {
+    localForageStub.clear();
   });
 
   context('setGitHubRepository', () => {
@@ -75,45 +88,17 @@ describe('repository input actions', () => {
       nock.cleanAll();
     });
 
-    it('redirects to /login/authenticate on successful creation', () => {
-      scope.get('/api/github/snapcraft-yaml/foo/bar')
-        .reply(200, {
-          status: 'success',
-          payload: {
-            code: 'snapcraft-yaml-found',
-            contents: { name: 'test-snap' }
-          }
-        });
-      scope
-        .post('/api/launchpad/snaps', {
-          repository_url: repository.url,
-          snap_name: 'test-snap',
-          series: '16',
-          channels: ['edge']
-        })
-        .reply(201, {
-          status: 'success',
-          payload: {
-            code: 'snap-created',
-            message: 'dummy-caveat'
-          }
-        });
-
-      const location = {};
-      return store.dispatch(createSnaps([ repository ], location))
+    it('stores a CREATE_SNAPS_START action', () => {
+      return store.dispatch(createSnaps([ repository ]))
         .then(() => {
-          expect(url.parse(location.href, true)).toMatch({
-            path: '/login/authenticate',
-            query: {
-              starting_url: '/foo/bar/setup',
-              caveat_id: 'dummy-caveat'
-            }
-          });
+          expect(store.getActions()).toHaveActionOfType(
+            ActionTypes.CREATE_SNAPS_START
+          );
         });
     });
 
-    it('stores an error on failure', () => {
-      scope.post('/api/launchpad/snaps')
+    it('stores an error on failure to get snap name', () => {
+      scope.get('/api/github/snapcraft-yaml/foo/bar')
         .reply(400, {
           status: 'error',
           payload: {
@@ -122,14 +107,193 @@ describe('repository input actions', () => {
           }
         });
 
-      const location = {};
-      return store.dispatch(createSnaps([ repository ], location))
+      return store.dispatch(createSnaps([ repository ]))
         .then(() => {
-          expect(location).toExcludeKey('href');
-          expect(store.getActions()).toHaveActionOfType(
-            ActionTypes.CREATE_SNAP_ERROR
-          );
+          const errorAction = store.getActions().filter((action) => {
+            return action.type === ActionTypes.CREATE_SNAP_ERROR;
+          })[0];
+          expect(errorAction.payload.id).toBe('foo/bar');
+          expect(errorAction.payload.error.json.payload).toEqual({
+            code: 'snapcraft-yaml-no-name',
+            message: 'snapcraft.yaml has no top-level "name" attribute'
+          });
         });
+    });
+
+    context('if getting snap name succeeds', () => {
+      let storeScope;
+      let rootMacaroon;
+      let dischargeMacaroon;
+
+      beforeEach(() => {
+        scope.get('/api/github/snapcraft-yaml/foo/bar')
+          .reply(200, {
+            status: 'success',
+            payload: {
+              code: 'snapcraft-yaml-found',
+              contents: { name: 'test-snap' }
+            }
+          });
+        storeScope = nock(conf.get('STORE_API_URL'));
+        rootMacaroon = new MacaroonsBuilder('sca', 'key', 'id')
+          .add_third_party_caveat('sso', '3p key', 'sso id')
+          .getMacaroon();
+        dischargeMacaroon = new MacaroonsBuilder('sso', '3p key', 'sso id')
+          .getMacaroon();
+        localForageStub.store['package_upload_request'] = {
+          root: rootMacaroon.serialize(),
+          discharge: dischargeMacaroon.serialize()
+        };
+      });
+
+      it('stores an error on failure to get package upload macaroon', () => {
+        storeScope
+          .post('/acl/', {
+            packages: [{ name: 'test-snap', series: '16' }],
+            permissions: ['package_upload'],
+            channels: ['edge']
+          })
+          .reply(404, {
+            status: 404,
+            error_code: 'resource-not-found'
+          });
+
+        return store.dispatch(createSnaps([ repository ]))
+          .then(() => {
+            const errorAction = store.getActions().filter((action) => {
+              return action.type === ActionTypes.CREATE_SNAP_ERROR;
+            })[0];
+            expect(errorAction.payload.id).toBe('foo/bar');
+            expect(errorAction.payload.error.json.payload).toEqual({
+              code: 'snap-name-not-registered',
+              message: 'Snap name is not registered in the store',
+              snap_name: 'test-snap'
+            });
+          });
+      });
+
+      context('if getting package upload macaroon succeeds', () => {
+        beforeEach(() => {
+          // XXX check headers and body
+          storeScope.post('/acl/')
+            .reply(200, { macaroon: 'dummy-package-upload-macaroon' });
+        });
+
+        it('stores an error on failure to create snap', () => {
+          scope
+            .post('/api/launchpad/snaps', {
+              repository_url: repository.url,
+              snap_name: 'test-snap',
+              series: '16',
+              channels: ['edge']
+            })
+            .reply(400, {
+              status: 'error',
+              payload: {
+                'code': 'not-logged-in',
+                'message': 'Not logged in'
+              }
+            });
+
+          return store.dispatch(createSnaps([ repository ]))
+            .then(() => {
+              const errorAction = store.getActions().filter((action) => {
+                return action.type === ActionTypes.CREATE_SNAP_ERROR;
+              })[0];
+              expect(errorAction.payload.id).toBe('foo/bar');
+              expect(errorAction.payload.error.json.payload).toEqual({
+                code: 'not-logged-in',
+                message: 'Not logged in',
+              });
+            });
+        });
+
+        context('if creating snap succeeds', () => {
+          beforeEach(() => {
+            scope
+              .post('/api/launchpad/snaps', {
+                repository_url: repository.url,
+                snap_name: 'test-snap',
+                series: '16',
+                channels: ['edge']
+              })
+              .reply(201, {
+                status: 'success',
+                payload: {
+                  code: 'snap-created',
+                  message: 'dummy-caveat'
+                }
+              });
+          });
+
+          it('stores an error on failure to authorize snap', () => {
+            scope
+              .post('/api/launchpad/snaps/authorize', {
+                repository_url: repository.url,
+                macaroon: 'dummy-package-upload-macaroon'
+              })
+              .reply(400, {
+                status: 'error',
+                payload: {
+                  code: 'not-logged-in',
+                  message: 'Not logged in'
+                }
+              });
+
+            return store.dispatch(createSnaps([ repository ]))
+              .then(() => {
+                const errorAction = store.getActions().filter((action) => {
+                  return action.type === ActionTypes.CREATE_SNAP_ERROR;
+                })[0];
+                expect(errorAction.payload.id).toBe('foo/bar');
+                expect(errorAction.payload.error.json.payload).toEqual({
+                  'code': 'not-logged-in',
+                  'message': 'Not logged in'
+                });
+              });
+          });
+
+          it('creates success action on successful creation', () => {
+            scope
+              .post('/api/launchpad/snaps/authorize', {
+                repository_url: repository.url,
+                macaroon: 'dummy-package-upload-macaroon'
+              })
+              .reply(204);
+
+            const expectedAction = {
+              type: ActionTypes.CREATE_SNAP_SUCCESS,
+              payload: { id: 'foo/bar' }
+            };
+            return store.dispatch(createSnaps([ repository ]))
+              .then(() => {
+                expect(store.getActions()).toInclude(expectedAction);
+              });
+          });
+        });
+      });
+    });
+  });
+
+  context('createSnapSuccess', () => {
+    let id = 'foo/bar';
+
+    beforeEach(() => {
+      action = createSnapSuccess(id);
+    });
+
+    it('creates an action to store success', () => {
+      const expectedAction = {
+        type: ActionTypes.CREATE_SNAP_SUCCESS,
+        payload: { id }
+      };
+
+      store.dispatch(action);
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('creates a valid flux standard action', () => {
+      expect(isFSA(action)).toBe(true);
     });
   });
 

--- a/test/unit/src/common/reducers/t_repositories-status.js
+++ b/test/unit/src/common/reducers/t_repositories-status.js
@@ -8,6 +8,7 @@ describe('repositoriesStatus reducers', () => {
 
   const initialStatus = {
     isFetching: false,
+    success: false,
     error: null
   };
 
@@ -17,8 +18,21 @@ describe('repositoriesStatus reducers', () => {
     expect(repositoriesStatus(undefined, {})).toEqual(initialState);
   });
 
+  context('CREATE_SNAPS_START', () => {
+    it('clears out any existing state', () => {
+      const state = {
+        ...initialState,
+        [id]: initialStatus
+      };
+
+      const action = { type: ActionTypes.CREATE_SNAPS_START };
+
+      expect(repositoriesStatus(state, action)).toEqual({});
+    });
+  });
+
   context('CREATE_SNAP', () => {
-    it('stores fetching status when repository is being created', () => {
+    it('stores fetching status when snap is being created', () => {
       const action = {
         type: ActionTypes.CREATE_SNAP,
         payload: { id }
@@ -31,11 +45,39 @@ describe('repositoriesStatus reducers', () => {
     });
   });
 
+  context('CREATE_SNAP_SUCCESS', () => {
+    it('handles snap creation success', () => {
+      const state = {
+        ...initialState,
+        [id]: {
+          ...initialStatus,
+          isFetching: true
+        }
+      };
+
+      const action = {
+        type: ActionTypes.CREATE_SNAP_SUCCESS,
+        payload: { id },
+        error: true
+      };
+
+      expect(repositoriesStatus(state, action)[id]).toEqual({
+        ...state[id],
+        isFetching: false,
+        success: true,
+        error: null
+      });
+    });
+  });
+
   context('CREATE_SNAP_ERROR', () => {
     it('handles snap creation failure', () => {
       const state = {
         ...initialState,
-        isFetching: true
+        [id]: {
+          ...initialStatus,
+          isFetching: true
+        }
       };
 
       const action = {
@@ -48,7 +90,7 @@ describe('repositoriesStatus reducers', () => {
       };
 
       expect(repositoriesStatus(state, action)[id]).toEqual({
-        ...state,
+        ...state[id],
         isFetching: false,
         success: false,
         error: action.payload.error


### PR DESCRIPTION
Creating snaps now requires being "signed into the store", which equates
to having a discharged package_upload_request macaroon in local storage.
For each snap to be created, we request a specific non-expiring
package_upload macaroon for it and tell the backend to store that in
Launchpad.  This allows batch-creation of snaps, and avoids a round-trip
through SSO per snap.

This leaves some unused endpoints around, but this PR is already large
enough; they can be cleaned up later.

The UI is pretty weak in places, but this should be enough to unblock other development (in particular, the `package_upload_request` macaroon can be reused for registering a snap name, after lifting up the `authStore` state to some suitable common ancestor component, and it should now be possible to put the rest of the dashboard workflow in place).

This cannot be landed until SCA >= r3802 is deployed to production.