### PR TITLE
allow setting secure cookies to false

### DIFF
--- a/src/server/helpers/session.js
+++ b/src/server/helpers/session.js
@@ -9,6 +9,7 @@ const SESSION_DEFAULTS = {
   name : 'sessionId',
   cookie: {
     maxAge: 2 * 60 * 60 * 1000, // 2 hours, macaroon life span
+    secure: false
   },
   resave: false,
   saveUninitialized: false
@@ -17,7 +18,8 @@ const SESSION_DEFAULTS = {
 export default function sessionStorageConfig(config) {
   let settings = { ...SESSION_DEFAULTS };
 
-  if (config.get('COOKIE_SECURE')) {
+  if (config.get('COOKIE_SECURE') === 'true') {
+    logger.info('Setting secure cookies, ensure https.');
     settings.cookie.secure = true;
   }
 


### PR DESCRIPTION
I got stuck in a sso loop, I've added a bug for part of it (can't see login/failed #133), but this I think fixes the loop bit (cookies not being set in http, therefore you are simply redirected to sso for all eternity) ... and now I've pushed I see why no-one else sees this, because they don't have `COOKIE_SECURE` in the env file _at all_ whereas I have it as `false`