### PR TITLE
Add babel-polyfill to production bundle build

### DIFF
--- a/webpack/build-config.js
+++ b/webpack/build-config.js
@@ -12,6 +12,7 @@ const sharedVars = require('../src/common/style/variables');
 module.exports = {
   context: path.resolve(__dirname, '..'),
   entry: [
+    'babel-polyfill',
     './dist/common',
   ],
   output: {


### PR DESCRIPTION
We're now using ES6 generators on the client side, so we need this.