### PR TITLE
Make the authError state be consistently an object

### DIFF
--- a/src/common/reducers/auth-error.js
+++ b/src/common/reducers/auth-error.js
@@ -1,9 +1,12 @@
 import { AUTH_ERROR } from '../actions/auth-error';
 
-export function authError(state = [], action) {
+export function authError(state = {}, action) {
   switch (action.type) {
     case AUTH_ERROR:
-      return [...state, { message: action.message }];
+      return {
+        ...state,
+        message: action.message
+      };
     default:
       return state;
   }

--- a/test/unit/src/common/reducers/t_auth-error.js
+++ b/test/unit/src/common/reducers/t_auth-error.js
@@ -1,0 +1,25 @@
+import expect from 'expect';
+
+import { authError } from '../../../../../src/common/reducers/auth-error';
+import * as ActionTypes from '../../../../../src/common/actions/auth-error';
+
+describe('authError reducer', () => {
+  const initialState = {};
+
+  it('returns the initial state', () => {
+    expect(authError(undefined, {})).toEqual(initialState);
+  });
+
+  context('AUTH_ERROR', () => {
+    it('stores the error', () => {
+      const action = {
+        type: ActionTypes.AUTH_ERROR,
+        message: 'Something went wrong'
+      };
+
+      expect(authError(initialState, action)).toEqual({
+        message: 'Something went wrong'
+      });
+    });
+  });
+});


### PR DESCRIPTION
Otherwise we get this when navigating directly to `/login/failed`
(though not when being sent there due to an error, since `handleMatch`
sets `authError` to an object in the initial state):

    Warning: Failed prop type: Invalid prop `authError` of type `array`
    supplied to `LoginFailed`, expected `object`.
        in LoginFailed (created by Connect(LoginFailed))
        in Connect(LoginFailed) (created by RouterContext)
        in div (created by App)
        in App (created by Connect(App))
        in Connect(App) (created by RouterContext)
        in RouterContext
        in Provider (created by Html)