### PR TITLE
Added brand, workflow and snap sections with placeholder images

### DIFF
--- a/src/common/components/footer/footer.css
+++ b/src/common/components/footer/footer.css
@@ -7,7 +7,7 @@ html {
 }
 
 body {
-  margin-bottom: 75px;
+  margin-bottom: 135px;
 }
 
 .footer {

--- a/src/common/containers/container.css
+++ b/src/common/containers/container.css
@@ -2,11 +2,12 @@
   box-sizing: border-box;
   max-width: 940px;
   margin: 0 auto;
-  padding: 10px;
+  padding: 0 10px;
 }
 
 .container {
   composes: wrapper;
+  padding: 10px;
   margin-bottom: 60px;
 }
 

--- a/src/common/containers/landing.css
+++ b/src/common/containers/landing.css
@@ -55,8 +55,21 @@
   flex-grow: 1;
 }
 
+.rowItemTwoThirds {
+  composes: rowItem;
+  width: 66.66%;
+}
+
 .section {
   padding-top: 60px;
   padding-bottom: 60px;
   border-bottom: 1px dotted $dark-grey;
+}
+
+.section:last-child {
+  border-bottom: none;
+}
+
+.snaps {
+  margin-bottom: 2em;
 }

--- a/src/common/containers/landing.css
+++ b/src/common/containers/landing.css
@@ -27,20 +27,36 @@
   transform: translate(-50%,50%);
 }
 
+.workflowImage {
+  display: block;
+  max-width: 100%;
+  margin-bottom: 60px;
+}
+
+.centeredButton {
+  text-align: center;
+}
+
 .row {
   display: flex;
+  justify-content: space-between;
 }
 
 .rowItem {
   margin-left: 20px;
-  flex-grow: 1;
 }
 
 .rowItem:first-child {
   margin-left: 0;
 }
 
+.rowItemGrow {
+  composes: rowItem;
+  flex-grow: 1;
+}
+
 .section {
-  padding: 80px 60px;
+  padding-top: 60px;
+  padding-bottom: 60px;
   border-bottom: 1px dotted $dark-grey;
 }

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -43,13 +43,13 @@ class Landing extends Component {
 
         <section className={styles.section}>
           <div className={ `${styles.row} ${containerStyles.wrapper}` }>
-            <ListDividedState className={ styles.rowItem }>
+            <ListDividedState className={ styles.rowItemGrow }>
               <li>Scale to millions of installs</li>
               <li>Available on all clouds and Linux OSes</li>
               <li>No need for build infrastructure</li>
             </ListDividedState>
 
-            <ListDividedState className={ styles.rowItem }>
+            <ListDividedState className={ styles.rowItemGrow }>
               <li>Automatic updates for everyone</li>
               <li>Roll back versions effortlessly</li>
               <li>FREE for open source projects</li>
@@ -57,9 +57,27 @@ class Landing extends Component {
           </div>
         </section>
 
+        <section className={styles.section}>
+          <div className={ `${styles.row} ${containerStyles.wrapper}` }>
+            {/* TODO put in actual logos */}
+            <img className={ styles.rowItem } src='http://placehold.it/180x130?text=BRAND+LOGO' />
+            <img className={ styles.rowItem } src='http://placehold.it/180x130?text=BRAND+LOGO' />
+            <img className={ styles.rowItem } src='http://placehold.it/180x130?text=BRAND+LOGO' />
+            <img className={ styles.rowItem } src='http://placehold.it/180x130?text=BRAND+LOGO' />
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className={containerStyles.wrapper}>
+            {/* TODO put in actual workflow image */}
+            <img className={ styles.workflowImage} src='http://placehold.it/920x480?text=WORKFLOW' />
+            <div className={ styles.centeredButton }>
+              <Anchor  href="/auth/authenticate">Get Started Now</Anchor>
+            </div>
+          </div>
+        </section>
+
         <div className={styles.container}>
-          {/* TODO brand logos */}
-          {/* TODO workflow */}
 
           <div>
             <p>Snaps are secure, sandboxed, containerised applications, packaged with their dependencies for predictable behavior. With the Snap Store, people can safely install apps from any vendor on mission-critical devices and PCs.</p>

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -83,7 +83,7 @@ class Landing extends Component {
 
             <div className={styles.rowItemTwoThirds}>
               <p className={styles.snaps}>Snaps are secure, sandboxed, containerised applications, packaged with their dependencies for predictable behavior. With the Snap Store, people can safely install apps from any vendor on mission-critical devices and PCs.</p>
-              <Anchor href="http://snapcraft.io">More about snaps</Anchor>
+              <Anchor href="https://snapcraft.io">More about snaps</Anchor>
             </div>
 
             <img className={ styles.rowItem } src='http://placehold.it/200x200?text=SNAP' />

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -77,15 +77,20 @@ class Landing extends Component {
           </div>
         </section>
 
-        <div className={styles.container}>
+        <section className={styles.section}>
+          <div className={ `${styles.row} ${containerStyles.wrapper}` }>
 
-          <div>
-            <p>Snaps are secure, sandboxed, containerised applications, packaged with their dependencies for predictable behavior. With the Snap Store, people can safely install apps from any vendor on mission-critical devices and PCs.</p>
-            <Anchor href="http://snapcraft.io">More about snaps</Anchor>
+
+            <div className={styles.rowItemTwoThirds}>
+              <p className={styles.snaps}>Snaps are secure, sandboxed, containerised applications, packaged with their dependencies for predictable behavior. With the Snap Store, people can safely install apps from any vendor on mission-critical devices and PCs.</p>
+              <Anchor href="http://snapcraft.io">More about snaps</Anchor>
+            </div>
+
+            <img className={ styles.rowItem } src='http://placehold.it/200x200?text=SNAP' />
           </div>
+        </section>
 
-          {/* TODO testimonials */}
-        </div>
+        {/* TODO testimonials */}
       </div>
     );
   }


### PR DESCRIPTION
<img width="1049" alt="screen shot 2017-02-15 at 13 23 43" src="https://cloud.githubusercontent.com/assets/83575/22974612/7549422c-f383-11e6-824a-27ba50fd7cab.png">

Also included bottom section about snap (and footer fixes):

<img width="1032" alt="screen shot 2017-02-15 at 15 11 57" src="https://cloud.githubusercontent.com/assets/83575/22978008/35bf6772-f391-11e6-9ee2-d9197600110e.png">
