### PR TITLE
Storing builds for multiple repositories in redux store

### DIFF
--- a/src/common/components/build-history/index.js
+++ b/src/common/components/build-history/index.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 
+import { snapBuildsInitialStatus } from '../../reducers/snap-builds';
 import BuildRow from '../build-row';
 import { Message } from '../forms';
 
@@ -29,15 +30,19 @@ export const BuildHistory = (props) => {
 BuildHistory.propTypes = {
   repository: PropTypes.shape({
     owner: PropTypes.string,
-    name: PropTypes.string
+    name: PropTypes.string,
+    fullName: PropTypes.string
   }),
   success: PropTypes.bool,
   builds: React.PropTypes.arrayOf(React.PropTypes.object)
 };
 
-function mapStateToProps(state) {
-  const builds = state.snapBuilds.builds;
-  const success = state.snapBuilds.success;
+function mapStateToProps(state, ownProps) {
+  const { fullName } = ownProps.repository;
+
+  // get builds for given repo from the store or set default empty values
+  const repoBuilds = state.snapBuilds[fullName] || snapBuildsInitialStatus;
+  const { builds, success } = repoBuilds;
 
   return {
     builds,

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -8,6 +8,7 @@ import { Message } from '../components/forms';
 
 import withRepository from './with-repository';
 import { fetchBuilds, fetchSnap } from '../actions/snap-builds';
+import { snapBuildsInitialStatus } from '../reducers/snap-builds';
 
 import styles from './container.css';
 
@@ -15,7 +16,7 @@ class BuildDetails extends Component {
 
   fetchData({ snapLink, repository }) {
     if (snapLink) {
-      this.props.dispatch(fetchBuilds(snapLink));
+      this.props.dispatch(fetchBuilds(repository.url, snapLink));
     } else if (repository) {
       this.props.dispatch(fetchSnap(repository.url));
     }
@@ -87,10 +88,13 @@ const mapStateToProps = (state, ownProps) => {
 
   const buildId = ownProps.params.buildId.toLowerCase();
 
-  const build = state.snapBuilds.builds.filter((build) => build.buildId === buildId)[0];
-  const isFetching = state.snapBuilds.isFetching;
-  const error = state.snapBuilds.error;
-  const snapLink = state.snapBuilds.snapLink;
+  // get builds for given repo from the store or set default empty values
+  const repoBuilds = state.snapBuilds[fullName] || snapBuildsInitialStatus;
+
+  const build = repoBuilds.builds.filter((build) => build.buildId === buildId)[0];
+  const isFetching = repoBuilds.isFetching;
+  const error = repoBuilds.error;
+  const snapLink = repoBuilds.snapLink;
 
   return {
     fullName,

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -8,6 +8,7 @@ import Spinner from '../components/spinner';
 
 import withRepository from './with-repository';
 import { fetchBuilds, fetchSnap } from '../actions/snap-builds';
+import { snapBuildsInitialStatus } from '../reducers/snap-builds';
 
 import styles from './container.css';
 
@@ -16,7 +17,7 @@ class Builds extends Component {
 
   fetchData({ snapLink, repository }) {
     if (snapLink) {
-      this.props.dispatch(fetchBuilds(snapLink));
+      this.props.dispatch(fetchBuilds(repository.url, snapLink));
     } else if (repository) {
       this.props.dispatch(fetchSnap(repository.url));
     }
@@ -89,11 +90,13 @@ const mapStateToProps = (state, ownProps) => {
   const name = ownProps.params.name.toLowerCase();
   const fullName = `${owner}/${name}`;
   const repository = state.repository;
+  // get builds for given repo from the store or set default empty values
+  const repoBuilds = state.snapBuilds[fullName] || snapBuildsInitialStatus;
 
   return {
     fullName,
     repository,
-    ...state.snapBuilds
+    ...repoBuilds
   };
 };
 

--- a/src/common/containers/repository-setup.js
+++ b/src/common/containers/repository-setup.js
@@ -6,6 +6,7 @@ import { withRouter } from 'react-router';
 import { createWebhook } from '../actions/webhook';
 import { requestBuilds } from '../actions/snap-builds';
 import withRepository from './with-repository';
+import { snapBuildsInitialStatus } from '../reducers/snap-builds';
 
 import { Message } from '../components/forms';
 import Spinner from '../components/spinner';
@@ -93,7 +94,8 @@ const mapStateToProps = (state, ownProps) => {
     fullName,
     repository: state.repository,
     webhook: state.webhook,
-    builds: state.snapBuilds
+    // get builds for given repo from the store or set default empty values
+    builds: state.snapBuilds[fullName] || snapBuildsInitialStatus
   };
 };
 

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -1,39 +1,58 @@
 import * as ActionTypes from '../actions/snap-builds';
 import { snapBuildFromAPI } from '../helpers/snap-builds';
 
-export function snapBuilds(state = {
+export const snapBuildsInitialStatus = {
   isFetching: false,
   snapLink: null,
   builds: [],
   success: false,
   error: null
-}, action) {
+};
+
+export function snapBuilds(state = {}, action) {
+  const { payload } = action;
+
+  const initialStatus = snapBuildsInitialStatus;
+
   switch(action.type) {
     case ActionTypes.FETCH_BUILDS:
       return {
         ...state,
-        isFetching: true
+        [payload.id]: {
+          ...initialStatus,
+          ...state[payload.id],
+          isFetching: true
+        }
       };
     case ActionTypes.FETCH_SNAP_SUCCESS:
       return {
         ...state,
-        isFetching: false,
-        snapLink: action.payload
+        [payload.id]: {
+          ...state[payload.id],
+          isFetching: false,
+          snapLink: payload.snapLink
+        }
       };
     case ActionTypes.FETCH_BUILDS_SUCCESS:
       return {
         ...state,
-        isFetching: false,
-        success: true,
-        builds: action.payload.map(snapBuildFromAPI),
-        error: null
+        [payload.id]: {
+          ...state[payload.id],
+          isFetching: false,
+          success: true,
+          builds: payload.builds.map(snapBuildFromAPI),
+          error: null
+        }
       };
     case ActionTypes.FETCH_BUILDS_ERROR:
       return {
         ...state,
-        isFetching: false,
-        success: false,
-        error: action.payload
+        [payload.id]: {
+          ...state[payload.id],
+          isFetching: false,
+          success: false,
+          error: payload.error
+        }
       };
     default:
       return state;

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -19,31 +19,30 @@ const middlewares = [ thunk ];
 const mockStore = configureMockStore(middlewares);
 
 describe('snap builds actions', () => {
-  const initialState = {
-    isFetching: false,
-    snapLink: null,
-    builds: [],
-    error: false
-  };
-
   let store;
   let action;
 
+  const repo = 'dummy/repo';
+  const repositoryUrl = `https://github.com/${repo}`;
+
   beforeEach(() => {
-    store = mockStore(initialState);
+    store = mockStore({});
   });
 
   context('fetchBuildsSuccess', () => {
-    let payload = [ { build: 'test1' }, { build: 'test2' }];
+    let builds = [ { build: 'test1' }, { build: 'test2' }];
 
     beforeEach(() => {
-      action = fetchBuildsSuccess(payload);
+      action = fetchBuildsSuccess(repo, builds);
     });
 
     it('should create an action to store snap builds', () => {
       const expectedAction = {
         type: ActionTypes.FETCH_BUILDS_SUCCESS,
-        payload
+        payload: {
+          id: repo,
+          builds
+        }
       };
 
       store.dispatch(action);
@@ -56,17 +55,20 @@ describe('snap builds actions', () => {
   });
 
   context('fetchBuildsError', () => {
-    let payload = 'Something went wrong!';
+    let error = 'Something went wrong!';
 
     beforeEach(() => {
-      action = fetchBuildsError(payload);
+      action = fetchBuildsError(repo, error);
     });
 
     it('should create an action to store request error on failure', () => {
       const expectedAction = {
         type: ActionTypes.FETCH_BUILDS_ERROR,
         error: true,
-        payload
+        payload: {
+          id: repo,
+          error
+        }
       };
 
       store.dispatch(action);
@@ -102,7 +104,7 @@ describe('snap builds actions', () => {
           }
         });
 
-      return store.dispatch(fetchBuilds(snapUrl))
+      return store.dispatch(fetchBuilds(repositoryUrl, snapUrl))
         .then(() => {
           api.done();
           expect(store.getActions()).toHaveActionOfType(
@@ -124,7 +126,7 @@ describe('snap builds actions', () => {
           }
         });
 
-      return store.dispatch(fetchBuilds(barUrl))
+      return store.dispatch(fetchBuilds(repositoryUrl, barUrl))
         .then(() => {
           expect(store.getActions()).toHaveActionOfType(
             ActionTypes.FETCH_BUILDS_ERROR
@@ -187,7 +189,7 @@ describe('snap builds actions', () => {
       });
 
       it('should dispatch error action', () => {
-        return store.dispatch(fetchBuilds(barUrl))
+        return store.dispatch(fetchBuilds(repositoryUrl, barUrl))
           .then(() => {
             expect(store.getActions()).toHaveActionOfType(
               ActionTypes.FETCH_BUILDS_ERROR
@@ -196,10 +198,10 @@ describe('snap builds actions', () => {
       });
 
       it('should pass error message from repsponse to action', () => {
-        return store.dispatch(fetchBuilds(barUrl))
+        return store.dispatch(fetchBuilds(repositoryUrl, barUrl))
           .then(() => {
             const action = store.getActions().filter(a => a.type === ActionTypes.FETCH_BUILDS_ERROR)[0];
-            expect(action.payload.message).toBe('Bad snap URL');
+            expect(action.payload.error.message).toBe('Bad snap URL');
           });
       });
 
@@ -236,7 +238,7 @@ describe('snap builds actions', () => {
         return store.dispatch(fetchSnap(repositoryUrl))
           .then(() => {
             const action = store.getActions().filter(a => a.type === ActionTypes.FETCH_BUILDS_ERROR)[0];
-            expect(action.payload.message).toBe('Bad repo URL');
+            expect(action.payload.error.message).toBe('Bad repo URL');
           });
       });
 

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -1,18 +1,13 @@
 import expect from 'expect';
 
-import { snapBuilds } from '../../../../../src/common/reducers/snap-builds';
+import { snapBuilds, snapBuildsInitialStatus } from '../../../../../src/common/reducers/snap-builds';
 import * as ActionTypes from '../../../../../src/common/actions/snap-builds';
 
 import { snapBuildFromAPI } from '../../../../../src/common/helpers/snap-builds';
 
 describe('snapBuilds reducers', () => {
-  const initialState = {
-    isFetching: false,
-    snapLink: null,
-    builds: [],
-    success: false,
-    error: null
-  };
+  const initialState = {};
+  const initialStatus = snapBuildsInitialStatus;
 
   const SNAP_ENTRIES = [{
     'can_be_rescored': false,
@@ -68,6 +63,8 @@ describe('snapBuilds reducers', () => {
     'upload_log_url': null
   }];
 
+  const id = 'dummy/repo';
+
   it('should return the initial state', () => {
     expect(snapBuilds(undefined, {})).toEqual(initialState);
   });
@@ -75,12 +72,12 @@ describe('snapBuilds reducers', () => {
   context('FETCH_BUILDS', () => {
     const action = {
       type: ActionTypes.FETCH_BUILDS,
-      payload: 'test'
+      payload: { id }
     };
 
     it('should store fetching status when fetching builds', () => {
-      expect(snapBuilds(initialState, action)).toEqual({
-        ...initialState,
+      expect(snapBuilds(initialState, action)[id]).toEqual({
+        ...initialStatus,
         isFetching: true
       });
     });
@@ -91,71 +88,89 @@ describe('snapBuilds reducers', () => {
 
     const state = {
       ...initialState,
-      isFetching: true
+      [id]: {
+        ...initialStatus,
+        isFetching: true
+      }
     };
     const action = {
       type: ActionTypes.FETCH_SNAP_SUCCESS,
-      payload: SNAP_LINK
+      payload: {
+        id,
+        snapLink: SNAP_LINK
+      }
     };
 
     it('should stop fetching', () => {
-      expect(snapBuilds(state, action).isFetching).toBe(false);
+      expect(snapBuilds(state, action)[id].isFetching).toBe(false);
     });
 
     it('should store snap link', () => {
-      expect(snapBuilds(state, action).snapLink).toEqual(SNAP_LINK);
+      expect(snapBuilds(state, action)[id].snapLink).toEqual(SNAP_LINK);
     });
   });
 
   context('FETCH_BUILDS_SUCCESS', () => {
     const state = {
       ...initialState,
-      isFetching: true,
-      error: 'Previous error'
+      [id]: {
+        ...initialStatus,
+        isFetching: true,
+        error: 'Previous error'
+      }
     };
 
     const action = {
       type: ActionTypes.FETCH_BUILDS_SUCCESS,
-      payload: SNAP_ENTRIES
+      payload: {
+        id,
+        builds: SNAP_ENTRIES
+      }
     };
 
     it('should stop fetching', () => {
-      expect(snapBuilds(state, action).isFetching).toBe(false);
+      expect(snapBuilds(state, action)[id].isFetching).toBe(false);
     });
 
     it('should store builds on fetch success', () => {
-      expect(snapBuilds(state, action).builds).toEqual(SNAP_ENTRIES.map(snapBuildFromAPI));
+      expect(snapBuilds(state, action)[id].builds).toEqual(SNAP_ENTRIES.map(snapBuildFromAPI));
     });
 
     it('should store success state', () => {
-      expect(snapBuilds(state, action).success).toBe(true);
+      expect(snapBuilds(state, action)[id].success).toBe(true);
     });
 
     it('should clean error', () => {
-      expect(snapBuilds(state, action).error).toBe(null);
+      expect(snapBuilds(state, action)[id].error).toBe(null);
     });
   });
 
   context('FETCH_BUILDS_ERROR', () => {
     const state = {
       ...initialState,
-      success: true,
-      builds: SNAP_ENTRIES,
-      isFetching: true
+      [id]: {
+        ...initialStatus,
+        success: true,
+        builds: SNAP_ENTRIES,
+        isFetching: true
+      }
     };
 
     const action = {
       type: ActionTypes.FETCH_BUILDS_ERROR,
-      payload: 'Something went wrong!',
+      payload: {
+        id,
+        error: 'Something went wrong!',
+      },
       error: true
     };
 
     it('should handle fetch builds failure', () => {
-      expect(snapBuilds(state, action)).toEqual({
-        ...state,
+      expect(snapBuilds(state, action)[id]).toEqual({
+        ...state[id],
         isFetching: false,
         success: false,
-        error: action.payload
+        error: action.payload.error
       });
     });
   });


### PR DESCRIPTION
Not as elegant as I hoped, but this extends `snapBuilds` reducer to allow storing builds for many repositories (keyed by repo full name).

Updated relevant views (repository setup, builds list and build details).
Currently not connected to new dashboard.