### PR TITLE
Include snap name in /api/github/repos response

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -152,6 +152,9 @@ To get a list of repositories for current user (user needs to be authorised to G
 
 On success, returns the following where the items in `repos` are GitHub repositories as returned by [GitHub API](https://developer.github.com/v3/repos/#list-your-repositories). Pagination parameter is optional. `pageLinks` for first, previous, next and last pages are supplied if results are paginated by the GitHub API. This happens when more than 30 repositories are returned.
 
+Each repository is supplemented with a `snap_info` object which contains the
+snap name, if any.
+
     HTTP/1.1 200 OK
     Content-Type: application/json
 
@@ -171,11 +174,14 @@ On success, returns the following where the items in `repos` are GitHub reposito
           }
         ]
       },
-      pageLinks: {
-        first: 1,
-        prev: 1,
-        next: 3,
-        last: 3
+      "pageLinks": {
+        "first": 1,
+        "prev": 1,
+        "next": 3,
+        "last": 3
+      },
+      "snap_info": {
+        "name": "snap-name"
       }
     }
 

--- a/src/server/helpers/memcached.js
+++ b/src/server/helpers/memcached.js
@@ -23,20 +23,26 @@ const getInMemoryMemcachedStub = () => {
 
   memcachedStub.get = (key, callback) => {
     if (callback) {
-      runSoon(() => callback(undefined, memcachedStub.cache[key]));
+      return runSoon(() => callback(undefined, memcachedStub.cache[key]));
+    } else {
+      return Promise.resolve();
     }
   };
   memcachedStub.set = (key, value, lifetime, callback) => {
     memcachedStub.cache[key] = value;
     if (callback) {
-      runSoon(() => callback(undefined, true));
+      return runSoon(() => callback(undefined, true));
+    } else {
+      return Promise.resolve();
     }
   };
   memcachedStub.del = (key, callback) => {
     delete memcachedStub.cache[key];
 
     if (callback) {
-      runSoon(() => callback(undefined));
+      return runSoon(() => callback(undefined));
+    } else {
+      return Promise.resolve();
     }
   };
 

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -5,7 +5,13 @@ import nock from 'nock';
 import expect from 'expect';
 
 import github from '../../../../../src/server/routes/github';
+import { getSnapNameCacheId } from '../../../../../src/server/handlers/github';
 import { conf } from '../../../../../src/server/helpers/config.js';
+import {
+  getMemcached,
+  resetMemcached,
+  setupInMemoryMemcached
+} from '../../../../../src/server/helpers/memcached';
 
 describe('The GitHub API endpoint', () => {
   const app = Express();
@@ -213,12 +219,31 @@ describe('The GitHub API endpoint', () => {
       });
 
       context('when GitHub returns repositories', () => {
-        const repos = [ { name: 'repo1' }, { name: 'repo2' }];
+        const repos = [
+          {
+            full_name: 'anowner/repo1',
+            url: 'https://github.com/anowner/repo1'
+          },
+          {
+            full_name: 'anowner/repo2',
+            url: 'https://github.com/anowner/repo2'
+          },
+          {
+            full_name: 'anowner/repo3',
+            url: 'https://github.com/anowner/repo3'
+          }
+        ];
+        const contents = {
+          'https://github.com/anowner/repo1': { name: 'snap1' },
+          'https://github.com/anowner/repo2': {}
+        };
         const pageLinks = { first: 1, prev: 1, next: 3, last: 3 };
+        let contentsScopes;
 
         beforeEach(() => {
-          scope = nock(conf.get('GITHUB_API_ENDPOINT'))
-            .get('/user/repos')
+          setupInMemoryMemcached();
+          const api = nock(conf.get('GITHUB_API_ENDPOINT'));
+          api.get('/user/repos')
             .query({ affiliation: 'owner' })
             .reply(200, repos, {
               Link: [
@@ -228,10 +253,22 @@ describe('The GitHub API endpoint', () => {
                 '<https://api.github.com?&page=3&per_page=30>; rel="last"'
               ].join(',')
             });
+          contentsScopes = repos.map((repo) => {
+            const scope = api.get(
+              `/repos/${repo.full_name}/contents/snapcraft.yaml`
+            );
+            const repoContents = contents[repo.url];
+            if (repoContents !== undefined) {
+              return scope.reply(200, repoContents);
+            } else {
+              return scope.reply(404);
+            }
+          });
         });
 
         afterEach(() => {
           nock.cleanAll();
+          resetMemcached();
         });
 
         it('should return with 200', (done) => {
@@ -258,7 +295,11 @@ describe('The GitHub API endpoint', () => {
           supertest(app)
             .get('/github/repos')
             .end((err, res) => {
-              expect(res.body.payload.repos).toEqual(repos);
+              expect(res.body.payload.repos).toEqual([
+                { ...repos[0], snap_info: { name: 'snap1' } },
+                { ...repos[1], snap_info: { name: null } },
+                { ...repos[2], snap_info: { name: null } }
+              ]);
               done(err);
             });
         });
@@ -272,6 +313,47 @@ describe('The GitHub API endpoint', () => {
             });
         });
 
+        it('should store snap names in memcached', (done) => {
+          supertest(app)
+            .get('/github/repos')
+            .end((err) => {
+              if (err) {
+                done(err);
+              }
+              contentsScopes.forEach((scope) => {
+                expect(scope.isDone()).toExist();
+              });
+              Promise.all(repos.map((repo) => {
+                const cacheId = getSnapNameCacheId(repo.url);
+                const snapName = getMemcached().cache[cacheId];
+                const repoContents = contents[repo.url];
+                if (repoContents !== undefined) {
+                  expect(snapName).toEqual(repoContents.name);
+                } else {
+                  expect(snapName).toBe(undefined);
+                }
+              }))
+                .then(() => done())
+                .catch((err) => done(err));
+            });
+        });
+
+        it('should use snap names already in memcached', (done) => {
+          getMemcached().cache[getSnapNameCacheId(repos[0].url)] = 'snap2';
+          supertest(app)
+            .get('/github/repos')
+            .end((err, res) => {
+              if (err) {
+                done(err);
+              }
+              expect(res.body.payload.repos).toEqual([
+                { ...repos[0], snap_info: { name: 'snap2' } },
+                { ...repos[1], snap_info: { name: null } },
+                { ...repos[2], snap_info: { name: null } }
+              ]);
+              done();
+            });
+        });
       });
     });
 


### PR DESCRIPTION
Positive responses are cached to avoid an unreasonable number of
requests, and the webhook clears the cache so that we notice changes
more quickly at least for enabled repositories.

I haven't tested this in a browser since this was mostly done in spare minutes at the hospital; somebody not on leave might want to give this a quick run to make sure it doesn't explode or anything.