### PR TITLE
Bring back orange non-underlined links

### DIFF
--- a/src/common/style/base.css
+++ b/src/common/style/base.css
@@ -49,8 +49,8 @@ q:before, q:after {
 }
 
 a {
-  color: $cool-grey;
-  text-decoration: underline;
+  color: #dd4814;
+  text-decoration: none;
 }
 
 a:hover {


### PR DESCRIPTION
Vanilla, Ubuntu and snapcraft.io all have orange links.