### PR TITLE
Login redirect to dashboard

### DIFF
--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -66,8 +66,9 @@ class RepositoriesHome extends Component {
   }
 
   render() {
+    const { snaps } = this.props;
     // show spinner until we know if user has any enabled repos
-    return this.props.snaps.success
+    return (snaps.success || snaps.error)
         ? this.renderRepositoriesList()
         : this.renderSpinner();
   }
@@ -75,7 +76,7 @@ class RepositoriesHome extends Component {
 
 RepositoriesHome.propTypes = {
   auth: PropTypes.object.isRequired,
-  user: PropTypes.object.isRequired,
+  user: PropTypes.object,
   snaps: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
   router: PropTypes.object.isRequired

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -76,7 +76,7 @@ export const verify = (req, res, next) => {
         req.session.user = response.body;
 
         // Redirect to logged in URL
-        res.redirect('/dashboard/select-repositories');
+        res.redirect('/dashboard');
       });
 
   });

--- a/test/routes/src/server/routes/t_github-auth.js
+++ b/test/routes/src/server/routes/t_github-auth.js
@@ -119,7 +119,7 @@ describe('The login route', () => {
             .send()
             .end((err, res) => {
               expect(res.statusCode).toEqual(302);
-              expect(res.headers.location).toEqual('/dashboard/select-repositories');
+              expect(res.headers.location).toEqual('/dashboard');
               done(err);
             });
         });


### PR DESCRIPTION
Login with GH should properly redirect to /dashboard and only if user doesn't have enabled repos show add repositories view (go to/dashboard/select-repositories).