### PR TITLE
Added table dropdown component with dummy usage in repository row

### DIFF
--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -10,6 +10,7 @@ import { parseGitHubRepoUrl } from '../../helpers/github-url';
 
 // loading container styles not to duplicate .spinner class
 import { spinner as spinnerStyles } from '../../containers/container.css';
+import styles from './repositoriesList.css';
 
 const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
 
@@ -67,7 +68,7 @@ class RepositoriesList extends Component {
     const isLoading = this.props.snaps.isFetching;
 
     return (
-      <div>
+      <div className={styles.repositoriesList}>
         { isLoading &&
           <div className={ spinnerStyles }>
             <Spinner />

--- a/src/common/components/repositories-list/repositoriesList.css
+++ b/src/common/components/repositories-list/repositoriesList.css
@@ -1,0 +1,7 @@
+.repositoriesList {
+  background-color: $light-grey;
+  padding: 20px;
+  width: 100%;
+  clear: both;
+  position: relative;
+}

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -1,37 +1,75 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 
-import { Row, Data } from '../vanilla/table-interactive';
+import { Row, Data, Dropdown } from '../vanilla/table-interactive';
 import BuildStatus from '../build-status';
 
 import { parseGitHubRepoUrl } from '../../helpers/github-url';
 
-const RepositoryRow = (props) => {
-  const { snap, latestBuild } = props;
-  const { fullName } = parseGitHubRepoUrl(snap.git_repository_url);
+class RepositoryRow extends Component {
 
-  return (
-    <Row>
-      <Data col="30"><Link to={ `/${fullName}/builds` }>{ fullName }</Link></Data>
-      <Data col="20"> </Data>
-      <Data col="20"> </Data>
-      <Data col="30">
-        {/*
-          TODO: show 'Loading' when waiting for status?
-            and also show 'Never built' when no builds available
-        */}
-        { latestBuild &&
-          <BuildStatus
-            link={ `/${fullName}/builds/${latestBuild.buildId}`}
-            status={ latestBuild.status }
-            statusMessage={ latestBuild.statusMessage }
-            dateStarted={ latestBuild.dateStarted }
-          />
-        }
-      </Data>
-    </Row>
-  );
-};
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      notConfiguredDropdownExpanded: false
+    };
+  }
+
+  onConfiguredClick() {
+    this.setState({
+      notConfiguredDropdownExpanded: !this.state.notConfiguredDropdownExpanded
+    });
+  }
+
+  renderNotConfiguredDropdown() {
+    return (
+      <Dropdown>
+        <Row>
+          <Data col="100">
+            This repo needs a snapcraft.yaml file, so that Snapcraft can make it buildable, installable, and runnable.
+            {/* TODO: add more info/links as in spec */}
+          </Data>
+        </Row>
+      </Dropdown>
+    );
+  }
+
+  render() {
+    const { snap, latestBuild } = this.props;
+    const { fullName } = parseGitHubRepoUrl(snap.git_repository_url);
+
+    const notConfigured = true;
+    const showNotConfiguredDropdown = notConfigured && this.state.notConfiguredDropdownExpanded;
+
+    const isActive = showNotConfiguredDropdown; // TODO (or any other dropdown)
+    return (
+      <Row isActive={isActive}>
+        <Data col="30"><Link to={ `/${fullName}/builds` }>{ fullName }</Link></Data>
+        <Data col="20">
+          {/* TODO: hardcoded Not configured for now, will show actual status later */}
+          <a onClick={this.onConfiguredClick.bind(this)}>Not configured</a>
+        </Data>
+        <Data col="20"> </Data>
+        <Data col="30">
+          {/*
+            TODO: show 'Loading' when waiting for status?
+              and also show 'Never built' when no builds available
+          */}
+          { latestBuild &&
+            <BuildStatus
+              link={ `/${fullName}/builds/${latestBuild.buildId}`}
+              status={ latestBuild.status }
+              statusMessage={ latestBuild.statusMessage }
+              dateStarted={ latestBuild.dateStarted }
+            />
+          }
+        </Data>
+        { showNotConfiguredDropdown && this.renderNotConfiguredDropdown() }
+      </Row>
+    );
+  }
+}
 
 RepositoryRow.propTypes = {
   snap: PropTypes.shape({

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -12,13 +12,13 @@ class RepositoryRow extends Component {
     super(props);
 
     this.state = {
-      notConfiguredDropdownExpanded: false
+      unconfiguredDropdownExpanded: false
     };
   }
 
   onConfiguredClick() {
     this.setState({
-      notConfiguredDropdownExpanded: !this.state.notConfiguredDropdownExpanded
+      unconfiguredDropdownExpanded: !this.state.unconfiguredDropdownExpanded
     });
   }
 
@@ -40,7 +40,7 @@ class RepositoryRow extends Component {
     const { fullName } = parseGitHubRepoUrl(snap.git_repository_url);
 
     const notConfigured = true;
-    const showNotConfiguredDropdown = notConfigured && this.state.notConfiguredDropdownExpanded;
+    const showNotConfiguredDropdown = notConfigured && this.state.unconfiguredDropdownExpanded;
 
     const isActive = showNotConfiguredDropdown; // TODO (or any other dropdown)
     return (

--- a/src/common/components/vanilla/table-interactive/dropdown.js
+++ b/src/common/components/vanilla/table-interactive/dropdown.js
@@ -1,0 +1,14 @@
+import React, { PropTypes } from 'react';
+import styles from './table.css';
+
+export default function Dropdown(props) {
+  return (
+    <div className={ styles.dropdown }>
+      { props.children }
+    </div>
+  );
+}
+
+Dropdown.propTypes = {
+  children: PropTypes.node
+};

--- a/src/common/components/vanilla/table-interactive/index.js
+++ b/src/common/components/vanilla/table-interactive/index.js
@@ -1,6 +1,7 @@
 import Table from './table';
 import Body from './body';
 import Data from './data';
+import Dropdown from './dropdown';
 import Header from './header';
 import Head from './head';
 import Row from './row';
@@ -9,6 +10,7 @@ export {
   Table,
   Body,
   Data,
+  Dropdown,
   Header,
   Head,
   Row

--- a/src/common/components/vanilla/table-interactive/row.js
+++ b/src/common/components/vanilla/table-interactive/row.js
@@ -2,13 +2,15 @@ import React, { PropTypes } from 'react';
 import styles from './table.css';
 
 export default function Row(props) {
+  const className = `${styles.row} ${props.isActive && styles.active}`;
   return (
-    <div className={ styles.row }>
+    <div className={ className }>
       { props.children }
     </div>
   );
 }
 
 Row.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  isActive: PropTypes.bool
 };

--- a/src/common/components/vanilla/table-interactive/table.css
+++ b/src/common/components/vanilla/table-interactive/table.css
@@ -58,16 +58,37 @@ $table-row-border-color: $dark-grey;
   border-bottom-width: 1px;
 }
 
-.head .row {
-  border-bottom: 1px solid;
+.row.active {
+  background: #FFF;
 }
 
-.row:hover {
-  background-color: #FFF;
+.head .row {
+  border-bottom: 1px solid;
 }
 
 .body {
   display: table-row-group;
   width: 100%;
   float: left;
+}
+
+.dropdown {
+  width: 100%;
+}
+
+.dropdown .row {
+  position: relative;
+  border: 0;
+}
+
+.dropdown .row:before {
+  display: block;
+  margin: 0 auto;
+  width: calc(100% - 20px);
+  border-top: 1px dotted #d2d2d2;
+  position: absolute;
+  height: 1px;
+  content: "";
+  top: 0;
+  left: 10px;
 }


### PR DESCRIPTION
<img width="1028" alt="screen shot 2017-02-20 at 16 10 17" src="https://cloud.githubusercontent.com/assets/83575/23133001/65060992-f787-11e6-85bb-45ddcb6e64ea.png">

<img width="1024" alt="screen shot 2017-02-20 at 16 10 29" src="https://cloud.githubusercontent.com/assets/83575/23133003/68c8cd1c-f787-11e6-9218-b22adc218100.png">

Simple dropdown component for interactive table with basic usage in RepositoryRow.