### PR TITLE
Add /api/store/register-name endpoint

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -209,3 +209,23 @@ of the parsed YAML file:
         }
       }
     }
+
+## Store
+
+### Snap name registration
+
+To register a name with the store:
+
+    POST /api/store/register-name
+    Content-Type: application/json
+
+    {
+      "snap_name": ":snap-name",
+      "macaroon": ":package-upload-request-macaroon"
+    }
+
+The response is [defined by the
+store](https://myapps.developer.ubuntu.com/docs/api/snap.html#register-a-package-name).
+
+This endpoint should be considered temporary; once it is possible to make a
+cross-origin request directly to the store, we will do that instead.

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -1,0 +1,22 @@
+import 'isomorphic-fetch';
+
+import { conf } from '../helpers/config';
+
+export const registerName = (req, res) => {
+  const snapName = req.body.snap_name;
+  const macaroon = req.body.macaroon;
+
+  return fetch(`${conf.get('STORE_API_URL')}/register-name/`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Macaroon root="${macaroon}"`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({ snap_name: snapName })
+  }).then((response) => {
+    return response.json().then((json) => {
+      return res.status(response.status).send(json);
+    });
+  });
+};

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,8 +1,9 @@
 import github from './github';
+import githubAuth from './github-auth';
 import launchpad from './launchpad';
 import login from './login';
+import store from 'store';
 import universal from './universal';
-import githubAuth from './github-auth';
 import webhook from './webhook';
 
 export {
@@ -10,6 +11,7 @@ export {
   github,
   launchpad,
   login,
+  store,
   webhook,
   universal
 };

--- a/src/server/routes/store.js
+++ b/src/server/routes/store.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { json } from 'body-parser';
+
+import { registerName } from '../handlers/store';
+
+const router = Router();
+
+router.use('/store/register-name', json());
+router.post('/store/register-name', registerName);
+
+export default router;

--- a/test/routes/src/server/routes/t_store.js
+++ b/test/routes/src/server/routes/t_store.js
@@ -1,0 +1,38 @@
+import expect from 'expect';
+import Express from 'express';
+import nock from 'nock';
+import supertest from 'supertest';
+
+import store from '../../../../../src/server/routes/store';
+import { conf } from '../../../../../src/server/helpers/config';
+
+describe('The store API endpoint', () => {
+  const app = Express();
+  app.use(store);
+
+  describe('register-name route', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('passes request through to store', (done) => {
+      const scope = nock(conf.get('STORE_API_URL'))
+        .post('/register-name/', { snap_name: 'test-snap' })
+        .matchHeader('Authorization', 'Macaroon root="dummy-macaroon"')
+        .reply(201, { snap_id: 'test-snap-id' });
+
+      supertest(app)
+        .post('/store/register-name')
+        .send({
+          snap_name: 'test-snap',
+          macaroon: 'dummy-macaroon'
+        })
+        .expect((res) => {
+          scope.done();
+          expect(res.status).toBe(201);
+          expect(res.body).toEqual({ snap_id: 'test-snap-id' });
+        })
+        .end(done);
+    });
+  });
+});


### PR DESCRIPTION
Simple endpoint to proxy register-name requests from the client in
advance of cross-origin support in the SCA register-name endpoint.