### PR TITLE
Removes no-longer-needed text from the footer

### DIFF
--- a/src/common/components/footer/index.js
+++ b/src/common/components/footer/index.js
@@ -23,7 +23,6 @@ export default class Footer extends Component {
           </div>
           <p className={ styles.copyright }>© 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
           <p><a href="http://www.ubuntu.com/legal">Legal information</a> · <a href="https://github.com/canonical-ols/build.snapcraft.io/issues/new">Report a bug on this site</a></p>
-          <p className={ styles.note }>Yocto Project and all related marks and logos are trademarks of The Linux Foundation. This website is not, in any way, endorsed by the Yocto Project or The Linux Foundation.</p>
         </div>
       </div>
     );


### PR DESCRIPTION
Since, on this site, we don’t mention the platform that the footer was disclaiming.