### PR TITLE
Use https link for www.ubuntu.com

### DIFF
--- a/src/common/components/footer/index.js
+++ b/src/common/components/footer/index.js
@@ -22,7 +22,7 @@ export default class Footer extends Component {
             </ul>
           </div>
           <p className={ styles.copyright }>© 2017 Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-          <p><a href="http://www.ubuntu.com/legal">Legal information</a> · <a href="https://github.com/canonical-ols/build.snapcraft.io/issues/new">Report a bug on this site</a></p>
+          <p><a href="https://www.ubuntu.com/legal">Legal information</a> · <a href="https://github.com/canonical-ols/build.snapcraft.io/issues/new">Report a bug on this site</a></p>
         </div>
       </div>
     );


### PR DESCRIPTION
http://www.ubuntu.com/legal redirects to https://www.ubuntu.com/legal
anyway, so we might as well link to the latter directly.