### PR TITLE
Making user name in header not look like a link

### DIFF
--- a/src/common/components/header/header.css
+++ b/src/common/components/header/header.css
@@ -41,7 +41,7 @@ $text-color: $cool-grey;
   float: right;
 }
 
-.link {
+.navItem {
   box-sizing: border-box;
   display: inline-block;
   height: 50px;
@@ -51,6 +51,14 @@ $text-color: $cool-grey;
   font-size: .875em;
   text-align: center;
   border-left: 1px solid $border-color;
+}
+
+.navItem:first-child {
+  border-left: none;
+}
+
+.link {
+  composes: navItem;
 }
 
 .link:hover {

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -18,7 +18,7 @@ class Header extends Component {
           { authenticated
             ?
               <div className={ styles.sideNav }>
-                { user && <span className={ styles.link } >Hi, {user.name}</span> }
+                { user && <span className={ styles.navItem } >Hi, {user.name}</span> }
                 <Link to="/dashboard" className={ styles.link }>Dashboard</Link>
                 <a
                   className={ styles.link }


### PR DESCRIPTION
<img width="1073" alt="screen shot 2017-02-21 at 13 47 27" src="https://cloud.githubusercontent.com/assets/83575/23167477/75212fa4-f83c-11e6-8542-6e02837657ae.png">

Still has the same font, but without the border, hover affect and with 'Hi,' text it should look less like a link.