### PR TITLE
Add name registration to UI

### DIFF
--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -2,6 +2,10 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { conf } from '../../helpers/config';
+import {
+  checkSignedIntoStore,
+  getSSODischarge
+} from '../../actions/auth-store';
 import { createSnap } from '../../actions/create-snap';
 import RepositoryRow from '../repository-row';
 import Spinner from '../spinner';
@@ -15,6 +19,14 @@ import styles from './repositoriesList.css';
 const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
 
 class RepositoriesList extends Component {
+  componentDidMount() {
+    if (this.props.authStore.hasDischarge) {
+      this.props.dispatch(getSSODischarge());
+    } else if (this.props.authStore.authenticated === null) {
+      this.props.dispatch(checkSignedIntoStore());
+    }
+  }
+
   getSnapNotRegisteredMessage(snapName) {
     const devportalUrl = conf.get('STORE_DEVPORTAL_URL');
     const registerNameUrl = `${devportalUrl}/click-apps/register-name/` +
@@ -49,11 +61,16 @@ class RepositoriesList extends Component {
       latestBuild = snapBuilds.builds[0];
     }
 
+    const registerNameStatus = this.props.registerName[fullName] || {};
+
     return (
       <RepositoryRow
         key={ `repo_${fullName}` }
         snap={ snap }
         latestBuild={ latestBuild }
+        fullName={ fullName }
+        authStore={ this.props.authStore }
+        registerNameStatus={ registerNameStatus }
       />
     );
   }
@@ -95,21 +112,27 @@ class RepositoriesList extends Component {
 }
 
 RepositoriesList.propTypes = {
+  auth: PropTypes.object.isRequired,
+  authStore: PropTypes.object.isRequired,
+  registerName: PropTypes.object,
   snaps: PropTypes.object,
   snapBuilds: PropTypes.object,
-  auth: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
 };
 
 function mapStateToProps(state) {
   const {
     auth,
+    authStore,
+    registerName,
     snaps,
     snapBuilds
   } = state;
 
   return {
     auth,
+    authStore,
+    registerName,
     snaps,
     snapBuilds
   };

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -1,25 +1,60 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
+import Button from '../vanilla/button';
 import { Row, Data, Dropdown } from '../vanilla/table-interactive';
 import BuildStatus from '../build-status';
 
-import { parseGitHubRepoUrl } from '../../helpers/github-url';
+import { signIntoStore } from '../../actions/auth-store';
+import { registerName } from '../../actions/register-name';
+
+import styles from './repositoryRow.css';
 
 class RepositoryRow extends Component {
 
   constructor(props) {
     super(props);
 
+    let snapName;
+    if (props.snap.snapcraft_data && props.snap.snapcraft_data.name) {
+      snapName = props.snap.snapcraft_data.name;
+    } else {
+      snapName = '';
+    }
+
     this.state = {
-      unconfiguredDropdownExpanded: false
+      snapName,
+      unconfiguredDropdownExpanded: false,
+      unregisteredDropdownExpanded: false
     };
   }
 
   onConfiguredClick() {
     this.setState({
-      unconfiguredDropdownExpanded: !this.state.unconfiguredDropdownExpanded
+      unconfiguredDropdownExpanded: !this.state.unconfiguredDropdownExpanded,
+      unregisteredDropdownExpanded: false
     });
+  }
+
+  onUnregisteredClick() {
+    this.setState({
+      unconfiguredDropdownExpanded: false,
+      unregisteredDropdownExpanded: !this.state.unregisteredDropdownExpanded
+    });
+  }
+
+  onSignInClick() {
+    this.props.dispatch(signIntoStore());
+  }
+
+  onSnapNameChange(event) {
+    const snapName = event.target.value.replace(/[^a-z0-9-]/g, '');
+    this.setState({ snapName });
+  }
+
+  onRegisterClick(fullName) {
+    this.props.dispatch(registerName(fullName, this.state.snapName));
   }
 
   renderUnconfiguredDropdown() {
@@ -35,12 +70,87 @@ class RepositoryRow extends Component {
     );
   }
 
+  renderUnregisteredDropdown() {
+    const { authStore, fullName, registerNameStatus } = this.props;
+
+    // If the user has signed into the store but we haven't fetched the
+    // resulting discharge macaroon, we need to wait for that before
+    // allowing them to proceed.
+    const authStoreFetchingDischarge = (
+      authStore.hasDischarge && !authStore.authenticated
+    );
+
+    let caption;
+    if (registerNameStatus.error) {
+      caption = <div>{ registerNameStatus.error.json.detail }</div>;
+    } else {
+      caption = (
+        <div>
+          To publish to the Snap Store, this repo needs a registered name.
+          { !authStore.authenticated &&
+            ' You need to sign in to Ubuntu One to register a name.'
+          }
+          { (authStoreFetchingDischarge || authStore.authenticated) &&
+            <div className={ styles.helpText }>
+              Lower-case letters, numbers, and hyphens only.
+            </div>
+          }
+        </div>
+      );
+    }
+
+    let actionDisabled;
+    let actionOnClick;
+    let actionSpinner = false;
+    let actionText;
+    if (authStoreFetchingDischarge || authStore.authenticated) {
+      actionDisabled = (
+        this.state.snapName === '' ||
+        registerNameStatus.isFetching ||
+        authStoreFetchingDischarge
+      );
+      actionOnClick = this.onRegisterClick.bind(this, fullName);
+      if (registerNameStatus.isFetching) {
+        actionSpinner = true;
+        actionText = 'Checking...';
+      } else {
+        actionText = 'Register';
+      }
+    } else {
+      actionDisabled = authStore.isFetching;
+      actionOnClick = this.onSignInClick.bind(this);
+      actionText = 'Sign in...';
+    }
+
+    return (
+      <Dropdown>
+        <Row>
+          <Data col="100">
+            { caption }
+          </Data>
+        </Row>
+        <Row>
+          <Button onClick={this.onUnregisteredClick.bind(this)} appearance='neutral'>
+            Cancel
+          </Button>
+          <Button disabled={actionDisabled} onClick={actionOnClick} spinner={actionSpinner}>
+            { actionText }
+          </Button>
+        </Row>
+      </Dropdown>
+    );
+  }
+
   render() {
-    const { snap, latestBuild } = this.props;
-    const { fullName } = parseGitHubRepoUrl(snap.git_repository_url);
+    const { snap, latestBuild, fullName, authStore } = this.props;
 
     const unconfigured = true;
     const showUnconfiguredDropdown = unconfigured && this.state.unconfiguredDropdownExpanded;
+    const unregistered = true;
+    const showUnregisteredDropdown = unregistered && this.state.unregisteredDropdownExpanded;
+    const showRegisterNameInput = (
+      showUnregisteredDropdown && authStore.authenticated
+    );
 
     const isActive = showUnconfiguredDropdown; // TODO (or any other dropdown)
     return (
@@ -50,7 +160,7 @@ class RepositoryRow extends Component {
           { this.renderConfiguredStatus.call(this, snap.snapcraft_data) }
         </Data>
         <Data col="20">
-          { this.renderSnapName.call(this, snap.snapcraft_data) }
+          { this.renderSnapName.call(this, showRegisterNameInput) }
         </Data>
         <Data col="30">
           {/*
@@ -67,6 +177,7 @@ class RepositoryRow extends Component {
           }
         </Data>
         { showUnconfiguredDropdown && this.renderUnconfiguredDropdown() }
+        { showUnregisteredDropdown && this.renderUnregisteredDropdown() }
       </Row>
     );
   }
@@ -83,12 +194,23 @@ class RepositoryRow extends Component {
     );
   }
 
-  renderSnapName(snapcraftData) {
-    if (snapcraftData && snapcraftData.name) {
-      return (<div>{ snapcraftData.name }</div>);
+  renderSnapName(showRegisterNameInput) {
+    if (showRegisterNameInput) {
+      return (
+        <input
+          type='text'
+          className={ styles.snapName }
+          value={ this.state.snapName }
+          onChange={ this.onSnapNameChange.bind(this) }
+        />
+      );
+    } else {
+      return (
+        <a onClick={this.onUnregisteredClick.bind(this)}>
+          Not registered
+        </a>
+      );
     }
-
-    return (<a>Not registered</a>);
   }
 }
 
@@ -96,13 +218,24 @@ RepositoryRow.propTypes = {
   snap: PropTypes.shape({
     resource_type_link: PropTypes.string,
     git_repository_url: PropTypes.string,
-    self_link: PropTypes.string
+    self_link: PropTypes.string,
+    snapcraft_data: PropTypes.object
   }),
   latestBuild: PropTypes.shape({
     buildId: PropTypes.string,
     status: PropTypes.string,
     statusMessage: PropTypes.string
-  })
+  }),
+  fullName: PropTypes.string,
+  authStore: PropTypes.shape({
+    authenticated: PropTypes.bool
+  }),
+  registerNameStatus: PropTypes.shape({
+    isFetching: PropTypes.bool,
+    success: PropTypes.bool,
+    error: PropTypes.object
+  }),
+  dispatch: PropTypes.func.isRequired
 };
 
-export default RepositoryRow;
+export default connect()(RepositoryRow);

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -133,7 +133,7 @@ class RepositoryRow extends Component {
           <Button onClick={this.onUnregisteredClick.bind(this)} appearance='neutral'>
             Cancel
           </Button>
-          <Button disabled={actionDisabled} onClick={actionOnClick} spinner={actionSpinner}>
+          <Button disabled={actionDisabled} onClick={actionOnClick} isSpinner={actionSpinner}>
             { actionText }
           </Button>
         </Row>

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -22,7 +22,7 @@ class RepositoryRow extends Component {
     });
   }
 
-  renderNotConfiguredDropdown() {
+  renderUnconfiguredDropdown() {
     return (
       <Dropdown>
         <Row>
@@ -39,10 +39,10 @@ class RepositoryRow extends Component {
     const { snap, latestBuild } = this.props;
     const { fullName } = parseGitHubRepoUrl(snap.git_repository_url);
 
-    const notConfigured = true;
-    const showNotConfiguredDropdown = notConfigured && this.state.unconfiguredDropdownExpanded;
+    const unconfigured = true;
+    const showUnconfiguredDropdown = unconfigured && this.state.unconfiguredDropdownExpanded;
 
-    const isActive = showNotConfiguredDropdown; // TODO (or any other dropdown)
+    const isActive = showUnconfiguredDropdown; // TODO (or any other dropdown)
     return (
       <Row isActive={isActive}>
         <Data col="30"><Link to={ `/${fullName}/builds` }>{ fullName }</Link></Data>
@@ -66,7 +66,7 @@ class RepositoryRow extends Component {
             />
           }
         </Data>
-        { showNotConfiguredDropdown && this.renderNotConfiguredDropdown() }
+        { showUnconfiguredDropdown && this.renderUnconfiguredDropdown() }
       </Row>
     );
   }

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -1,0 +1,8 @@
+.snapName {
+  width: 100%;
+}
+
+.helpText {
+  font-size: .875rem;
+  color: $warm-grey;
+}

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -3,11 +3,6 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
 import { conf } from '../../helpers/config';
-import {
-  checkSignedIntoStore,
-  getSSODischarge,
-  signIntoStore
-} from '../../actions/auth-store';
 import { createSnaps } from '../../actions/create-snap';
 import { toggleRepository } from '../../actions/select-repositories-form';
 import SelectRepositoryRow from '../select-repository-row';
@@ -24,14 +19,6 @@ import { spinner as spinnerStyles } from '../../containers/container.css';
 const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
 
 class SelectRepositoryList extends Component {
-
-  componentDidMount() {
-    if (this.props.authStore.hasDischarge) {
-      this.props.dispatch(getSSODischarge());
-    } else if (this.props.authStore.authenticated === null) {
-      this.props.dispatch(checkSignedIntoStore());
-    }
-  }
 
   componentWillReceiveProps(nextProps) {
     const repositoriesStatus = nextProps.repositoriesStatus;
@@ -88,13 +75,9 @@ class SelectRepositoryList extends Component {
   }
 
   onSubmit() {
-    if (this.props.authStore.authenticated) {
-      const { selectedRepos } = this.props.selectRepositoriesForm;
-      if (selectedRepos.length) {
-        this.props.dispatch(createSnaps(selectedRepos));
-      }
-    } else {
-      this.props.dispatch(signIntoStore());
+    const { selectedRepos } = this.props.selectRepositoriesForm;
+    if (selectedRepos.length) {
+      this.props.dispatch(createSnaps(selectedRepos));
     }
   }
 
@@ -104,13 +87,6 @@ class SelectRepositoryList extends Component {
 
   render() {
     const isLoading = this.props.repositories.isFetching;
-    // If the user has signed into the store but we haven't fetched the
-    // resulting discharge macaroon, we need to wait for that before
-    // allowing them to proceed.
-    const submitButtonDisabled = (
-      this.props.authStore.hasDischarge &&
-      !this.props.authStore.authenticated
-    );
 
     return (
       <div>
@@ -124,7 +100,7 @@ class SelectRepositoryList extends Component {
         { this.renderPageLinks.call(this) }
         <div className={ styles.footer }>
           <div className={ styles.right }>
-            <Button disabled={ submitButtonDisabled } onClick={ this.onSubmit.bind(this) } appearance={ 'positive' }>
+            <Button onClick={ this.onSubmit.bind(this) } appearance={ 'positive' }>
               Add
             </Button>
           </div>
@@ -150,21 +126,18 @@ SelectRepositoryList.propTypes = {
   repositoriesStatus: PropTypes.object,
   selectRepositoriesForm: PropTypes.object,
   onSelectRepository: PropTypes.func,
-  authStore: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
 };
 
 function mapStateToProps(state) {
   const {
-    authStore,
     repositories,
     repositoriesStatus,
     selectRepositoriesForm
   } = state;
 
   return {
-    authStore,
     repositories,
     repositoriesStatus,
     selectRepositoriesForm

--- a/src/common/components/vanilla/button/button.css
+++ b/src/common/components/vanilla/button/button.css
@@ -116,3 +116,13 @@ $neutral-border-color: $dark-grey;
   float: right;
   box-sizing: content-box;
 }
+
+.spinner {
+  display: block;
+  margin: 0;
+  padding: 1px 0 0 0;
+  margin-right: 0.5em;
+  height: 21px;
+  float: left;
+  box-sizing: content-box;
+}

--- a/src/common/components/vanilla/button/index.js
+++ b/src/common/components/vanilla/button/index.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 
+import Spinner from '../../spinner';
 import style from './button.css';
 
 const defaultProps = {
@@ -12,8 +13,13 @@ const defaultProps = {
 };
 
 export default function Button(props) {
-  const { appearance='primary', ...rest } = props;
-  return <button {...rest} className={ style[appearance] } />;
+  const { appearance='primary', spinner=false, ...rest } = props;
+  return (
+    <button {...rest} className={ style[appearance] }>
+      { spinner && <span className={ style.spinner }><Spinner /></span> }
+      { props.children }
+    </button>
+  );
 }
 
 export function Anchor(props) {

--- a/src/common/components/vanilla/button/index.js
+++ b/src/common/components/vanilla/button/index.js
@@ -13,10 +13,10 @@ const defaultProps = {
 };
 
 export default function Button(props) {
-  const { appearance='primary', spinner=false, ...rest } = props;
+  const { appearance='primary', isSpinner=false, ...rest } = props;
   return (
     <button {...rest} className={ style[appearance] }>
-      { spinner && <span className={ style.spinner }><Spinner /></span> }
+      { isSpinner && <span className={ style.spinner }><Spinner /></span> }
       { props.children }
     </button>
   );


### PR DESCRIPTION
Signing into the store is now done on the main dashboard page as part of
registering a name, and the store macaroon is used to register the name
over the API.

We don't yet do anything useful with the registered name; the next step
will be to push it into Launchpad and create builds immediately after
name registration is complete.