### PR TITLE
Fix dashboard redirect loop

### DIFF
--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -10,7 +10,9 @@ export function snaps(state = {
     case ActionTypes.FETCH_SNAPS:
       return {
         ...state,
-        isFetching: true
+        isFetching: true,
+        success: false,
+        error: null
       };
     case ActionTypes.FETCH_SNAPS_SUCCESS:
       return {

--- a/test/unit/src/common/reducers/t_snaps.js
+++ b/test/unit/src/common/reducers/t_snaps.js
@@ -35,11 +35,16 @@ describe('snaps reducers', () => {
       type: ActionTypes.FETCH_SNAPS
     };
 
-    it('should store fetching status when fetching builds', () => {
-      expect(snaps(initialState, action)).toEqual({
-        ...initialState,
-        isFetching: true
-      });
+    it('should store fetching status', () => {
+      expect(snaps(initialState, action).isFetching).toBe(true);
+    });
+
+    it('should clean success state', () => {
+      expect(snaps(initialState, action).success).toBe(false);
+    });
+
+    it('should clean error', () => {
+      expect(snaps(initialState, action).error).toBe(null);
     });
   });
 


### PR DESCRIPTION
On the first time through for a new user, /dashboard will fetch snaps
and find an empty list, then send the user to
/dashboard/select-repositories.  If the user then creates a snap and
returns to /dashboard, the store may already have state that looks like
`{ snaps: { success: true, snaps: [] } }`, which will cause it to
immediately redirect back to /dashboard/select-repositories, entering a
redirect loop.

Clearing previous success/error state in response to the `FETCH_SNAPS`
action avoids this problem.