### PR TITLE
Tweaks snap install text

### DIFF
--- a/src/common/components/help/install-snap/index.js
+++ b/src/common/components/help/install-snap/index.js
@@ -18,7 +18,6 @@ export default class HelpInstallSnap extends Component {
             sudo snap install --edge { name } { revOption }
           </code>
         </pre>
-        <p className={ styles.p }>The installed snap will not be auto-updated.</p>
         <p className={ styles.p }>
           Don’t have snapd installed? <a className={ styles.external } href={ HELP_INSTALL_URL }>Install it now</a>.
         </p>

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -66,9 +66,8 @@ class BuildDetails extends Component {
           </div>
         }
         <HelpInstallSnap
-          headline='To test this build on your PC, cloud instance, or device:'
+          headline='To test the latest successful build on your PC or cloud instance:'
           name='foo'
-          revision={1}
         />
       </div>
     );

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -71,7 +71,7 @@ class Builds extends Component {
           <Message status='error'>{ error.message || error }</Message>
         }
         <HelpInstallSnap
-          headline='To test this snap on your PC, cloud instance, or device:'
+          headline='To test this snap on your PC or cloud instance:'
           name='foo'
         />
       </div>


### PR DESCRIPTION
Reflecting that (a) we’re building on only two architectures and (b) the build page doesn't yet know whether this build succeeded.