### PR TITLE
Move snap authorization after name registration

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -16,10 +16,7 @@ To create a snap:
     Accept: application/json
 
     {
-      "repository_url": "https://github.com/:owner/:name",
-      "snap_name": ":snap-name",
-      "series": ":series",
-      "channels": [":channel", ...]
+      "repository_url": "https://github.com/:owner/:name"
     }
 
 On success, returns:
@@ -35,16 +32,11 @@ On success, returns:
       }
     }
 
-The caller should proceed to authorize the snap using an OpenID exchange,
-using `:caveat-id` as the parameter to the Macaroon extension.  If
-successful, the result of this OpenID exchange will be a discharge macaroon,
-which the `/login/verify` handler will store in Launchpad.
-
-We're moving to a slightly different arrangement for authorizing snaps.  In
-this, the caller should acquire a pre-authorized macaroon from the store (on
-the authority of a `package_upload_request` macaroon which has itself been
-authorized using OpenID) and tell Launchpad to use that for uploads.  This
-can be done using this API method:
+Once the caller has registered the snap name with the store, it should
+acquire a pre-authorized macaroon from the store (on the authority of a
+`package_upload_request` macaroon which has itself been authorized using
+OpenID) and tell Launchpad to use that for uploads along with telling it the
+snap name, series, and channels.  This can be done using this API method:
 
     POST /api/launchpad/snaps/authorize
     Cookie: <session cookie>
@@ -52,6 +44,9 @@ can be done using this API method:
 
     {
       "repository_url": "https://github.com/:owner/:name",
+      "snap_name": ":snap-name",
+      "series": ":series",
+      "channels": [":channel", ...],
       "macaroon": ":macaroon"
     }
 

--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -128,7 +128,7 @@ export function signIntoStoreError(error) {
   };
 }
 
-function checkPackageUploadRequest(rootRaw, dischargeRaw) {
+export function checkPackageUploadRequest(rootRaw, dischargeRaw) {
   // We can't do full verification here, but at least make sure that the
   // caveat ID matches.
   const root = MacaroonsBuilder.deserialize(rootRaw);
@@ -139,6 +139,7 @@ function checkPackageUploadRequest(rootRaw, dischargeRaw) {
                     'macaroon.');
   }
   // XXX cjwatson 2017-02-13: Check expires caveat?
+  return { root, discharge };
 }
 
 export function getSSODischarge() {

--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -1,8 +1,6 @@
 import 'isomorphic-fetch';
-import localforage from 'localforage';
-import { MacaroonsBuilder } from 'macaroons.js';
 
-import { APICompatibleError, checkStatus, getError } from '../helpers/api';
+import { checkStatus } from '../helpers/api';
 import { conf } from '../helpers/config';
 
 const BASE_URL = conf.get('BASE_URL');
@@ -13,11 +11,6 @@ export const CREATE_SNAP = 'CREATE_SNAP';
 export const CREATE_SNAP_SUCCESS = 'CREATE_SNAP_SUCCESS';
 export const CREATE_SNAP_ERROR = 'CREATE_SNAP_ERROR';
 
-// XXX cjwatson 2017-02-08: Hardcoded for now, but should eventually be
-// configurable.
-const STORE_SERIES = '16';
-const STORE_CHANNELS = ['edge'];
-
 export function setGitHubRepository(value) {
   return {
     type: SET_GITHUB_REPOSITORY,
@@ -25,126 +18,23 @@ export function setGitHubRepository(value) {
   };
 }
 
-function getSnapName(owner, name) {
-  return fetch(`${BASE_URL}/api/github/snapcraft-yaml/${owner}/${name}`, {
-    headers: { 'Accept': 'application/json' },
-    credentials: 'same-origin'
-  })
-    .then(checkStatus)
-    .then((response) => response.json().then((json) => {
-      if (json.status !== 'success' ||
-          json.payload.code !== 'snapcraft-yaml-found') {
-        throw getError(response, json);
-      }
-      const snapcraftYaml = json.payload.contents;
-      if (!('name' in snapcraftYaml)) {
-        throw new APICompatibleError({
-          code: 'snapcraft-yaml-no-name',
-          message: 'snapcraft.yaml has no top-level "name" attribute'
-        });
-      }
-      return snapcraftYaml.name;
-    }));
-}
-
-function getPackageUploadMacaroon(snapName) {
-  return localforage.getItem('package_upload_request')
-    .catch(() => {
-      throw new APICompatibleError({
-        code: 'not-logged-into-store',
-        message: 'Not logged into store',
-        detail: 'No package_upload_request macaroons in local storage'
-      });
-    })
-    .then((packageUploadRequest) => {
-      let rootMacaroon;
-      let dischargeMacaroon;
-      try {
-        rootMacaroon = MacaroonsBuilder.deserialize(packageUploadRequest.root);
-        dischargeMacaroon = MacaroonsBuilder.deserialize(
-            packageUploadRequest.discharge);
-      } catch (e) {
-        throw new APICompatibleError({
-          code: 'not-logged-into-store',
-          message: 'Not logged into store',
-          detail: `Cannot deserialise package_upload_request macaroons: ${e}`
-        });
-      }
-      const root = rootMacaroon.serialize();
-      const discharge = MacaroonsBuilder.modify(rootMacaroon)
-        .prepare_for_request(dischargeMacaroon)
-        .getMacaroon()
-        .serialize();
-      return fetch(`${conf.get('STORE_API_URL')}/acl/`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-          'Authorization': `Macaroon root="${root}", discharge="${discharge}"`
-        },
-        body: JSON.stringify({
-          packages: [{ name: snapName, series: STORE_SERIES }],
-          permissions: ['package_upload'],
-          channels: STORE_CHANNELS
-        })
-      });
-    })
-    .then((response) => response.json().then((json) => {
-      if (response.status !== 200 || !json.macaroon) {
-        throw new APICompatibleError({
-          code: 'snap-name-not-registered',
-          message: 'Snap name is not registered in the store',
-          snap_name: snapName
-        });
-      }
-      return json.macaroon;
-    }));
-}
-
 export function createSnap(repository) {
   return (dispatch) => {
     const repositoryUrl = repository.url;
     if (repositoryUrl) {
-      const { owner, name, fullName } = repository;
+      const { fullName } = repository;
 
       dispatch({
         type: CREATE_SNAP,
         payload: { id: fullName }
       });
 
-      let snapName;
-      let packageUploadMacaroon;
-      return getSnapName(owner, name)
-        .then((foundSnapName) => {
-          snapName = foundSnapName;
-          return getPackageUploadMacaroon(snapName);
-        })
-        .then((macaroon) => {
-          packageUploadMacaroon = macaroon;
-          return fetch(`${BASE_URL}/api/launchpad/snaps`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              repository_url: repositoryUrl,
-              snap_name: snapName,
-              series: STORE_SERIES,
-              channels: STORE_CHANNELS
-            }),
-            credentials: 'same-origin'
-          });
-        })
-        .then(checkStatus)
-        .then(() => {
-          return fetch(`${BASE_URL}/api/launchpad/snaps/authorize`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              repository_url: repositoryUrl,
-              macaroon: packageUploadMacaroon
-            }),
-            credentials: 'same-origin'
-          });
-        })
+      return fetch(`${BASE_URL}/api/launchpad/snaps`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repository_url: repositoryUrl }),
+        credentials: 'same-origin'
+      })
         .then(checkStatus)
         .then(() => dispatch(createSnapSuccess(fullName)))
         .catch((error) => dispatch(createSnapError(fullName, error)));

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -2,8 +2,9 @@ import 'isomorphic-fetch';
 import localforage from 'localforage';
 import { MacaroonsBuilder } from 'macaroons.js';
 
-import { APICompatibleError, checkStatus } from '../helpers/api';
+import { APICompatibleError, checkStatus, getError } from '../helpers/api';
 import { conf } from '../helpers/config';
+import { checkPackageUploadRequest } from './auth-store';
 
 const BASE_URL = conf.get('BASE_URL');
 
@@ -11,63 +12,131 @@ export const REGISTER_NAME = 'REGISTER_NAME';
 export const REGISTER_NAME_SUCCESS = 'REGISTER_NAME_SUCCESS';
 export const REGISTER_NAME_ERROR = 'REGISTER_NAME_ERROR';
 
-export function registerName(fullName, snapName) {
-  return (dispatch) => {
-    dispatch({
-      type: REGISTER_NAME,
-      payload: { id: fullName, snapName }
-    });
+// XXX cjwatson 2017-02-08: Hardcoded for now, but should eventually be
+// configurable.
+const STORE_SERIES = '16';
+const STORE_CHANNELS = ['edge'];
 
-    return localforage.getItem('package_upload_request')
-      .catch(() => {
+function getPackageUploadRequestMacaroon() {
+  return localforage.getItem('package_upload_request')
+    .catch(() => null)
+    .then((packageUploadRequest) => {
+      if (packageUploadRequest === null) {
         throw new APICompatibleError({
           code: 'not-logged-into-store',
           message: 'Not logged into store',
           detail: 'No package_upload_request macaroons in local storage'
         });
+      }
+      let macaroons;
+      try {
+        macaroons = checkPackageUploadRequest(
+          packageUploadRequest.root, packageUploadRequest.discharge
+        );
+      } catch (e) {
+        throw new APICompatibleError({
+          code: 'not-logged-into-store',
+          message: 'Not logged into store',
+          detail: `Checking package_upload_request macaroons failed: ${e}`
+        });
+      }
+      const root = macaroons.root.serialize();
+      const discharge = MacaroonsBuilder.modify(macaroons.root)
+        .prepare_for_request(macaroons.discharge)
+        .getMacaroon()
+        .serialize();
+      return { root, discharge };
+    });
+}
+
+export function internalRegisterName(root, discharge, snapName) {
+  return fetch(`${BASE_URL}/api/store/register-name`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({
+      snap_name: snapName,
+      root,
+      discharge
+    })
+  })
+    .then((response) => {
+      if (response.status >= 200 && response.status < 300) {
+        return response;
+      } else {
+        return response.json().then((json) => {
+          if (response.status === 409 && json.code === 'already_owned') {
+            return { status: 201 };
+          } else {
+            throw getError(response, { status: 'error', payload: json });
+          }
+        });
+      }
+    });
+}
+
+function getPackageUploadMacaroon(root, discharge, snapName) {
+  return fetch(`${conf.get('STORE_API_URL')}/acl/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`
+    },
+    body: JSON.stringify({
+      packages: [{ name: snapName, series: STORE_SERIES }],
+      permissions: ['package_upload'],
+      channels: STORE_CHANNELS
+    })
+  })
+    .then((response) => response.json().then((json) => {
+      if (response.status !== 200 || !json.macaroon) {
+        throw new APICompatibleError({
+          code: 'snap-name-not-registered',
+          message: 'Snap name is not registered in the store',
+          snap_name: snapName
+        });
+      }
+      return json.macaroon;
+    }));
+}
+
+export function registerName(repository, snapName) {
+  return (dispatch) => {
+    const { fullName } = repository;
+
+    dispatch({
+      type: REGISTER_NAME,
+      payload: { id: fullName, snapName }
+    });
+
+    let root;
+    let discharge;
+    let packageUploadMacaroon;
+    return getPackageUploadRequestMacaroon()
+      .then((macaroons) => {
+        ({ root, discharge } = macaroons);
+        return internalRegisterName(root, discharge, snapName);
       })
-      .then((packageUploadRequest) => {
-        let rootMacaroon;
-        let dischargeMacaroon;
-        try {
-          rootMacaroon = MacaroonsBuilder.deserialize(
-              packageUploadRequest.root);
-          dischargeMacaroon = MacaroonsBuilder.deserialize(
-              packageUploadRequest.discharge);
-        } catch (e) {
-          throw new APICompatibleError({
-            code: 'not-logged-into-store',
-            message: 'Not logged into store',
-            detail: `Cannot deserialise package_upload_request macaroons: ${e}`
-          });
-        }
-        const root = rootMacaroon.serialize();
-        const discharge = MacaroonsBuilder.modify(rootMacaroon)
-          .prepare_for_request(dischargeMacaroon)
-          .getMacaroon()
-          .serialize();
-        return fetch(`${BASE_URL}/api/store/register-name`, {
+      .then(() => getPackageUploadMacaroon(root, discharge, snapName))
+      .then((macaroon) => {
+        packageUploadMacaroon = macaroon;
+        return fetch(`${BASE_URL}/api/launchpad/snaps/authorize`, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
+            repository_url: repository.url,
             snap_name: snapName,
-            root,
-            discharge
-          })
+            series: STORE_SERIES,
+            channels: STORE_CHANNELS,
+            macaroon: packageUploadMacaroon
+          }),
+          credentials: 'same-origin'
         });
       })
       .then(checkStatus)
-      .catch((error) => {
-        const response = error.response;
-        if (response && response.status === 409 &&
-            error.json.code === 'already_owned') {
-          return { status: 201 };
-        }
-        throw error;
-      })
       .then(() => dispatch(registerNameSuccess(fullName)))
       .catch((error) => dispatch(registerNameError(fullName, error)));
   };

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -8,6 +8,7 @@ import BuildStatus from '../build-status';
 
 import { signIntoStore } from '../../actions/auth-store';
 import { registerName } from '../../actions/register-name';
+import { parseGitHubRepoUrl } from '../../helpers/github-url';
 
 import styles from './repositoryRow.css';
 
@@ -53,8 +54,9 @@ class RepositoryRow extends Component {
     this.setState({ snapName });
   }
 
-  onRegisterClick(fullName) {
-    this.props.dispatch(registerName(fullName, this.state.snapName));
+  onRegisterClick(repositoryUrl) {
+    const repository = parseGitHubRepoUrl(repositoryUrl);
+    this.props.dispatch(registerName(repository, this.state.snapName));
   }
 
   renderUnconfiguredDropdown() {
@@ -71,7 +73,7 @@ class RepositoryRow extends Component {
   }
 
   renderUnregisteredDropdown() {
-    const { authStore, fullName, registerNameStatus } = this.props;
+    const { snap, authStore, registerNameStatus } = this.props;
 
     // If the user has signed into the store but we haven't fetched the
     // resulting discharge macaroon, we need to wait for that before
@@ -82,7 +84,7 @@ class RepositoryRow extends Component {
 
     let caption;
     if (registerNameStatus.error) {
-      caption = <div>{ registerNameStatus.error.json.detail }</div>;
+      caption = <div>{ registerNameStatus.error.message }</div>;
     } else {
       caption = (
         <div>
@@ -109,7 +111,7 @@ class RepositoryRow extends Component {
         registerNameStatus.isFetching ||
         authStoreFetchingDischarge
       );
-      actionOnClick = this.onRegisterClick.bind(this, fullName);
+      actionOnClick = this.onRegisterClick.bind(this, snap.git_repository_url);
       if (registerNameStatus.isFetching) {
         actionSpinner = true;
         actionText = 'Checking...';

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 import Button from '../vanilla/button';
 import { Row, Data, Dropdown } from '../vanilla/table-interactive';
 import BuildStatus from '../build-status';
+import { Message } from '../forms';
 
 import { signIntoStore } from '../../actions/auth-store';
 import { registerName } from '../../actions/register-name';
@@ -84,7 +85,11 @@ class RepositoryRow extends Component {
 
     let caption;
     if (registerNameStatus.error) {
-      caption = <div>{ registerNameStatus.error.message }</div>;
+      caption = (
+        <Message status='error'>
+          { registerNameStatus.error.message }
+        </Message>
+      );
     } else {
       caption = (
         <div>

--- a/src/common/helpers/api.js
+++ b/src/common/helpers/api.js
@@ -1,6 +1,9 @@
 export function getError(response, json) {
-  const message = (json.payload && json.payload.message) ||
-                  response.statusText;
+  // 'message' is produced by our own APIs; 'title' is produced by some
+  // store APIs that we call directly.
+  const message = (
+    json.payload && (json.payload.message || json.payload.title)
+  ) || response.statusText;
   const error = new Error(message);
   error.response = response;
   error.json = json;

--- a/test/unit/src/common/actions/t_create-snap.js
+++ b/test/unit/src/common/actions/t_create-snap.js
@@ -1,26 +1,17 @@
 import expect from 'expect';
 import { isFSA } from 'flux-standard-action';
 import nock from 'nock';
-import { MacaroonsBuilder } from 'macaroons.js';
-import proxyquire from 'proxyquire';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { conf } from '../../../../../src/common/helpers/config';
-import { makeLocalForageStub } from '../../../../helpers';
-
-const localForageStub = makeLocalForageStub();
-const createSnapModule = proxyquire.noCallThru().load(
-  '../../../../../src/common/actions/create-snap',
-  { 'localforage': localForageStub }
-);
-const {
+import {
   createSnaps,
   createSnapError,
   createSnapSuccess,
   setGitHubRepository
-} = createSnapModule;
-const ActionTypes = createSnapModule;
+} from '../../../../../src/common/actions/create-snap';
+import * as ActionTypes from '../../../../../src/common/actions/create-snap';
 
 const middlewares = [ thunk ];
 const mockStore = configureMockStore(middlewares);
@@ -42,10 +33,6 @@ describe('create snap actions', () => {
 
   beforeEach(() => {
     store = mockStore(initialState);
-  });
-
-  afterEach(() => {
-    localForageStub.clear();
   });
 
   context('setGitHubRepository', () => {
@@ -89,9 +76,6 @@ describe('create snap actions', () => {
     });
 
     it('stores a CREATE_SNAPS_START action', () => {
-      scope.get('/api/github/snapcraft-yaml/foo/bar')
-        .reply(200);
-
       return store.dispatch(createSnaps([ repository ]))
         .then(() => {
           expect(store.getActions()).toHaveActionOfType(
@@ -101,66 +85,16 @@ describe('create snap actions', () => {
         });
     });
 
-    it('stores an error on failure to get snap name', () => {
-      scope.get('/api/github/snapcraft-yaml/foo/bar')
-        .reply(400, {
-          status: 'error',
-          payload: {
-            code: 'snapcraft-yaml-no-name',
-            message: 'snapcraft.yaml has no top-level "name" attribute'
-          }
-        });
-
-      return store.dispatch(createSnaps([ repository ]))
-        .then(() => {
-          const errorAction = store.getActions().filter((action) => {
-            return action.type === ActionTypes.CREATE_SNAP_ERROR;
-          })[0];
-          expect(errorAction.payload.id).toBe('foo/bar');
-          expect(errorAction.payload.error.json.payload).toEqual({
-            code: 'snapcraft-yaml-no-name',
-            message: 'snapcraft.yaml has no top-level "name" attribute'
-          });
-          scope.done();
-        });
-    });
-
     context('if getting snap name succeeds', () => {
-      let storeScope;
-      let rootMacaroon;
-      let dischargeMacaroon;
-
-      beforeEach(() => {
-        scope.get('/api/github/snapcraft-yaml/foo/bar')
-          .reply(200, {
-            status: 'success',
+      it('stores an error on failure to create snap', () => {
+        scope
+          .post('/api/launchpad/snaps', { repository_url: repository.url })
+          .reply(400, {
+            status: 'error',
             payload: {
-              code: 'snapcraft-yaml-found',
-              contents: { name: 'test-snap' }
+              'code': 'not-logged-in',
+              'message': 'Not logged in'
             }
-          });
-        storeScope = nock(conf.get('STORE_API_URL'));
-        rootMacaroon = new MacaroonsBuilder('sca', 'key', 'id')
-          .add_third_party_caveat('sso', '3p key', 'sso id')
-          .getMacaroon();
-        dischargeMacaroon = new MacaroonsBuilder('sso', '3p key', 'sso id')
-          .getMacaroon();
-        localForageStub.store['package_upload_request'] = {
-          root: rootMacaroon.serialize(),
-          discharge: dischargeMacaroon.serialize()
-        };
-      });
-
-      it('stores an error on failure to get package upload macaroon', () => {
-        storeScope
-          .post('/acl/', {
-            packages: [{ name: 'test-snap', series: '16' }],
-            permissions: ['package_upload'],
-            channels: ['edge']
-          })
-          .reply(404, {
-            status: 404,
-            error_code: 'resource-not-found'
           });
 
         return store.dispatch(createSnaps([ repository ]))
@@ -170,116 +104,33 @@ describe('create snap actions', () => {
             })[0];
             expect(errorAction.payload.id).toBe('foo/bar');
             expect(errorAction.payload.error.json.payload).toEqual({
-              code: 'snap-name-not-registered',
-              message: 'Snap name is not registered in the store',
-              snap_name: 'test-snap'
+              code: 'not-logged-in',
+              message: 'Not logged in',
             });
             scope.done();
           });
       });
 
-      context('if getting package upload macaroon succeeds', () => {
-        beforeEach(() => {
-          // XXX check headers and body
-          storeScope.post('/acl/')
-            .reply(200, { macaroon: 'dummy-package-upload-macaroon' });
-        });
-
-        it('stores an error on failure to create snap', () => {
-          scope
-            .post('/api/launchpad/snaps', {
-              repository_url: repository.url,
-              snap_name: 'test-snap',
-              series: '16',
-              channels: ['edge']
-            })
-            .reply(400, {
-              status: 'error',
-              payload: {
-                'code': 'not-logged-in',
-                'message': 'Not logged in'
-              }
-            });
-
-          return store.dispatch(createSnaps([ repository ]))
-            .then(() => {
-              const errorAction = store.getActions().filter((action) => {
-                return action.type === ActionTypes.CREATE_SNAP_ERROR;
-              })[0];
-              expect(errorAction.payload.id).toBe('foo/bar');
-              expect(errorAction.payload.error.json.payload).toEqual({
-                code: 'not-logged-in',
-                message: 'Not logged in',
-              });
-              scope.done();
-            });
-        });
-
-        context('if creating snap succeeds', () => {
-          beforeEach(() => {
-            scope
-              .post('/api/launchpad/snaps', {
-                repository_url: repository.url,
-                snap_name: 'test-snap',
-                series: '16',
-                channels: ['edge']
-              })
-              .reply(201, {
-                status: 'success',
-                payload: {
-                  code: 'snap-created',
-                  message: 'dummy-caveat'
-                }
-              });
+      it('creates success action if creating snap succeeds', () => {
+        scope
+          .post('/api/launchpad/snaps', { repository_url: repository.url })
+          .reply(201, {
+            status: 'success',
+            payload: {
+              code: 'snap-created',
+              message: 'dummy-caveat'
+            }
           });
 
-          it('stores an error on failure to authorize snap', () => {
-            scope
-              .post('/api/launchpad/snaps/authorize', {
-                repository_url: repository.url,
-                macaroon: 'dummy-package-upload-macaroon'
-              })
-              .reply(400, {
-                status: 'error',
-                payload: {
-                  code: 'not-logged-in',
-                  message: 'Not logged in'
-                }
-              });
-
-            return store.dispatch(createSnaps([ repository ]))
-              .then(() => {
-                const errorAction = store.getActions().filter((action) => {
-                  return action.type === ActionTypes.CREATE_SNAP_ERROR;
-                })[0];
-                expect(errorAction.payload.id).toBe('foo/bar');
-                expect(errorAction.payload.error.json.payload).toEqual({
-                  'code': 'not-logged-in',
-                  'message': 'Not logged in'
-                });
-                scope.done();
-              });
+        const expectedAction = {
+          type: ActionTypes.CREATE_SNAP_SUCCESS,
+          payload: { id: 'foo/bar' }
+        };
+        return store.dispatch(createSnaps([ repository ]))
+          .then(() => {
+            expect(store.getActions()).toInclude(expectedAction);
+            scope.done();
           });
-
-          it('creates success action on successful creation', () => {
-            scope
-              .post('/api/launchpad/snaps/authorize', {
-                repository_url: repository.url,
-                macaroon: 'dummy-package-upload-macaroon'
-              })
-              .reply(204);
-
-            const expectedAction = {
-              type: ActionTypes.CREATE_SNAP_SUCCESS,
-              payload: { id: 'foo/bar' }
-            };
-            return store.dispatch(createSnaps([ repository ]))
-              .then(() => {
-                expect(store.getActions()).toInclude(expectedAction);
-                scope.done();
-              });
-          });
-        });
       });
     });
   });


### PR DESCRIPTION
Enabling a repository now creates a bare snap object in Launchpad with
no store configuration, and all the store configuration is filled in
later once the name is registered.  This lets us remove all dependencies
on being signed into the store from `/dashboard/select-repositories`.