### PR TITLE
Trigger builds if possible once name is registered

### DIFF
--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -5,6 +5,7 @@ import { MacaroonsBuilder } from 'macaroons.js';
 import { APICompatibleError, checkStatus, getError } from '../helpers/api';
 import { conf } from '../helpers/config';
 import { checkPackageUploadRequest } from './auth-store';
+import { requestBuilds } from './snap-builds';
 
 const BASE_URL = conf.get('BASE_URL');
 
@@ -103,7 +104,7 @@ function getPackageUploadMacaroon(root, discharge, snapName) {
     }));
 }
 
-export function registerName(repository, snapName) {
+export function registerName(repository, snapName, triggerBuilds) {
   return (dispatch) => {
     const { fullName } = repository;
 
@@ -115,7 +116,7 @@ export function registerName(repository, snapName) {
     let root;
     let discharge;
     let packageUploadMacaroon;
-    return getPackageUploadRequestMacaroon()
+    let promise = getPackageUploadRequestMacaroon()
       .then((macaroons) => {
         ({ root, discharge } = macaroons);
         return internalRegisterName(root, discharge, snapName);
@@ -139,6 +140,10 @@ export function registerName(repository, snapName) {
       .then(checkStatus)
       .then(() => dispatch(registerNameSuccess(fullName)))
       .catch((error) => dispatch(registerNameError(fullName, error)));
+    if (triggerBuilds) {
+      promise = promise.then(() => requestBuilds(repository.url)(dispatch));
+    }
+    return promise;
   };
 }
 

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -141,7 +141,7 @@ export function registerName(repository, snapName, triggerBuilds) {
       .then(() => dispatch(registerNameSuccess(fullName)))
       .catch((error) => dispatch(registerNameError(fullName, error)));
     if (triggerBuilds) {
-      promise = promise.then(() => requestBuilds(repository.url)(dispatch));
+      promise = promise.then(() => dispatch(requestBuilds(repository.url)));
     }
     return promise;
   };

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -68,8 +68,11 @@ class RepositoryRow extends Component {
   }
 
   onRegisterClick(repositoryUrl) {
+    const { snap } = this.props;
     const repository = parseGitHubRepoUrl(repositoryUrl);
-    this.props.dispatch(registerName(repository, this.state.snapName));
+    const { snapName } = this.state;
+    const triggerBuilds = (!!snap.snapcraft_data);
+    this.props.dispatch(registerName(repository, snapName, triggerBuilds));
   }
 
   componentWillReceiveProps(nextProps) {

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -116,7 +116,7 @@ describe('register name actions', () => {
         type: ActionTypes.REGISTER_NAME,
         payload: { id: 'foo/bar', snapName: 'test-snap' }
       };
-      return store.dispatch(registerName(repository, 'test-snap', false))
+      return store.dispatch(registerName(repository, 'test-snap'))
         .then(() => {
           expect(store.getActions()).toInclude(expectedAction);
           scope.done();
@@ -125,7 +125,7 @@ describe('register name actions', () => {
 
     it('stores an error if there is no package upload request ' +
        'macaroon', () => {
-      return store.dispatch(registerName(repository, 'test-snap', false))
+      return store.dispatch(registerName(repository, 'test-snap'))
         .then(() => {
           const errorAction = store.getActions().filter((action) => {
             return action.type === ActionTypes.REGISTER_NAME_ERROR;
@@ -153,7 +153,7 @@ describe('register name actions', () => {
             code: 'already_registered',
             detail: '\'test-snap\' is already registered.'
           });
-        return store.dispatch(registerName(repository, 'test-snap', false))
+        return store.dispatch(registerName(repository, 'test-snap'))
           .then(() => {
             const errorAction = store.getActions().filter((action) => {
               return action.type === ActionTypes.REGISTER_NAME_ERROR;
@@ -192,7 +192,7 @@ describe('register name actions', () => {
               error_code: 'resource-not-found'
             });
 
-          return store.dispatch(registerName(repository, 'test-snap', false))
+          return store.dispatch(registerName(repository, 'test-snap'))
             .then(() => {
               const errorAction = store.getActions().filter((action) => {
                 return action.type === ActionTypes.REGISTER_NAME_ERROR;
@@ -231,7 +231,7 @@ describe('register name actions', () => {
                 }
               });
 
-            return store.dispatch(registerName(repository, 'test-snap', false))
+            return store.dispatch(registerName(repository, 'test-snap'))
               .then(() => {
                 const errorAction = store.getActions().filter((action) => {
                   return action.type === ActionTypes.REGISTER_NAME_ERROR;
@@ -264,9 +264,7 @@ describe('register name actions', () => {
             });
 
             it('creates success action if not triggering builds', () => {
-              return store.dispatch(
-                registerName(repository, 'test-snap', false)
-              )
+              return store.dispatch(registerName(repository, 'test-snap'))
                 .then(() => {
                   expect(store.getActions()).toInclude(expectedAction);
                   scope.done();


### PR DESCRIPTION
Once snapcraft.yaml exists and the name is registered, we can trigger
builds.  One path for this (already implemented) is that if the name is
registered first then we may be told of a new snapcraft.yaml by way of a
webhook push event.  The other possibility is implemented here: if
snapcraft.yaml already exists when the name is registered, we should
trigger builds at that point.