### PR TITLE
Create webhook before creating snap

### DIFF
--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -31,7 +31,7 @@ export function createWebhook(repository) {
         return response;
       } else {
         return response.json().then((json) => {
-          if (json.payload && json.payload.code == 'github-already-created') {
+          if (json.payload && json.payload.code === 'github-already-created') {
             return response;
           }
           throw getError(response, json);

--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 
-import { checkStatus } from '../helpers/api';
+import { checkStatus, getError } from '../helpers/api';
 import { conf } from '../helpers/config';
 
 const BASE_URL = conf.get('BASE_URL');
@@ -18,6 +18,28 @@ export function setGitHubRepository(value) {
   };
 }
 
+export function createWebhook(repository) {
+  const { owner, name } = repository;
+  return fetch(`${BASE_URL}/api/github/webhook`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ owner, name }),
+    credentials: 'same-origin'
+  })
+    .then((response) => {
+      if (response.status >= 200 && response.status < 300) {
+        return response;
+      } else {
+        return response.json().then((json) => {
+          if (json.payload && json.payload.code == 'github-already-created') {
+            return response;
+          }
+          throw getError(response, json);
+        });
+      }
+    });
+}
+
 export function createSnap(repository) {
   return (dispatch) => {
     const repositoryUrl = repository.url;
@@ -29,12 +51,15 @@ export function createSnap(repository) {
         payload: { id: fullName }
       });
 
-      return fetch(`${BASE_URL}/api/launchpad/snaps`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ repository_url: repositoryUrl }),
-        credentials: 'same-origin'
-      })
+      return createWebhook(repository)
+        .then(() => {
+          return fetch(`${BASE_URL}/api/launchpad/snaps`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ repository_url: repositoryUrl }),
+            credentials: 'same-origin'
+          });
+        })
         .then(checkStatus)
         .then(() => dispatch(createSnapSuccess(fullName)))
         .catch((error) => dispatch(createSnapError(fullName, error)));


### PR DESCRIPTION
We used to create a webhook during the setup workflow, but that fell out
during the major reorganisations of the last couple of weeks.  This
restores it.  We can safely create the webhook as the very first thing
we do, since the webhook handler will fail cleanly if the snap doesn't
exist yet, and error handling is easier this way round.

This duplicates part of `src/common/actions/webhook.js`, but that can
just be removed after this is in place; we don't need to have separate
actions and state for this.