### PR TITLE
replace workflow image with ubuntu font as vectors

### DIFF
--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -81,7 +81,7 @@ class Landing extends Component {
         <section className={styles.section}>
 
           <div className={ `${styles.row} ${containerStyles.wrapper}`  }>
-            <img src='https://assets.ubuntu.com/v1/1037bac4-workflow.svg' width='100%' />
+            <img src='https://assets.ubuntu.com/v1/6bee41f5-workflow_text-to-path.svg' width='100%' />
           </div>
 
           <div className={ styles.centeredButton }>


### PR DESCRIPTION
## DONE

* replaced workflow image with a new svg with the ubuntu font as vectors

## QA 

1. on the landing page, see that the workflow image font is ubuntu now

Fixes #212 