### PR TITLE
Fix default heading align

### DIFF
--- a/src/common/components/vanilla/heading/index.js
+++ b/src/common/components/vanilla/heading/index.js
@@ -4,9 +4,9 @@ import styles from './heading.css';
 
 const Heading = (props) => {
   const H = props.heading || 'h1';
-  const align = props.align || 'left';
+  const align = props.align;
   return (
-    <H className={ `${styles[H]} ${styles[align]} `}>
+    <H className={ `${styles[H]} ${align && styles[align]} `}>
       { props.children }
     </H>
   );


### PR DESCRIPTION
With recent changes to headings they got `text-align: left` by default (if no other specified).
This has broken some headings already centered by styles from parent element.

By default heading should not specify alignment at all (so it would inherit text-align from parent).