### PR TITLE
Properly fetching data needed for first time heading

### DIFF
--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
+import { fetchUserSnaps } from '../../actions/snaps';
+import { fetchBuilds } from '../../actions/snap-builds';
 import { fetchUserRepositories } from '../../actions/repositories';
 import SelectRepositoryList from '../select-repository-list';
 import { HeadingThree } from '../vanilla/heading';
@@ -10,9 +12,29 @@ import { CardHighlighted } from '../vanilla/card';
 class SelectRepositoriesPage extends Component {
   componentDidMount() {
     const { authenticated } = this.props.auth;
+    const owner = this.props.user.login;
 
     if (authenticated) {
       this.props.dispatch(fetchUserRepositories());
+      this.props.dispatch(fetchUserSnaps(owner));
+    }
+
+    this.fetchData(this.props);
+  }
+
+  fetchData(props) {
+    const { snaps } = props;
+
+    if (snaps.success) {
+      snaps.snaps.forEach((snap) => {
+        this.props.dispatch(fetchBuilds(snap.git_repository_url, snap.self_link));
+      });
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.snaps.success !== nextProps.snaps.success) {
+      this.fetchData(nextProps);
     }
   }
 
@@ -20,7 +42,7 @@ class SelectRepositoriesPage extends Component {
     const { snaps, snapBuilds } = this.props;
     return (
       <div>
-        <FirstTimeHeading  snaps={snaps} snapBuilds={snapBuilds} />
+        <FirstTimeHeading snaps={snaps} snapBuilds={snapBuilds} />
         <CardHighlighted>
           <HeadingThree>
             Choose repos to add
@@ -34,6 +56,7 @@ class SelectRepositoriesPage extends Component {
 
 SelectRepositoriesPage.propTypes = {
   auth: PropTypes.object.isRequired,
+  user: PropTypes.object,
   snaps: PropTypes.object.isRequired,
   snapBuilds: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
@@ -42,12 +65,14 @@ SelectRepositoriesPage.propTypes = {
 function mapStateToProps(state) {
   const {
     auth,
+    user,
     snaps,
     snapBuilds
   } = state;
 
   return {
     auth,
+    user,
     snaps,
     snapBuilds
   };


### PR DESCRIPTION
Previously on select-repositories it was assumed that snaps and builds data will be available in the store already (from dashboard), but it turned out not to be true is some cases (like full page reloads).

So now we fetch all the data needed for first time heading in select-repositories too.

Should fix #195 and #214