### PR TITLE
Snap name registration tidying

### DIFF
--- a/src/common/components/forms/message.js
+++ b/src/common/components/forms/message.js
@@ -6,7 +6,7 @@ export default function Message({ children, status, text }) {
 
   return <div>
     { (children || text) &&
-      <p className={ style[status] }>{ children || text }</p>
+      <div className={ style[status] }>{ children || text }</div>
     }
   </div>;
 }

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -95,8 +95,8 @@ class RepositoriesList extends Component {
           <Head>
             <Row>
               <Header col="30">Name</Header>
-              <Header col="20">Configured</Header>
-              <Header col="20">Registered for publishing</Header>
+              <Header col="15">Configured</Header>
+              <Header col="25">Registered for publishing</Header>
               <Header col="30">Latest build</Header>
             </Row>
           </Head>

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -155,6 +155,8 @@ class RepositoryRow extends Component {
     if (registerNameStatus.success) {
       caption = <div>{ tickIcon } Registered successfully</div>;
     } else if ( registerNameStatus.error
+      && registerNameStatus.error.json
+      && registerNameStatus.error.json.payload
       && registerNameStatus.error.json.payload.code === 'already_registered') {
       caption = (
         <Message status='error'>

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -15,7 +15,7 @@ import { parseGitHubRepoUrl } from '../../helpers/github-url';
 
 import styles from './repositoryRow.css';
 
-const MINIMUM_SNAP_NAME_LENGTH = 2;
+const MINIMUM_SNAP_NAME_LENGTH = 1;
 
 const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-snap';
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -82,7 +82,7 @@ class RepositoryRow extends Component {
 
     if (/^-|-$/.test(snapName)) {
       clientValidationError = {
-        message: 'Sorry the name can\'t start or end with a hypen.'
+        message: 'Sorry the name can\'t start or end with a hyphen.'
       };
     } else if (!/[a-z0-9-]/.test(snapName)) {
       clientValidationError = {

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -10,7 +10,7 @@ import { Message } from '../forms';
 import templateYaml from './template-yaml.js';
 
 import { signIntoStore } from '../../actions/auth-store';
-import { registerName } from '../../actions/register-name';
+import { registerName, registerNameError } from '../../actions/register-name';
 import { parseGitHubRepoUrl } from '../../helpers/github-url';
 
 import styles from './repositoryRow.css';
@@ -74,11 +74,27 @@ class RepositoryRow extends Component {
   }
 
   onRegisterClick(repositoryUrl) {
-    const { snap } = this.props;
+    const { snap, dispatch, fullName } = this.props;
     const repository = parseGitHubRepoUrl(repositoryUrl);
     const { snapName } = this.state;
     const triggerBuilds = (!!snap.snapcraft_data);
-    this.props.dispatch(registerName(repository, snapName, triggerBuilds));
+    let clientValidationError = false;
+
+    if (/^-|-$/.test(snapName)) {
+      clientValidationError = {
+        message: 'Sorry the name can\'t start or end with a hypen.'
+      };
+    } else if (!/[a-z0-9-]/.test(snapName)) {
+      clientValidationError = {
+        message: 'Sorry the name may only contain lower-case letters, numbers and hyphens.'
+      };
+    }
+
+    if (clientValidationError) {
+      dispatch(registerNameError(fullName, clientValidationError));
+    } else {
+      dispatch(registerName(repository, snapName, triggerBuilds));
+    }
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -15,6 +15,7 @@ import { parseGitHubRepoUrl } from '../../helpers/github-url';
 
 import styles from './repositoryRow.css';
 
+const MINIMUM_SNAP_NAME_LENGTH = 2;
 
 const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-snap';
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
@@ -163,7 +164,7 @@ class RepositoryRow extends Component {
     let actionText;
     if (authStoreFetchingDischarge || authStore.authenticated) {
       actionDisabled = (
-        this.state.snapName === '' ||
+        !(this.state.snapName && this.state.snapName.length > MINIMUM_SNAP_NAME_LENGTH) ||
         registerNameStatus.isFetching ||
         authStoreFetchingDischarge
       );
@@ -188,12 +189,19 @@ class RepositoryRow extends Component {
           </Data>
         </Row>
         <Row>
-          <Button onClick={this.onUnregisteredClick.bind(this)} appearance='neutral'>
-            Cancel
-          </Button>
-          <Button disabled={actionDisabled} onClick={actionOnClick} isSpinner={actionSpinner}>
-            { actionText }
-          </Button>
+          <div className={ styles.buttonRow }>
+            <a onClick={this.onUnregisteredClick.bind(this)} className={ styles.cancel }>
+              Cancel
+            </a>
+            <Button
+              appearance="positive"
+              disabled={actionDisabled}
+              onClick={actionOnClick}
+              isSpinner={actionSpinner}
+            >
+              { actionText }
+            </Button>
+          </div>
         </Row>
       </Dropdown>
     );

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -16,6 +16,7 @@ import { parseGitHubRepoUrl } from '../../helpers/github-url';
 import styles from './repositoryRow.css';
 
 const MINIMUM_SNAP_NAME_LENGTH = 1;
+const FILE_NAME_CLAIM_URL = 'https://myapps.developer.ubuntu.com/dev/click-apps/register-name/';
 
 const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-snap';
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
@@ -85,6 +86,7 @@ class RepositoryRow extends Component {
         message: 'Sorry the name can\'t start or end with a hyphen.'
       };
     } else if (!/[a-z0-9-]/.test(snapName)) {
+      // XXX we can't get here on any browser that supports pattern validation
       clientValidationError = {
         message: 'Sorry the name may only contain lower-case letters, numbers and hyphens.'
       };
@@ -152,6 +154,17 @@ class RepositoryRow extends Component {
     let caption;
     if (registerNameStatus.success) {
       caption = <div>{ tickIcon } Registered successfully</div>;
+    } else if ( registerNameStatus.error
+      && registerNameStatus.error.json.payload.code === 'already_registered') {
+      caption = (
+        <Message status='error'>
+          <p>Sorry, that name is already taken. Try a different name.</p>
+          <p className={ styles.helpText }>
+            If you think you should have sole rights to the name,
+            you can <a href={ FILE_NAME_CLAIM_URL } target='_blank'>file a claim</a>.
+          </p>
+        </Message>
+      );
     } else if (registerNameStatus.error) {
       caption = (
         <Message status='error'>
@@ -248,10 +261,10 @@ class RepositoryRow extends Component {
     return (
       <Row isActive={isActive}>
         <Data col="30"><Link to={ `/${fullName}/builds` }>{ fullName }</Link></Data>
-        <Data col="20">
+        <Data col="15">
           { this.renderConfiguredStatus.call(this, snap.snapcraft_data) }
         </Data>
-        <Data col="20">
+        <Data col="25">
           { this.renderSnapName.call(this, registeredName, showRegisterNameInput) }
         </Data>
         <Data col="30">

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -1,5 +1,6 @@
 .snapName {
   width: 100%;
+  height: 24px;
 }
 
 .helpText {

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -11,3 +11,12 @@
   width: 22px;
   height: 16px;
 }
+
+.buttonRow {
+  padding: 16px;
+  text-align: right;
+}
+
+.cancel {
+  margin:0 2em;
+}

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
+import { fetchUserSnaps } from '../../actions/snaps';
+import { fetchBuilds } from '../../actions/snap-builds';
 import { fetchUserRepositories } from '../../actions/repositories';
 import SelectRepositoryList from '../select-repository-list';
 import { HeadingThree } from '../vanilla/heading';
@@ -10,9 +12,29 @@ import { CardHighlighted } from '../vanilla/card';
 class SelectRepositoriesPage extends Component {
   componentDidMount() {
     const { authenticated } = this.props.auth;
+    const owner = this.props.user.login;
 
     if (authenticated) {
       this.props.dispatch(fetchUserRepositories());
+      this.props.dispatch(fetchUserSnaps(owner));
+    }
+
+    this.fetchData(this.props);
+  }
+
+  fetchData(props) {
+    const { snaps } = props;
+
+    if (snaps.success) {
+      snaps.snaps.forEach((snap) => {
+        this.props.dispatch(fetchBuilds(snap.git_repository_url, snap.self_link));
+      });
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.snaps.success !== nextProps.snaps.success) {
+      this.fetchData(nextProps);
     }
   }
 
@@ -20,7 +42,7 @@ class SelectRepositoriesPage extends Component {
     const { snaps, snapBuilds } = this.props;
     return (
       <div>
-        <FirstTimeHeading  snaps={snaps} snapBuilds={snapBuilds} />
+        <FirstTimeHeading snaps={snaps} snapBuilds={snapBuilds} />
         <CardHighlighted>
           <HeadingThree>
             Choose repos to add
@@ -34,6 +56,7 @@ class SelectRepositoriesPage extends Component {
 
 SelectRepositoriesPage.propTypes = {
   auth: PropTypes.object.isRequired,
+  user: PropTypes.object,
   snaps: PropTypes.object.isRequired,
   snapBuilds: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
@@ -42,12 +65,14 @@ SelectRepositoriesPage.propTypes = {
 function mapStateToProps(state) {
   const {
     auth,
+    user,
     snaps,
     snapBuilds
   } = state;
 
   return {
     auth,
+    user,
     snaps,
     snapBuilds
   };

--- a/src/common/components/vanilla/heading/index.js
+++ b/src/common/components/vanilla/heading/index.js
@@ -4,9 +4,9 @@ import styles from './heading.css';
 
 const Heading = (props) => {
   const H = props.heading || 'h1';
-  const align = props.align || 'left';
+  const align = props.align;
   return (
-    <H className={ `${styles[H]} ${styles[align]} `}>
+    <H className={ `${styles[H]} ${align && styles[align]} `}>
       { props.children }
     </H>
   );

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -83,7 +83,7 @@ class Landing extends Component {
         <section className={styles.section}>
 
           <div className={ `${styles.row} ${containerStyles.wrapper}`  }>
-            <img src='https://assets.ubuntu.com/v1/6bee41f5-workflow_text-to-path.svg' width='100%' />
+            <img src='https://assets.ubuntu.com/v1/84ce5b81-workflow_text-to-path02.svg' width='100%' />
           </div>
 
           <div className={ styles.centeredButton }>


### PR DESCRIPTION
Asking for review early, even though this doesn't cover all error states and keeping the dropdown open through SSO dance.

## Missing, to include in follow up:

* We're not handling the case when the SSO session expires (or maybe the macaroon?) in the background, the user is left with no clear way of dealing with that (the button does not change to 'Sign in').

## To QA:

* Click "Not registered" in repos to build and publish list.
* Check register button is green and on RHS appropriately spaced.
* Check cancel button is plain text.
* Enter "-ubuntu" in text input, check error is "Sorry the name can't start or end with a hyphen."
* Enter "ubuntu-" ... check as above.
* Enter "ubuntu" in text input, check error is "Sorry, that name is already taken. Try a different name.
If you think you should have sole rights to the name, you can file a claim."