### PR TITLE
Updating store_name in snap when name is registered

### DIFF
--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -138,7 +138,7 @@ export function registerName(repository, snapName, triggerBuilds) {
         });
       })
       .then(checkStatus)
-      .then(() => dispatch(registerNameSuccess(fullName)))
+      .then(() => dispatch(registerNameSuccess(fullName, snapName)))
       .catch((error) => dispatch(registerNameError(fullName, error)));
     if (triggerBuilds) {
       promise = promise.then(() => dispatch(requestBuilds(repository.url)));
@@ -147,10 +147,10 @@ export function registerName(repository, snapName, triggerBuilds) {
   };
 }
 
-export function registerNameSuccess(id) {
+export function registerNameSuccess(id, snapName) {
   return {
     type: REGISTER_NAME_SUCCESS,
-    payload: { id }
+    payload: { id, snapName }
   };
 }
 

--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -1,4 +1,31 @@
 import * as ActionTypes from '../actions/snaps';
+import * as RegisterNameActionTypes from '../actions/register-name';
+import { getGitHubRepoUrl } from '../helpers/github-url';
+
+function findSnapByFullName(snaps, fullName) {
+  const snap = snaps.filter((snap) => {
+    return snap.git_repository_url === getGitHubRepoUrl(fullName);
+  })[0];
+
+  return snap;
+}
+
+function updateRegisteredName(snaps, fullName, snapName) {
+  if (!snaps) {
+    return snaps;
+  }
+
+  const updatedSnaps = [ ...snaps ]; // copy snaps array
+  const snap = findSnapByFullName(updatedSnaps, fullName);
+  const index = updatedSnaps.indexOf(snap);
+
+  if (snap && index !== -1) {
+    // change snap at correct index with new updated snap object
+    updatedSnaps[index] = { ...snap, store_name: snapName };
+  }
+
+  return updatedSnaps;
+}
 
 export function snaps(state = {
   isFetching: false,
@@ -30,6 +57,11 @@ export function snaps(state = {
         isFetching: false,
         success: false,
         error: action.payload
+      };
+    case RegisterNameActionTypes.REGISTER_NAME_SUCCESS:
+      return {
+        ...state,
+        snaps: updateRegisteredName(state.snaps, action.payload.id, action.payload.snapName)
       };
     default:
       return state;

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -248,7 +248,7 @@ describe('register name actions', () => {
           context('if authorizing snap succeeds', () => {
             const expectedAction = {
               type: ActionTypes.REGISTER_NAME_SUCCESS,
-              payload: { id: 'foo/bar' }
+              payload: { id: 'foo/bar', snapName: 'test-snap' }
             };
 
             beforeEach(() => {
@@ -330,15 +330,16 @@ describe('register name actions', () => {
 
   context('registerNameSuccess', () => {
     let id = 'foo/bar';
+    let snapName = 'foo-bar';
 
     beforeEach(() => {
-      action = registerNameSuccess(id);
+      action = registerNameSuccess(id, snapName);
     });
 
     it('creates an action to store success', () => {
       const expectedAction = {
         type: ActionTypes.REGISTER_NAME_SUCCESS,
-        payload: { id }
+        payload: { id, snapName }
       };
 
       store.dispatch(action);

--- a/test/unit/src/common/reducers/t_snaps.js
+++ b/test/unit/src/common/reducers/t_snaps.js
@@ -2,6 +2,7 @@ import expect from 'expect';
 
 import { snaps } from '../../../../../src/common/reducers/snaps';
 import * as ActionTypes from '../../../../../src/common/actions/snaps';
+import * as RegisterNameActionTypes from '../../../../../src/common/actions/register-name';
 
 describe('snaps reducers', () => {
   const initialState = {
@@ -84,7 +85,7 @@ describe('snaps reducers', () => {
     const state = {
       ...initialState,
       success: true,
-      repos: SNAPS,
+      snaps: SNAPS,
       isFetching: true
     };
 
@@ -103,4 +104,27 @@ describe('snaps reducers', () => {
       });
     });
   });
+
+  context('REGISTER_NAME_SUCCESS', () => {
+    const state = {
+      ...initialState,
+      success: true,
+      snaps: SNAPS,
+      isFetching: true
+    };
+
+    const action = {
+      type: RegisterNameActionTypes.REGISTER_NAME_SUCCESS,
+      payload: {
+        id: 'anowner/anothername',
+        snapName: 'new-test-snap-name'
+      }
+    };
+
+    it('should update store_name of given snap', () => {
+      expect(snaps(state, action).snaps[0].store_name).toBe('test-snap-store-name');
+      expect(snaps(state, action).snaps[1].store_name).toBe('new-test-snap-name');
+    });
+  });
+
 });


### PR DESCRIPTION
Snaps with registered name should have `store_name` property set to a registered name (which is done on LP side)

Right now after registering the name from BSI we are not updating snaps list, so on client side they don't have this property set yet, so for example first time heading does not properly move to next step (because it sees snaps still as unregistered).

We could possibly reload snaps list (fetch them again) when name is registered, but this will be an unnecessary request and UI update.

In this PR I update the `store_name` directly in snaps data in redux store in response REGISTER_NAME_SUCCESS action.