### PR TITLE
Add proxy routes for store account management

### DIFF
--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -92,7 +92,7 @@ function getPackageUploadRequestPermission() {
       'Accept': 'application/json'
     },
     body: JSON.stringify({
-      permissions: ['package_upload_request'],
+      permissions: ['package_upload_request', 'edit_account'],
       channels: conf.get('STORE_ALLOWED_CHANNELS'),
       expires: moment()
         .add(lifetime, 'seconds')

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -21,3 +21,64 @@ export const registerName = (req, res) => {
     });
   });
 };
+
+export const getAccount = (req, res) => {
+  const root = req.query.root;
+  const discharge = req.query.discharge;
+
+  return fetch(`${conf.get('STORE_API_URL')}/account`, {
+    headers: {
+      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
+      'Accept': 'application/json'
+    }
+  }).then((response) => {
+    return response.json().then((json) => {
+      return res.status(response.status).send(json);
+    });
+  });
+};
+
+export const patchAccount = (req, res) => {
+  const shortNamespace = req.body.short_namespace;
+  const root = req.body.root;
+  const discharge = req.body.discharge;
+
+  return fetch(`${conf.get('STORE_API_URL')}/account`, {
+    method: 'PATCH',
+    headers: {
+      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ short_namespace: shortNamespace })
+  }).then((response) => {
+    return response.text().then((text) => {
+      let json;
+      if (text === '') {
+        json = null;
+      } else {
+        json = JSON.parse(text);
+      }
+      return res.status(response.status).send(json);
+    });
+  });
+};
+
+export const signAgreement = (req, res) => {
+  const latestTosAccepted = req.body.latest_tos_accepted;
+  const root = req.body.root;
+  const discharge = req.body.discharge;
+
+  return fetch(`${conf.get('STORE_API_URL')}/agreement/`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({ latest_tos_accepted: latestTosAccepted })
+  }).then((response) => {
+    return response.json().then((json) => {
+      return res.status(response.status).send(json);
+    });
+  });
+};

--- a/src/server/routes/store.js
+++ b/src/server/routes/store.js
@@ -1,11 +1,23 @@
 import { Router } from 'express';
 import { json } from 'body-parser';
 
-import { registerName } from '../handlers/store';
+import {
+  getAccount,
+  patchAccount,
+  registerName,
+  signAgreement
+} from '../handlers/store';
 
 const router = Router();
 
 router.use('/store/register-name', json());
 router.post('/store/register-name', registerName);
+
+router.use('/store/account', json());
+router.get('/store/account', getAccount);
+router.patch('/store/account', patchAccount);
+
+router.use('/store/agreement', json());
+router.post('/store/agreement', signAgreement);
 
 export default router;

--- a/test/routes/src/server/routes/t_store.js
+++ b/test/routes/src/server/routes/t_store.js
@@ -67,4 +67,176 @@ describe('The store API endpoint', () => {
         .end(done);
     });
   });
+
+  describe('GET account route', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('passes request through to store', (done) => {
+      const scope = nock(conf.get('STORE_API_URL'))
+        .get('/account')
+        .matchHeader(
+          'Authorization',
+          'Macaroon root="dummy-root", discharge="dummy-discharge"'
+        )
+        .reply(200, { account_id: 'test-account-id' });
+
+      supertest(app)
+        .get('/store/account')
+        .query({
+          root: 'dummy-root',
+          discharge: 'dummy-discharge'
+        })
+        .expect((res) => {
+          scope.done();
+          expect(res.status).toBe(200);
+          expect(res.body).toEqual({ account_id: 'test-account-id' });
+        })
+        .end(done);
+    });
+
+    it('handles error responses reasonably', (done) => {
+      const error = {
+        code: 'user-not-ready',
+        message: 'Developer has not signed agreement.'
+      };
+      const scope = nock(conf.get('STORE_API_URL'))
+        .get('/account')
+        .matchHeader(
+          'Authorization',
+          'Macaroon root="dummy-root", discharge="dummy-discharge"'
+        )
+        .reply(403, { error_list: [error] });
+
+      supertest(app)
+        .get('/store/account')
+        .query({
+          root: 'dummy-root',
+          discharge: 'dummy-discharge'
+        })
+        .expect((res) => {
+          scope.done();
+          expect(res.status).toBe(403);
+          expect(res.body).toEqual({ error_list: [error] });
+        })
+        .end(done);
+    });
+  });
+
+  describe('PATCH account route', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('passes request through to store', (done) => {
+      const scope = nock(conf.get('STORE_API_URL'))
+        .patch('/account', { short_namespace: 'test-namespace' })
+        .matchHeader(
+          'Authorization',
+          'Macaroon root="dummy-root", discharge="dummy-discharge"'
+        )
+        .reply(204);
+
+      supertest(app)
+        .patch('/store/account')
+        .send({
+          short_namespace: 'test-namespace',
+          root: 'dummy-root',
+          discharge: 'dummy-discharge'
+        })
+        .expect((res) => {
+          scope.done();
+          expect(res.status).toBe(204);
+          expect(res.body).toEqual({});
+        })
+        .end(done);
+    });
+
+    it('handles error responses reasonably', (done) => {
+      const error = {
+        code: 'user-not-ready',
+        message: 'Developer has not signed agreement.'
+      };
+      const scope = nock(conf.get('STORE_API_URL'))
+        .patch('/account', { short_namespace: 'test-namespace' })
+        .matchHeader(
+          'Authorization',
+          'Macaroon root="dummy-root", discharge="dummy-discharge"'
+        )
+        .reply(403, { error_list: [error] });
+
+      supertest(app)
+        .patch('/store/account')
+        .send({
+          short_namespace: 'test-namespace',
+          root: 'dummy-root',
+          discharge: 'dummy-discharge'
+        })
+        .expect((res) => {
+          scope.done();
+          expect(res.status).toBe(403);
+          expect(res.body).toEqual({ error_list: [error] });
+        })
+        .end(done);
+    });
+  });
+
+  describe('sign agreement route', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('passes request through to store', (done) => {
+      const scope = nock(conf.get('STORE_API_URL'))
+        .post('/agreement/', { latest_tos_accepted: true })
+        .matchHeader(
+          'Authorization',
+          'Macaroon root="dummy-root", discharge="dummy-discharge"'
+        )
+        .reply(200, { latest_tos_accepted: true });
+
+      supertest(app)
+        .post('/store/agreement')
+        .send({
+          latest_tos_accepted: true,
+          root: 'dummy-root',
+          discharge: 'dummy-discharge'
+        })
+        .expect((res) => {
+          scope.done();
+          expect(res.status).toBe(200);
+          expect(res.body).toEqual({ latest_tos_accepted: true });
+        })
+        .end(done);
+    });
+
+    it('handles error responses reasonably', (done) => {
+      const error = {
+        code: 'bad-request',
+        message: '`latest_tos_accepted` must be `true`'
+      };
+      const scope = nock(conf.get('STORE_API_URL'))
+        .post('/agreement/', { latest_tos_accepted: false })
+        .matchHeader(
+          'Authorization',
+          'Macaroon root="dummy-root", discharge="dummy-discharge"'
+        )
+        .reply(400, { error_list: [error] });
+
+      supertest(app)
+        .post('/store/agreement')
+        .send({
+          latest_tos_accepted: false,
+          root: 'dummy-root',
+          discharge: 'dummy-discharge'
+        })
+        .expect((res) => {
+          scope.done();
+          expect(res.status).toBe(400);
+          expect(res.body).toEqual({ error_list: [error] });
+        })
+        .end(done);
+    });
+  });
 });

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -350,7 +350,7 @@ describe('store authentication actions', () => {
           .getMacaroon();
         storeApi.post('/acl/', (body) => {
           if (!tmatch(body, {
-            permissions: ['package_upload_request'],
+            permissions: ['package_upload_request', 'edit_account'],
             channels: ['edge'],
           })) {
             return false;


### PR DESCRIPTION
These will let us deal with signing the developer agreement and setting
the short namespace.

We now request the new `edit_account` macaroon permission along with
`package_upload_request`, so that we can use `PATCH /dev/api/account`.