### PR TITLE
Improve handling of new store accounts

### DIFF
--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { conf } from '../../helpers/config';
 import {
   checkSignedIntoStore,
+  getAccountInfo,
   getSSODischarge
 } from '../../actions/auth-store';
 import { createSnap } from '../../actions/create-snap';
@@ -19,11 +20,28 @@ import styles from './repositoriesList.css';
 const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
 
 class RepositoriesList extends Component {
+  fetchAuthData(authStore) {
+    if (authStore.authenticated === null) {
+      this.props.dispatch(checkSignedIntoStore());
+    } else if (authStore.hasShortNamespace === null) {
+      this.props.dispatch(getAccountInfo(authStore.userName));
+    }
+  }
+
   componentDidMount() {
     if (this.props.authStore.hasDischarge) {
       this.props.dispatch(getSSODischarge());
-    } else if (this.props.authStore.authenticated === null) {
-      this.props.dispatch(checkSignedIntoStore());
+    } else {
+      this.fetchAuthData(this.props.authStore);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const authStore = this.props.authStore;
+    const nextAuthStore = nextProps.authStore;
+    if (authStore.authenticated !== nextAuthStore.authenticated ||
+        authStore.hasShortNamespace !== nextAuthStore.hasShortNamespace) {
+      this.fetchAuthData(nextAuthStore);
     }
   }
 

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -21,3 +21,9 @@
 .cancel {
   margin:0 2em;
 }
+
+.external {
+  background: url($icon-link-external) 100% 0 no-repeat;
+  background-size: 0.7em;
+  padding-right: 0.9em;
+}

--- a/src/common/reducers/auth-store.js
+++ b/src/common/reducers/auth-store.js
@@ -4,6 +4,9 @@ export function authStore(state = {
   isFetching: false,
   hasDischarge: false,
   authenticated: null,
+  userName: null,
+  signedAgreement: null,
+  hasShortNamespace: null,
   error: null
 }, action) {
   switch (action.type) {
@@ -36,6 +39,8 @@ export function authStore(state = {
         isFetching: false,
         hasDischarge: false,
         authenticated: true,
+        signedAgreement: null,
+        hasShortNamespace: null,
         error: null
       };
     case ActionTypes.GET_SSO_DISCHARGE_ERROR:
@@ -55,6 +60,8 @@ export function authStore(state = {
         ...state,
         isFetching: false,
         authenticated: action.payload,
+        signedAgreement: null,
+        hasShortNamespace: null,
         error: null
       };
     case ActionTypes.CHECK_SIGNED_INTO_STORE_ERROR:
@@ -62,7 +69,35 @@ export function authStore(state = {
         ...state,
         isFetching: false,
         authenticated: false,
+        signedAgreement: null,
+        hasShortNamespace: null,
         error: action.payload
+      };
+    case ActionTypes.GET_ACCOUNT_INFO:
+      return {
+        ...state,
+        isFetching: true,
+        signedAgreement: null,
+        hasShortNamespace: null
+      };
+    case ActionTypes.GET_ACCOUNT_INFO_SUCCESS:
+      return {
+        ...state,
+        isFetching: false,
+        signedAgreement: action.payload.signedAgreement,
+        hasShortNamespace: action.payload.hasShortNamespace,
+        error: null
+      };
+    case ActionTypes.GET_ACCOUNT_INFO_ERROR:
+      return {
+        ...state,
+        isFetching: false,
+        error: action.payload
+      };
+    case ActionTypes.SIGN_AGREEMENT_SUCCESS:
+      return {
+        ...state,
+        signedAgreement: true
       };
     case ActionTypes.SIGN_OUT_OF_STORE_ERROR:
       return {

--- a/src/server/handlers/login.js
+++ b/src/server/handlers/login.js
@@ -65,7 +65,8 @@ export const processVerifiedAssertion = (req, res, next, error, result) => {
   }
 
   req.session.authenticated = result.authenticated;
-  req.session.name = result.fullname;
+  req.session.nickname = result.nickname;
+  req.session.fullname = result.fullname;
   req.session.email = result.email;
   if (result.discharge) {
     // Temporarily stash the discharge macaroon in the session.  The client

--- a/src/server/handlers/universal.js
+++ b/src/server/handlers/universal.js
@@ -35,9 +35,8 @@ export const handleMatch = (req, res, error, redirectLocation, renderProps) => {
   } else if (renderProps) {
 
     const initialState = {
-      auth: {
-        authenticated: false
-      }
+      auth: { authenticated: false },
+      authStore: {}
     };
 
     if (req.session.githubAuthenticated) {
@@ -53,10 +52,14 @@ export const handleMatch = (req, res, error, redirectLocation, renderProps) => {
       return;
     }
 
+    if (req.session.nickname) {
+      initialState.authStore.userName = req.session.nickname;
+    }
+
     if (req.session.ssoDischarge) {
       // Tell the client that it can pick up a discharge macaroon from the
       // session and move it to local storage.
-      initialState.authStore = { hasDischarge: true };
+      initialState.authStore.hasDischarge = true;
     }
 
     const store = configureStore(initialState);

--- a/src/server/openid/relyingparty.js
+++ b/src/server/openid/relyingparty.js
@@ -48,8 +48,9 @@ const RelyingPartyFactory = (session, returnUrl, caveatId) => {
 
   const extensions = [
     new openid.SimpleRegistration({
-      'email' : 'required',
-      'fullname' : 'required'
+      'email': 'required',
+      'fullname': 'required',
+      'nickname': 'required'
     })
   ];
 

--- a/test/unit/src/common/reducers/t_auth-store.js
+++ b/test/unit/src/common/reducers/t_auth-store.js
@@ -8,6 +8,9 @@ describe('authStore reducers', () => {
     isFetching: false,
     hasDischarge: false,
     authenticated: null,
+    userName: null,
+    signedAgreement: null,
+    hasShortNamespace: null,
     error: null
   };
 
@@ -98,6 +101,14 @@ describe('authStore reducers', () => {
       it('clears authenticated status', () => {
         expect(authStore(state, action).authenticated).toBe(false);
       });
+
+      it('clears signed-agreement status', () => {
+        expect(authStore(state, action).signedAgreement).toBe(null);
+      });
+
+      it('clears has-short-namespace status', () => {
+        expect(authStore(state, action).hasShortNamespace).toBe(null);
+      });
     });
 
     context('if authenticated', () => {
@@ -112,6 +123,14 @@ describe('authStore reducers', () => {
 
       it('sets authenticated status', () => {
         expect(authStore(state, action).authenticated).toBe(true);
+      });
+
+      it('clears signed-agreement status', () => {
+        expect(authStore(state, action).signedAgreement).toBe(null);
+      });
+
+      it('clears has-short-namespace status', () => {
+        expect(authStore(state, action).hasShortNamespace).toBe(null);
       });
     });
   });
@@ -135,8 +154,90 @@ describe('authStore reducers', () => {
       expect(authStore(state, action).hasDischarge).toBe(false);
     });
 
+    it('clears signed-agreement status', () => {
+      expect(authStore(state, action).signedAgreement).toBe(null);
+    });
+
+    it('clears has-short-namespace status', () => {
+      expect(authStore(state, action).hasShortNamespace).toBe(null);
+    });
+
     it('stores error', () => {
       expect(authStore(state, action).error).toEqual(action.payload);
+    });
+  });
+
+  context('GET_ACCOUNT_INFO', () => {
+    const state = {
+      ...initialState,
+      signedAgreement: 'sentinel',
+      hasShortNamespace: 'sentinel'
+    };
+    const action = { type: ActionTypes.GET_ACCOUNT_INFO };
+
+    it('sets fetching status', () => {
+      expect(authStore(state, action).isFetching).toBe(true);
+    });
+
+    it('clears signed-agreement status', () => {
+      expect(authStore(state, action).signedAgreement).toBe(null);
+    });
+
+    it('clears has-short-namespace status', () => {
+      expect(authStore(state, action).hasShortNamespace).toBe(null);
+    });
+  });
+
+  context('GET_ACCOUNT_INFO_SUCCESS', () => {
+    const state = {
+      ...initialState,
+      isFetching: true
+    };
+    const action = {
+      type: ActionTypes.GET_ACCOUNT_INFO_SUCCESS,
+      payload: {
+        signedAgreement: 'sentinel-1',
+        hasShortNamespace: 'sentinel-2'
+      }
+    };
+
+    it('clears fetching status', () => {
+      expect(authStore(state, action).isFetching).toBe(false);
+    });
+
+    it('copies signed-agreement status', () => {
+      expect(authStore(state, action).signedAgreement).toBe('sentinel-1');
+    });
+
+    it('copies has-short-namespace status', () => {
+      expect(authStore(state, action).hasShortNamespace).toBe('sentinel-2');
+    });
+  });
+
+  context('GET_ACCOUNT_INFO_ERROR', () => {
+    const state = {
+      ...initialState,
+      isFetching: true
+    };
+    const action = {
+      type: ActionTypes.GET_ACCOUNT_INFO_ERROR,
+      payload: 'Something went wrong!',
+      error: true
+    };
+
+    it('clears fetching status', () => {
+      expect(authStore(state, action).isFetching).toBe(false);
+    });
+
+    it('stores error', () => {
+      expect(authStore(state, action).error).toEqual(action.payload);
+    });
+  });
+
+  context('SIGN_AGREEMENT_SUCCESS', () => {
+    it('sets signed-agreement status', () => {
+      const action = { type: ActionTypes.SIGN_AGREEMENT_SUCCESS };
+      expect(authStore(initialState, action).signedAgreement).toBe(true);
     });
   });
 


### PR DESCRIPTION
New store accounts may require some additional setup.  Prompt the user
to sign the developer agreement if necessary, and try to set their short
developer namespace to be the same as their SSO username.