### PR TITLE
Fetch all snap info in one request

### DIFF
--- a/src/common/actions/snap-builds.js
+++ b/src/common/actions/snap-builds.js
@@ -60,7 +60,7 @@ export function fetchSnap(repositoryUrl) {
         .then(checkStatus)
         .then(response => response.json())
         .then((json) => {
-          const snapLink = json.payload.message;
+          const snapLink = json.payload.snap.self_link;
           dispatch({
             type: FETCH_SNAP_SUCCESS,
             payload: {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -427,7 +427,6 @@ export const findSnap = (req, res) => {
         status: 'success',
         payload: {
           code: 'snap-found',
-          message: snap.self_link, // TODO: bartaz it's just for backwards compatibility for now
           snap
         }
       });

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -341,8 +341,8 @@ export const internalFindSnap = async (repositoryUrl) => {
         // https://github.com/babel/babel-eslint/issues/415
         for await (const entry of result) { // eslint-disable-line semi
           if (entry.owner_link.endsWith(`/~${username}`)) {
-            return getMemcached().set(cacheId, entry.self_link, 3600, () => {
-              return resolve(entry.self_link);
+            return getMemcached().set(cacheId, entry, 3600, () => {
+              return resolve(entry);
             });
           }
         }
@@ -422,12 +422,13 @@ export const findSnaps = (req, res) => {
 
 export const findSnap = (req, res) => {
   internalFindSnap(req.query.repository_url)
-    .then((snapUrl) => {
+    .then((snap) => {
       return res.status(200).send({
         status: 'success',
         payload: {
           code: 'snap-found',
-          message: snapUrl
+          message: snap.self_link, // TODO: bartaz it's just for backwards compatibility for now
+          snap
         }
       });
     })
@@ -445,7 +446,7 @@ export const authorizeSnap = (req, res) => {
   return checkAdminPermissions(req.session, repositoryUrl)
     .then(() => internalFindSnap(repositoryUrl))
     .then((result) => {
-      snapUrl = result;
+      snapUrl = result.self_link;
       return getLaunchpad().patch(snapUrl, {
         store_upload: true,
         store_series_link: `/+snappy-series/${series}`,
@@ -506,7 +507,7 @@ export const requestSnapBuilds = (req, res) => {
   const lpClient = getLaunchpad();
   checkAdminPermissions(req.session, req.body.repository_url)
     .then(() => internalFindSnap(req.body.repository_url))
-    .then((snapUrl) => lpClient.named_post(snapUrl, 'requestAutoBuilds'))
+    .then((snap) => lpClient.named_post(snap.self_link, 'requestAutoBuilds'))
     .then((builds) => {
       return res.status(201).send({
         status: 'success',

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -65,7 +65,6 @@ export const notify = (req, res) => {
     // the content of the push event.
     return getMemcached().del(getSnapNameCacheId(repositoryUrl))
       .then(() => internalFindSnap(repositoryUrl))
-      .then((snapUrl) => lpClient.get(snapUrl))
       .then((snap) => {
         if (!snap.auto_build) {
           return internalGetSnapcraftYaml(owner, name)

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -733,11 +733,14 @@ describe('The Launchpad API endpoint', () => {
 
     context('when repository is memcached', () => {
       const repositoryUrl = 'https://github.com/anowner/aname';
-      const snapUrl = `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`;
+      const snap = {
+        self_link: `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`
+      };
+
 
       before(() => {
         setupInMemoryMemcached();
-        getMemcached().set(getRepositoryUrlCacheId(repositoryUrl), snapUrl);
+        getMemcached().set(getRepositoryUrlCacheId(repositoryUrl), snap);
       });
 
       after(() => {
@@ -763,7 +766,7 @@ describe('The Launchpad API endpoint', () => {
         supertest(app)
           .get('/launchpad/snaps')
           .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasMessage('snap-found', snapUrl))
+          .expect(hasMessage('snap-found', snap.self_link))
           .end(done);
       });
 

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -589,9 +589,25 @@ describe('The Launchpad API endpoint', () => {
   describe('find snap route', () => {
 
     context('when snap exists', () => {
+      let testSnaps;
+
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
         const lp_api_base = `${lp_api_url}/devel`;
+
+        testSnaps = [
+          {
+            resource_type_link: `${lp_api_base}/#snap`,
+            self_link: `${lp_api_base}/~another-user/+snap/test-snap`,
+            owner_link: `${lp_api_base}/~another-user`
+          },
+          {
+            resource_type_link: `${lp_api_base}/#snap`,
+            self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
+            owner_link: `${lp_api_base}/~test-user`
+          }
+        ];
+
         nock(lp_api_url)
           .get('/devel/+snaps')
           .query({
@@ -601,18 +617,7 @@ describe('The Launchpad API endpoint', () => {
           .reply(200, {
             total_size: 2,
             start: 0,
-            entries: [
-              {
-                resource_type_link: `${lp_api_base}/#snap`,
-                self_link: `${lp_api_base}/~another-user/+snap/test-snap`,
-                owner_link: `${lp_api_base}/~another-user`
-              },
-              {
-                resource_type_link: `${lp_api_base}/#snap`,
-                self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
-                owner_link: `${lp_api_base}/~test-user`
-              }
-            ]
+            entries: testSnaps
           });
       });
 
@@ -635,14 +640,14 @@ describe('The Launchpad API endpoint', () => {
           .end(done);
       });
 
-      it('should return a body with a "snap-found" message with the correct ' +
-         'URL', (done) => {
+      it('should return a body with a "snap-found" message with the correct snap', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
           .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasMessage(
-            'snap-found',
-            `${conf.get('LP_API_URL')}/devel/~test-user/+snap/test-snap`))
+          .expect(hasMessage('snap-found'))
+          .expect((res) => {
+            expect(res.body.payload.snap).toEqual(testSnaps[1]);
+          })
           .end(done);
       });
     });
@@ -762,11 +767,14 @@ describe('The Launchpad API endpoint', () => {
           .end(done);
       });
 
-      it('should return a body with a "snap-found" message with the correct URL', (done) => {
+      it('should return a body with a "snap-found" message with the correct snap', (done) => {
         supertest(app)
           .get('/launchpad/snaps')
           .query({ repository_url: 'https://github.com/anowner/aname' })
-          .expect(hasMessage('snap-found', snap.self_link))
+          .expect(hasMessage('snap-found'))
+          .expect((res) => {
+            expect(res.body.payload.snap).toEqual(snap);
+          })
           .end(done);
       });
 

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -84,7 +84,6 @@ describe('The WebHook API endpoint', () => {
 
       describe('if auto_build is true', () => {
         let findByURL;
-        let getSnap;
         let requestAutoBuilds;
 
         beforeEach(() => {
@@ -101,16 +100,10 @@ describe('The WebHook API endpoint', () => {
                 {
                   resource_type_link: `${lp_api_base}/#snap`,
                   self_link: `${lp_api_base}${lp_snap_path}`,
-                  owner_link: `${lp_api_base}/~${lp_snap_user}`
+                  owner_link: `${lp_api_base}/~${lp_snap_user}`,
+                  auto_build: true
                 }
               ]
-            });
-          getSnap = nock(lp_api_url)
-            .get(`/devel${lp_snap_path}`)
-            .reply(200, {
-              resource_type_link: `${lp_api_base}/#snap`,
-              self_link: `${lp_api_base}${lp_snap_path}`,
-              auto_build: true
             });
           requestAutoBuilds = nock(lp_api_url)
             .post(`/devel${lp_snap_path}`, { 'ws.op': 'requestAutoBuilds' })
@@ -139,7 +132,6 @@ describe('The WebHook API endpoint', () => {
             .send(body)
             .expect(200, (err) => {
               findByURL.done();
-              getSnap.done();
               requestAutoBuilds.done();
               done(err);
             });
@@ -165,7 +157,6 @@ describe('The WebHook API endpoint', () => {
 
       describe('if auto_build is false', () => {
         let findByURL;
-        let getSnap;
 
         beforeEach(() => {
           findByURL = nock(lp_api_url)
@@ -181,16 +172,10 @@ describe('The WebHook API endpoint', () => {
                 {
                   resource_type_link: `${lp_api_base}/#snap`,
                   self_link: `${lp_api_base}${lp_snap_path}`,
-                  owner_link: `${lp_api_base}/~${lp_snap_user}`
+                  owner_link: `${lp_api_base}/~${lp_snap_user}`,
+                  auto_build: false
                 }
               ]
-            });
-          getSnap = nock(lp_api_url)
-            .get(`/devel${lp_snap_path}`)
-            .reply(200, {
-              resource_type_link: `${lp_api_base}/#snap`,
-              self_link: `${lp_api_base}${lp_snap_path}`,
-              auto_build: false
             });
         });
 
@@ -226,7 +211,6 @@ describe('The WebHook API endpoint', () => {
               .send(body)
               .expect(500, (err) => {
                 findByURL.done();
-                getSnap.done();
                 getSnapcraftYaml.done();
                 done(err);
               });
@@ -297,7 +281,6 @@ describe('The WebHook API endpoint', () => {
               .send(body)
               .expect(200, (err) => {
                 findByURL.done();
-                getSnap.done();
                 getSnapcraftYaml.done();
                 patchSnapAutoBuild.done();
                 requestAutoBuilds.done();

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -160,7 +160,9 @@ describe('snap builds actions', () => {
           status: 'success',
           payload: {
             code: 'snap-found',
-            message: snapUrl
+            snap: {
+              self_link: snapUrl
+            }
           }
         });
 


### PR DESCRIPTION
Currently our find snap route returns just a `self_link` of a snap for given repository.
To get whose snap data we would need to call LP API again (even though we got all the snap data in first place).

This PR updates `GET /launchpad/snaps` (via `internalSnapFind`) to return whole snap object instead of just `self_link`.

This allows webhook to know if `auto_build` is set on snap without additional API request.
It will also allow us to show snap name in UI (install instructions) without additional API calls (this will be done in separate PR).