### PR TITLE
Only show a checkmark for configured repos

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -371,7 +371,7 @@ class RepositoryRow extends Component {
     }
 
     return (
-      <div>Configured</div>
+      <div>{ tickIcon }</div>
     );
   }
 


### PR DESCRIPTION
This is per the specification, because "Configured" gets too monotonous
when there are many configured repositories.