### PR TITLE
Extracted fetching snap builds to higher order component

### DIFF
--- a/src/common/containers/with-repository.js
+++ b/src/common/containers/with-repository.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 import { setGitHubRepository } from '../actions/create-snap';
 
@@ -35,7 +36,19 @@ function withRepository(WrappedComponent) {
     dispatch: PropTypes.func.isRequired
   };
 
-  return WithRepository;
+  const mapStateToProps = (state, ownProps) => {
+    const owner = ownProps.params.owner.toLowerCase();
+    const name = ownProps.params.name.toLowerCase();
+    const fullName = `${owner}/${name}`;
+    const repository = state.repository;
+
+    return {
+      fullName,
+      repository
+    };
+  };
+
+  return connect(mapStateToProps)(WithRepository);
 }
 
 function getDisplayName(WrappedComponent) {

--- a/src/common/containers/with-snap-builds.js
+++ b/src/common/containers/with-snap-builds.js
@@ -1,0 +1,81 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { fetchBuilds, fetchSnap } from '../actions/snap-builds';
+import { snapBuildsInitialStatus } from '../reducers/snap-builds';
+
+function withSnapBuilds(WrappedComponent) {
+
+  class WithSnapBuilds extends Component {
+
+    fetchInterval = null
+
+    fetchData({ snap, repository }) {
+      if (snap && snap.self_link) {
+        this.props.dispatch(fetchBuilds(repository.url, snap.self_link));
+      } else if (repository) {
+        this.props.dispatch(fetchSnap(repository.url));
+      }
+    }
+
+    componentDidMount() {
+      this.fetchData(this.props);
+
+      this.fetchInterval = setInterval(() => {
+        this.fetchData(this.props);
+      }, 15000);
+    }
+
+    componentWillUnmount() {
+      clearInterval(this.fetchInterval);
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const currentSnap = this.props.snap;
+      const nextSnap = nextProps.snap;
+      const currentRepository = this.props.repository.fullName;
+      const nextRepository = nextProps.repository.fullName;
+
+      if ((currentSnap !== nextSnap) || (currentRepository !== nextRepository)) {
+        // if snap or repo changed, fetch new data
+        this.fetchData(nextProps);
+      }
+    }
+
+    render() {
+      const { snap, ...passThroughProps } = this.props; // eslint-disable-line no-unused-vars
+
+      return (this.props.snap
+        ? <WrappedComponent {...passThroughProps} />
+        : null
+      );
+    }
+  }
+  WithSnapBuilds.displayName = `WithSnapBuilds(${getDisplayName(WrappedComponent)})`;
+
+  WithSnapBuilds.propTypes = {
+    repository: PropTypes.object,
+    snap: PropTypes.object,
+    dispatch: PropTypes.func.isRequired
+  };
+
+  const mapStateToProps = (state) => {
+    const repository = state.repository;
+    // get builds for given repo from the store or set default empty values
+    const snapBuilds = state.snapBuilds[repository.fullName] || snapBuildsInitialStatus;
+
+    return {
+      repository,
+      snap: snapBuilds.snap,
+      snapBuilds
+    };
+  };
+
+  return connect(mapStateToProps)(WithSnapBuilds);
+}
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export default withSnapBuilds;


### PR DESCRIPTION
Both builds listing for repo and build details did a bunch of same fetch logic (getting repo from URL, fetching snap and builds for it), so I extracted this functionality to higher order component.

