### PR TITLE
Tweak icon CSS to match MAAS Vanilla theme

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -21,12 +21,6 @@ const FILE_NAME_CLAIM_URL = 'https://myapps.developer.ubuntu.com/dev/click-apps/
 
 const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-snap';
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
-const tickIcon = (
-  <img
-    src='http://assets.ubuntu.com/v1/6c395e6d-green-tick.svg'
-    className={ styles.tickIcon }
-  />
-);
 
 class RepositoryRow extends Component {
 
@@ -221,7 +215,13 @@ class RepositoryRow extends Component {
 
     let caption;
     if (registerNameStatus.success) {
-      caption = <div>{ tickIcon } Registered successfully</div>;
+      caption = (
+        <div>
+          <span
+            className={ `${styles.icon} ${styles.tickIcon}` }
+          /> Registered successfully
+        </div>
+      );
     } else if ( registerNameStatus.error
       && registerNameStatus.error.json
       && registerNameStatus.error.json.payload
@@ -371,13 +371,19 @@ class RepositoryRow extends Component {
     }
 
     return (
-      <div>{ tickIcon }</div>
+      <span className={ `${styles.icon} ${styles.tickIcon}` } />
     );
   }
 
   renderSnapName(registeredName, showRegisterNameInput) {
     if (registeredName !== null) {
-      return <span>{ tickIcon } { registeredName }</span>;
+      return (
+        <span>
+          <span
+            className={ `${styles.icon} ${styles.tickIcon}` }
+          /> { registeredName }
+        </span>
+      );
     } else if (showRegisterNameInput) {
       return (
         <input

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -21,6 +21,7 @@ const FILE_NAME_CLAIM_URL = 'https://myapps.developer.ubuntu.com/dev/click-apps/
 
 const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-snap';
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
+const tickIcon = <span className={ `${styles.icon} ${styles.tickIcon}` } />;
 
 class RepositoryRow extends Component {
 
@@ -217,9 +218,7 @@ class RepositoryRow extends Component {
     if (registerNameStatus.success) {
       caption = (
         <div>
-          <span
-            className={ `${styles.icon} ${styles.tickIcon}` }
-          /> Registered successfully
+          { tickIcon } Registered successfully
         </div>
       );
     } else if ( registerNameStatus.error
@@ -370,18 +369,14 @@ class RepositoryRow extends Component {
       );
     }
 
-    return (
-      <span className={ `${styles.icon} ${styles.tickIcon}` } />
-    );
+    return tickIcon;
   }
 
   renderSnapName(registeredName, showRegisterNameInput) {
     if (registeredName !== null) {
       return (
         <span>
-          <span
-            className={ `${styles.icon} ${styles.tickIcon}` }
-          /> { registeredName }
+          { tickIcon } { registeredName }
         </span>
       );
     } else if (showRegisterNameInput) {

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -23,10 +23,6 @@
   background-size: 100% 100%;
 }
 
-span.icon {
-  margin-top: -3px;
-}
-
 .buttonRow {
   padding: 16px;
   text-align: right;

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -12,7 +12,7 @@
   width: 16px;
   height: 16px;
   padding: 0;
-  border-bottom: 0 !important;
+  border-bottom: 0;
   display: inline-block;
   vertical-align: middle;
   text-indent: 999em;

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -8,9 +8,23 @@
   color: $warm-grey;
 }
 
-.tickIcon {
-  width: 22px;
+.icon {
+  width: 16px;
   height: 16px;
+  padding: 0;
+  border-bottom: 0 !important;
+  display: inline-block;
+  vertical-align: middle;
+  text-indent: 999em;
+}
+
+.tickIcon {
+  background: url(https://assets.ubuntu.com/v1/6c395e6d-green-tick.svg) no-repeat;
+  background-size: 100% 100%;
+}
+
+span.icon {
+  margin-top: -3px;
 }
 
 .buttonRow {


### PR DESCRIPTION
This puts the asset URL together with the rest of its presentation; and
this code layout works better when we need an icon with an action
associated with it, as we will for snap removals.

While I was at it, I made the asset URL use HTTPS rather than HTTP.