### PR TITLE
Add snap removal support

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -121,6 +121,29 @@ as returned by the Launchpad API:
       }
     }
 
+To delete a snap:
+
+    POST /api/launchpad/snaps/delete
+    Cookie: <session cookie>
+    Content-Type: application/json
+    Accept: application/json
+
+    {
+      "repository_url": "https://github.com/:owner/:name"
+    }
+
+On success, returns:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "status": "success",
+      "payload": {
+        "code": "snap-deleted",
+        "message": "Snap deleted"
+      }
+    }
 
 ## GitHub
 

--- a/src/common/actions/snaps.js
+++ b/src/common/actions/snaps.js
@@ -8,6 +8,9 @@ const BASE_URL = conf.get('BASE_URL');
 export const FETCH_SNAPS = 'FETCH_SNAP_REPOSITORIES';
 export const FETCH_SNAPS_SUCCESS = 'FETCH_SNAPS_SUCCESS';
 export const FETCH_SNAPS_ERROR = 'FETCH_SNAPS_ERROR';
+export const REMOVE_SNAP = 'REMOVE_SNAP';
+export const REMOVE_SNAP_SUCCESS = 'REMOVE_SNAP_SUCCESS';
+export const REMOVE_SNAP_ERROR = 'REMOVE_SNAP_ERROR';
 
 export function fetchUserSnaps(owner) {
   return (dispatch) => {
@@ -50,6 +53,51 @@ export function fetchSnapsError(error) {
   return {
     type: FETCH_SNAPS_ERROR,
     payload: error,
+    error: true
+  };
+}
+
+export function removeSnap(repositoryUrl) {
+  return (dispatch) => {
+    dispatch({
+      type: REMOVE_SNAP,
+      payload: { repository_url: repositoryUrl }
+    });
+
+    return fetch(`${BASE_URL}/api/launchpad/snaps/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repository_url: repositoryUrl }),
+      credentials: 'same-origin'
+    })
+      .then(checkStatus)
+      .then((response) => {
+        return response.json().then((result) => {
+          if (result.status !== 'success') {
+            throw getError(response, result);
+          }
+
+          dispatch(removeSnapSuccess(repositoryUrl));
+        });
+      })
+      .catch((error) => dispatch(removeSnapError(repositoryUrl, error)));
+  };
+}
+
+export function removeSnapSuccess(repositoryUrl) {
+  return {
+    type: REMOVE_SNAP_SUCCESS,
+    payload: { repository_url: repositoryUrl }
+  };
+}
+
+export function removeSnapError(repositoryUrl, error) {
+  return {
+    type: REMOVE_SNAP_ERROR,
+    payload: {
+      repository_url: repositoryUrl,
+      error
+    },
     error: true
   };
 }

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -112,10 +112,10 @@ class RepositoriesList extends Component {
         <Table>
           <Head>
             <Row>
-              <Header col="30">Name</Header>
+              <Header col="27">Name</Header>
               <Header col="15">Configured</Header>
               <Header col="25">Registered for publishing</Header>
-              <Header col="27">Latest build</Header>
+              <Header col="30">Latest build</Header>
             </Row>
           </Head>
           <Body>

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -115,7 +115,7 @@ class RepositoriesList extends Component {
               <Header col="30">Name</Header>
               <Header col="15">Configured</Header>
               <Header col="25">Registered for publishing</Header>
-              <Header col="30">Latest build</Header>
+              <Header col="27">Latest build</Header>
             </Row>
           </Head>
           <Body>

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -413,14 +413,14 @@ class RepositoryRow extends Component {
     // icon playing hide-and-seek.
     return (
       <Row isActive={isActive}>
-        <Data col="30"><Link to={ `/${fullName}/builds` }>{ fullName }</Link></Data>
+        <Data col="27"><Link to={ `/${fullName}/builds` }>{ fullName }</Link></Data>
         <Data col="15">
           { this.renderConfiguredStatus.call(this, snap.snapcraft_data) }
         </Data>
         <Data col="25">
           { this.renderSnapName.call(this, registeredName, showRegisterNameInput) }
         </Data>
-        <Data col="27">
+        <Data col="30">
           {/*
             TODO: show 'Loading' when waiting for status?
               and also show 'Never built' when no builds available

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -12,6 +12,7 @@ import templateYaml from './template-yaml.js';
 
 import { signIntoStore } from '../../actions/auth-store';
 import { registerName, registerNameError } from '../../actions/register-name';
+import { removeSnap } from '../../actions/snaps';
 import { conf } from '../../helpers/config';
 import { parseGitHubRepoUrl } from '../../helpers/github-url';
 
@@ -22,6 +23,9 @@ const FILE_NAME_CLAIM_URL = 'https://myapps.developer.ubuntu.com/dev/click-apps/
 const LEARN_THE_BASICS_LINK = 'https://snapcraft.io/docs/build-snaps/your-first-snap';
 const INSTALL_IT_LINK = 'https://snapcraft.io/create/';
 const tickIcon = <span className={ `${styles.icon} ${styles.tickIcon}` } />;
+const warningIcon = (
+  <span className={ `${styles.icon} ${styles.warningIcon}` } />
+);
 
 class RepositoryRow extends Component {
 
@@ -39,6 +43,7 @@ class RepositoryRow extends Component {
       snapName,
       unconfiguredDropdownExpanded: false,
       unregisteredDropdownExpanded: false,
+      removeDropdownExpanded: false,
       signAgreement: false
     };
   }
@@ -72,14 +77,24 @@ class RepositoryRow extends Component {
   onConfiguredClick() {
     this.setState({
       unconfiguredDropdownExpanded: !this.state.unconfiguredDropdownExpanded,
-      unregisteredDropdownExpanded: false
+      unregisteredDropdownExpanded: false,
+      removeDropdownExpanded: false
     });
   }
 
   onUnregisteredClick() {
     this.setState({
       unconfiguredDropdownExpanded: false,
-      unregisteredDropdownExpanded: !this.state.unregisteredDropdownExpanded
+      unregisteredDropdownExpanded: !this.state.unregisteredDropdownExpanded,
+      removeDropdownExpanded: false
+    });
+  }
+
+  onToggleRemoveClick() {
+    this.setState({
+      unconfiguredDropdownExpanded: false,
+      unregisteredDropdownExpanded: false,
+      removeDropdownExpanded: !this.state.removeDropdownExpanded
     });
   }
 
@@ -121,6 +136,10 @@ class RepositoryRow extends Component {
       signAgreement: signAgreement ? authStore.userName : null,
       requestBuilds
     }));
+  }
+
+  onRemoveClick(repositoryUrl) {
+    this.props.dispatch(removeSnap(repositoryUrl));
   }
 
   componentWillReceiveProps(nextProps) {
@@ -311,6 +330,57 @@ class RepositoryRow extends Component {
     );
   }
 
+  renderRemoveDropdown(registeredName) {
+    const { snap, latestBuild } = this.props;
+
+    let warningText;
+    if (latestBuild) {
+      warningText = (
+        'Removing this repo will delete all its builds and build logs.'
+      );
+    } else {
+      warningText = (
+        'Are you sure you want to remove this repo from the list?'
+      );
+    }
+    if (registeredName !== null) {
+      warningText += ' The name will remain registered.';
+    }
+    // XXX cjwatson 2017-02-28: Once we can get hold of published states for
+    // builds, we should also implement this design requirement:
+    //   Separately, if any build has been published, the text should end
+    //   with:
+    //     Published builds will remain published.
+
+    return (
+      <Dropdown>
+        <Row>
+          <Data col="100">
+            { warningIcon } { warningText }
+          </Data>
+        </Row>
+        <Row>
+          <div className={ styles.buttonRow }>
+            <a
+              onClick={ this.onToggleRemoveClick.bind(this) }
+              className={ styles.cancel }
+            >
+              Cancel
+            </a>
+            <Button
+              appearance="negative"
+              onClick={
+                this.onRemoveClick.bind(this, snap.git_repository_url)
+              }
+            >
+              Remove
+            </Button>
+          </div>
+        </Row>
+      </Dropdown>
+    );
+  }
+
   render() {
     const {
       snap,
@@ -323,6 +393,7 @@ class RepositoryRow extends Component {
     const unconfigured = true;
     const showUnconfiguredDropdown = unconfigured && this.state.unconfiguredDropdownExpanded;
     const showUnregisteredDropdown = this.state.unregisteredDropdownExpanded;
+    const showRemoveDropdown = this.state.removeDropdownExpanded;
     const showRegisterNameInput = (
       showUnregisteredDropdown && authStore.authenticated
     );
@@ -331,8 +402,15 @@ class RepositoryRow extends Component {
       registerNameStatus.snapName : snap.store_name
     );
 
-    // TODO (or any other dropdown)
-    const isActive = showUnconfiguredDropdown || showUnregisteredDropdown;
+    const isActive = (
+      showUnconfiguredDropdown ||
+      showUnregisteredDropdown ||
+      showRemoveDropdown
+    );
+    // XXX cjwatson 2017-02-28: The specification calls for the remove icon
+    // to be shown only when hovering over or tapping in an empty part of
+    // the row.  My attempts to do this so far have resulted in the remove
+    // icon playing hide-and-seek.
     return (
       <Row isActive={isActive}>
         <Data col="30"><Link to={ `/${fullName}/builds` }>{ fullName }</Link></Data>
@@ -342,7 +420,7 @@ class RepositoryRow extends Component {
         <Data col="25">
           { this.renderSnapName.call(this, registeredName, showRegisterNameInput) }
         </Data>
-        <Data col="30">
+        <Data col="27">
           {/*
             TODO: show 'Loading' when waiting for status?
               and also show 'Never built' when no builds available
@@ -356,8 +434,17 @@ class RepositoryRow extends Component {
             />
           }
         </Data>
+        <Data col="3">
+          <a
+            className={ `${styles.icon} ${styles.deleteIcon}` }
+            onClick={ this.onToggleRemoveClick.bind(this) }
+          >
+            Remove
+          </a>
+        </Data>
         { showUnconfiguredDropdown && this.renderUnconfiguredDropdown() }
         { showUnregisteredDropdown && this.renderUnregisteredDropdown() }
+        { showRemoveDropdown && this.renderRemoveDropdown(registeredName) }
       </Row>
     );
   }

--- a/src/common/components/repository-row/repositoryRow.css
+++ b/src/common/components/repository-row/repositoryRow.css
@@ -23,6 +23,16 @@
   background-size: 100% 100%;
 }
 
+.deleteIcon {
+  background: url(https://assets.ubuntu.com/v1/b5573b6a-delete.svg) no-repeat;
+  background-size: 100% 100%;
+}
+
+.warningIcon {
+  background: url(https://assets.ubuntu.com/v1/5777c0c7-warning.svg) no-repeat;
+  background-size: 100% 100%;
+}
+
 .buttonRow {
   padding: 16px;
   text-align: right;

--- a/src/common/components/vanilla/button/button.css
+++ b/src/common/components/vanilla/button/button.css
@@ -12,6 +12,11 @@ $positive-button-color-hover: #0a5615;
 $positive-button-text-color: #FFF;
 $positive-border-color: $success;
 
+$negative-button-color: $error;
+$negative-button-color-hover: #8f2018;
+$negative-button-text-color: #FFF;
+$negative-border-color: $error;
+
 $neutral-button-color: #FFF;
 $neutral-button-color-hover: rgba(0, 0, 0, 0.1);
 $neutral-button-text-color: $dark-grey;
@@ -78,6 +83,20 @@ $neutral-border-color: $dark-grey;
 .positive:focus,
 .positive:hover {
   background-color: $positive-button-color-hover;
+}
+
+.negative {
+  composes: button;
+
+  color: $negative-button-text-color;
+  background-color: $negative-button-color;
+  border: 1px solid $negative-border-color;
+}
+
+.negative:active,
+.negative:focus,
+.negative:hover {
+  background-color: $negative-button-color-hover;
 }
 
 .neutral {

--- a/src/common/components/vanilla/button/index.js
+++ b/src/common/components/vanilla/button/index.js
@@ -9,7 +9,7 @@ const defaultProps = {
   children: PropTypes.string,
   onClick: PropTypes.func,
   type: PropTypes.string,
-  appearance: React.PropTypes.oneOf(['primary', 'secondary', 'positive', 'neutral']),
+  appearance: React.PropTypes.oneOf(['primary', 'secondary', 'positive', 'negative', 'neutral']),
   flavour: React.PropTypes.oneOf(['normal','embiggened']),
   href: PropTypes.string
 };

--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -63,6 +63,31 @@ export function snaps(state = {
         ...state,
         snaps: updateRegisteredName(state.snaps, action.payload.id, action.payload.snapName)
       };
+    case ActionTypes.REMOVE_SNAP:
+      return {
+        ...state,
+        isFetching: true
+      };
+    case ActionTypes.REMOVE_SNAP_SUCCESS:
+      return {
+        ...state,
+        isFetching: false,
+        success: true,
+        snaps: (
+          state.snaps !== null ?
+          state.snaps.filter((snap) => {
+            return snap.git_repository_url !== action.payload.repository_url;
+          }) : null
+        ),
+        error: null
+      };
+    case ActionTypes.REMOVE_SNAP_ERROR:
+      return {
+        ...state,
+        isFetching: false,
+        success: false,
+        error: action.payload.error
+      };
     default:
       return state;
   }

--- a/src/server/launchpad/client.js
+++ b/src/server/launchpad/client.js
@@ -159,6 +159,27 @@ export class Launchpad {
     });
   }
 
+  /**
+   * Delete the resource at the given URI.
+   * @returns {Promise<Resource|Object, ResourceError>}
+   */
+  delete(uri) {
+    uri = normalizeURI(this.base_uri, uri);
+
+    const headers = this.makeHeaders();
+
+    return fetch(uri, {
+      method: 'DELETE',
+      headers: headers
+    }).then((response) => {
+      if (Math.floor(response.status / 100) == 2) {
+        return this.wrap_resource_on_success(response, uri, 'DELETE');
+      } else {
+        throw new ResourceError(response, this, uri, 'DELETE');
+      }
+    });
+  }
+
   /** Given a representation, turn it into a subclass of Resource. */
   wrap_resource(uri, representation) {
     if (representation === null || representation === undefined) {

--- a/src/server/launchpad/resources.js
+++ b/src/server/launchpad/resources.js
@@ -130,4 +130,10 @@ export class Entry extends Resource {
     return this.lp_client.patch(uri, representation, config, headers)
       .then(() => { this.dirty_attributes = []; });
   }
+
+  /** Delete this entry. */
+  lp_delete() {
+    const uri = normalizeURI(this.lp_client.base_uri, this['self_link']);
+    return this.lp_client.delete(uri);
+  }
 }

--- a/src/server/routes/launchpad.js
+++ b/src/server/routes/launchpad.js
@@ -3,6 +3,7 @@ import { json } from 'body-parser';
 
 import {
   authorizeSnap,
+  deleteSnap,
   findSnap,
   findSnaps,
   getSnapBuilds,
@@ -27,5 +28,10 @@ router.get('/launchpad/builds', getSnapBuilds);
 
 router.use('/launchpad/snaps/request-builds', json());
 router.post('/launchpad/snaps/request-builds', requestSnapBuilds);
+
+// XXX cjwatson 2017-02-28: This would be more RESTful if we defined an API
+// URL for each snap and then just made this a DELETE.
+router.use('/launchpad/snaps/delete', json());
+router.post('/launchpad/snaps/delete', deleteSnap);
 
 export default router;

--- a/test/unit/src/common/reducers/t_snaps.js
+++ b/test/unit/src/common/reducers/t_snaps.js
@@ -80,7 +80,6 @@ describe('snaps reducers', () => {
     });
   });
 
-
   context('FETCH_SNAPS_ERROR', () => {
     const state = {
       ...initialState,
@@ -127,4 +126,73 @@ describe('snaps reducers', () => {
     });
   });
 
+  context('REMOVE_SNAP', () => {
+    const action = { type: ActionTypes.REMOVE_SNAP };
+
+    it('stores fetching status', () => {
+      expect(snaps(initialState, action).isFetching).toBe(true);
+    });
+  });
+
+  context('REMOVE_SNAP_SUCCESS', () => {
+    const state = {
+      ...initialState,
+      isFetching: true,
+      snaps: SNAPS,
+      error: 'Previous error'
+    };
+
+    const action = {
+      type: ActionTypes.REMOVE_SNAP_SUCCESS,
+      payload: { repository_url: 'https://github.com/anowner/aname' }
+    };
+
+    it('clears fetching status', () => {
+      expect(snaps(state, action).isFetching).toBe(false);
+    });
+
+    it('stores success status', () => {
+      expect(snaps(state, action).success).toBe(true);
+    });
+
+    it('clears error', () => {
+      expect(snaps(state, action).error).toBe(null);
+    });
+
+    it('removes snap from state', () => {
+      expect(snaps(state, action).snaps.map((snap) => {
+        return snap.git_repository_url;
+      })).toEqual(['https://github.com/anowner/anothername']);
+    });
+  });
+
+  context('REMOVE_SNAP_ERROR', () => {
+    const state = {
+      ...initialState,
+      isFetching: true,
+      success: true,
+      snaps: SNAPS
+    };
+
+    const action = {
+      type: ActionTypes.REMOVE_SNAP_ERROR,
+      payload: {
+        repository_url: 'https://github.com/anowner/aname',
+        error: 'Something went wrong!'
+      },
+      error: true
+    };
+
+    it('clears fetching status', () => {
+      expect(snaps(state, action).isFetching).toBe(false);
+    });
+
+    it('clears success status', () => {
+      expect(snaps(state, action).success).toBe(false);
+    });
+
+    it('stores error', () => {
+      expect(snaps(state, action).error).toBe('Something went wrong!');
+    });
+  });
 });

--- a/test/unit/src/server/launchpad/t_client.js
+++ b/test/unit/src/server/launchpad/t_client.js
@@ -178,6 +178,32 @@ describe('Launchpad', () => {
     });
   });
 
+  describe('delete', () => {
+    it('handles successful response', () => {
+      lp.delete('/devel/~foo')
+        .matchHeader('Authorization', checkAuthorization)
+        .reply(200, 'null');
+
+      return getLaunchpad().delete('/~foo').then(
+        (result) => {
+          expect(result).toBe(null);
+        });
+    });
+
+    it('handles failing response', () => {
+      lp.delete('/devel/~foo').reply(503);
+
+      return getLaunchpad().delete('/~foo')
+        .then((result) => {
+          assert(false, 'Expected promise to be rejected; got %s instead',
+                 result);
+        }, (error) => {
+          expect(error.response.status).toEqual(503);
+          expect(error.uri).toEqual(`${LP_API_URL}/devel/~foo`);
+        });
+    });
+  });
+
   describe('wrap_resource', () => {
     it('produces mappings of plain object literals', () => {
       const result = getLaunchpad().wrap_resource(null, {

--- a/test/unit/src/server/launchpad/t_resources.js
+++ b/test/unit/src/server/launchpad/t_resources.js
@@ -185,5 +185,18 @@ describe('Resources', () => {
       ]);
     });
 
+    it('can be deleted', () => {
+      lp.delete('/devel/~foo')
+        .reply(200, 'null');
+
+      const representation = {
+        resource_type_link: `${LP_API_URL}/devel/#person`,
+        self_link: `${LP_API_URL}/devel/~foo`
+      };
+      const entry = new Entry(
+        getLaunchpad(), `${LP_API_URL}/devel/~foo`, representation);
+      return entry.lp_delete()
+        .then(() => lp.done());
+    });
   });
 });


### PR DESCRIPTION
This removes the snap from Launchpad and invalidates relevant entries in
memcached.  It is per the specification except that it doesn't yet say
anything about published builds, and that the remove icon is always
shown rather than only being shown when hovering over a row.