### PR TITLE
doing whatever it takes to get the green button above the ‘fold’

### DIFF
--- a/src/common/components/vanilla/button/button.css
+++ b/src/common/components/vanilla/button/button.css
@@ -128,7 +128,7 @@ $neutral-border-color: $dark-grey;
 }
 
 .embiggened {
-  margin-top: 2em;
+  margin-top: 2.4em;
   padding: .5em 1.5em;
   font-size: 1.5em;
 }

--- a/src/common/containers/landing.css
+++ b/src/common/containers/landing.css
@@ -8,12 +8,12 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-around;
-  margin: 50px 0 30px;
+  margin: 50px 0 0 0;
 }
 
 .bannerImage {
   width: 920px;
-  margin-bottom: 2em;
+  margin-bottom: 1.2em;
 }
 
 .bannerImage img {
@@ -28,7 +28,9 @@
 }
 
 .bannerButton {
-  margin-bottom: 4em;
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+  vertical-align: middle;
 }
 
 .centeredButton {

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -22,7 +22,7 @@ class Landing extends Component {
           <div>
             <div className={ `${containerStyles.wrapper} ${styles.centeredText}` }>
               <HeadingTwo align='center'>
-                Auto-build and publish software for any Linux system or device
+                Auto-build and publish software<br />for any Linux system or device
               </HeadingTwo>
 
               <ul className={ styles.banner }>

--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { Anchor } from '../components/vanilla/button';
-import { HeadingOne } from '../components/vanilla/heading';
+import { HeadingTwo } from '../components/vanilla/heading';
 import { HeadingThree } from '../components/vanilla/heading';
 import { HeadingSix } from '../components/vanilla/heading';
 import { ListDividedState } from '../components/vanilla/list';
@@ -21,9 +21,9 @@ class Landing extends Component {
         <div className={ containerStyles.strip }>
           <div>
             <div className={ `${containerStyles.wrapper} ${styles.centeredText}` }>
-              <HeadingOne align='center'>
-                Auto-build and publish software<br />for any Linux system or device
-              </HeadingOne>
+              <HeadingTwo align='center'>
+                Auto-build and publish software for any Linux system or device
+              </HeadingTwo>
 
               <ul className={ styles.banner }>
                 <li className={ styles.bannerImage }>


### PR DESCRIPTION
## DONE

* lowered the font size on the h1 text (by making it an h2)
* reduced a lot of margins around the image and button to make it all tighter

## QA

1. go to the landing page (not logged in)
2. see the button above the fold

## SCREENSHOT

![image](https://cloud.githubusercontent.com/assets/441217/23413887/0a0c1012-fdd2-11e6-9f5a-e97197995403.png) - except h2 now on two lines
