### PR TITLE
moving the snapcraft.yaml template to the /snap directory

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -403,7 +403,7 @@ class RepositoryRow extends Component {
       host: 'github.com',
       pathname: parseGitHubRepoUrl(this.props.snap.git_repository_url).fullName + '/new/master',
       query: {
-        'filename': 'snapcraft.yaml',
+        'filename': 'snap/snapcraft.yaml',
         'value': templateYaml
       }
     });


### PR DESCRIPTION
## DONE

* added the 'snap/' to the filename 'snapcraft.yaml' to put the file in it's correct location

## QA

1. add a repo to build that doesn't have a snapcraft.yaml file
2. see that the instructions offer you a link that will let you create the file in the /snap directory [example](https://github.com/pmahnke/build.snapcraft.io/new/master?filename=snap%2Fsnapcraft.yaml&value=%0Aname%3A%20my-snap-name%20%23%20you%20probably%20want%20to%20%27snapcraft%20register%20%3Cname%3E%27%0Aversion%3A%20%270.1%27%20%23%20just%20for%20humans%2C%20typically%20%271.2%2Bgit%27%20or%20%271.3.2%27%0Asummary%3A%20Single-line%20elevator%20pitch%20for%20your%20amazing%20snap%20%23%2079%20char%20long%20summary%0Adescription%3A%20%7C%0A%20%20This%20is%20my-snap%27s%20description.%20You%20have%20a%20paragraph%20or%20two%20to%20tell%20the%0A%20%20most%20important%20story%20about%20your%20snap.%20Keep%20it%20under%20100%20words%20though%2C%0A%20%20we%20live%20in%20tweetspace%20and%20your%20description%20wants%20to%20look%20good%20in%20the%20snap%0A%20%20store.%0A%0Agrade%3A%20devel%20%23%20must%20be%20%27stable%27%20to%20release%20into%20candidate%2Fstable%20channels%0Aconfinement%3A%20devmode%20%23%20use%20%27strict%27%20once%20you%20have%20the%20right%20plugs%20and%20slots%0A%0Aparts%3A%0A%20%20my-part%3A%0A%20%20%20%20%23%20See%20%27snapcraft%20plugins%27%0A%20%20%20%20plugin%3A%20nil%0A)

## NOTE

* I could only test the URL as my dev env isn't letting me get past selecting a repo

