### PR TITLE
Fix "Add repos" loop after the first time through

### DIFF
--- a/src/common/actions/create-snap.js
+++ b/src/common/actions/create-snap.js
@@ -6,7 +6,7 @@ import { conf } from '../helpers/config';
 const BASE_URL = conf.get('BASE_URL');
 
 export const SET_GITHUB_REPOSITORY = 'SET_GITHUB_REPOSITORY';
-export const CREATE_SNAPS_START = 'CREATE_SNAPS_START';
+export const CREATE_SNAPS_CLEAR = 'CREATE_SNAPS_CLEAR';
 export const CREATE_SNAP = 'CREATE_SNAP';
 export const CREATE_SNAP_SUCCESS = 'CREATE_SNAP_SUCCESS';
 export const CREATE_SNAP_ERROR = 'CREATE_SNAP_ERROR';
@@ -69,13 +69,17 @@ export function createSnap(repository) {
 
 export function createSnaps(repositories) {
   return (dispatch) => {
-    // Clear out any previous batch-creation state.
-    dispatch({ type: CREATE_SNAPS_START });
+    dispatch(createSnapsClear());
     const promises = repositories.map(
       (repository) => dispatch(createSnap(repository))
     );
     return Promise.all(promises);
   };
+}
+
+// Clear out any previous batch-creation state.
+export function createSnapsClear() {
+  return { type: CREATE_SNAPS_CLEAR };
 }
 
 export function createSnapSuccess(id) {

--- a/src/common/actions/select-repositories-form.js
+++ b/src/common/actions/select-repositories-form.js
@@ -1,8 +1,13 @@
 export const TOGGLE_REPOSITORY = 'TOGGLE_REPOSITORY';
+export const UNSELECT_ALL_REPOSITORIES = 'UNSELECT_ALL_REPOSITORIES';
 
 export const toggleRepository = (repository) => {
   return {
     type: TOGGLE_REPOSITORY,
     payload: repository
   };
+};
+
+export const unselectAllRepositories = () => {
+  return { type: UNSELECT_ALL_REPOSITORIES };
 };

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -3,8 +3,11 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
 import { conf } from '../../helpers/config';
-import { createSnaps } from '../../actions/create-snap';
-import { toggleRepository } from '../../actions/select-repositories-form';
+import { createSnaps, createSnapsClear } from '../../actions/create-snap';
+import {
+  toggleRepository,
+  unselectAllRepositories
+} from '../../actions/select-repositories-form';
 import SelectRepositoryRow from '../select-repository-row';
 import Spinner from '../spinner';
 import PageLinks from '../page-links';
@@ -20,6 +23,11 @@ import { spinner as spinnerStyles } from '../../containers/container.css';
 const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
 
 class SelectRepositoryList extends Component {
+
+  componentDidMount() {
+    this.props.dispatch(createSnapsClear());
+    this.props.dispatch(unselectAllRepositories());
+  }
 
   componentWillReceiveProps(nextProps) {
     const repositoriesStatus = nextProps.repositoriesStatus;

--- a/src/common/reducers/repositories-status.js
+++ b/src/common/reducers/repositories-status.js
@@ -10,7 +10,7 @@ export function repositoriesStatus(state = {}, action) {
   };
 
   switch(action.type) {
-    case ActionTypes.CREATE_SNAPS_START:
+    case ActionTypes.CREATE_SNAPS_CLEAR:
       return {};
     case ActionTypes.CREATE_SNAP:
       return {

--- a/src/common/reducers/select-repositories-form.js
+++ b/src/common/reducers/select-repositories-form.js
@@ -24,6 +24,8 @@ export function selectRepositoriesForm(state = initialState, action) {
           action.payload
         ]
       };
+    case ActionTypes.UNSELECT_ALL_REPOSITORIES:
+      return initialState;
     default:
       return state;
   }

--- a/test/unit/src/common/actions/t_create-snap.js
+++ b/test/unit/src/common/actions/t_create-snap.js
@@ -134,11 +134,11 @@ describe('create snap actions', () => {
       nock.cleanAll();
     });
 
-    it('stores a CREATE_SNAPS_START action', () => {
+    it('stores a CREATE_SNAPS_CLEAR action', () => {
       return store.dispatch(createSnaps([ repository ]))
         .then(() => {
           expect(store.getActions()).toHaveActionOfType(
-            ActionTypes.CREATE_SNAPS_START
+            ActionTypes.CREATE_SNAPS_CLEAR
           );
           scope.done();
         });

--- a/test/unit/src/common/actions/t_select-repositories-form.js
+++ b/test/unit/src/common/actions/t_select-repositories-form.js
@@ -2,7 +2,11 @@ import expect from 'expect';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import { toggleRepository, TOGGLE_REPOSITORY } from '../../../../../src/common/actions/select-repositories-form';
+import {
+  toggleRepository,
+  unselectAllRepositories
+} from '../../../../../src/common/actions/select-repositories-form';
+import * as ActionTypes from '../../../../../src/common/actions/select-repositories-form';
 
 const middlewares = [ thunk ];
 const mockStore = configureMockStore(middlewares);
@@ -18,6 +22,23 @@ describe('The toggleRepository action creator', () => {
 
   it('should dispatch the TOGGLE_REPOSITORY action', () => {
     store.dispatch(toggleRepository({ fullName: 'foo/bar' }));
-    expect(store.getActions()).toHaveActionOfType(TOGGLE_REPOSITORY);
+    expect(store.getActions()).toHaveActionOfType(
+      ActionTypes.TOGGLE_REPOSITORY
+    );
+  });
+});
+
+describe('The unselectAllRepositories action creator', () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore();
+  });
+
+  it('should dispatch the UNSELECT_ALL_REPOSITORIES action', () => {
+    store.dispatch(unselectAllRepositories());
+    expect(store.getActions()).toHaveActionOfType(
+      ActionTypes.UNSELECT_ALL_REPOSITORIES
+    );
   });
 });

--- a/test/unit/src/common/reducers/t_repositories-status.js
+++ b/test/unit/src/common/reducers/t_repositories-status.js
@@ -18,14 +18,14 @@ describe('repositoriesStatus reducers', () => {
     expect(repositoriesStatus(undefined, {})).toEqual(initialState);
   });
 
-  context('CREATE_SNAPS_START', () => {
+  context('CREATE_SNAPS_CLEAR', () => {
     it('clears out any existing state', () => {
       const state = {
         ...initialState,
         [id]: initialStatus
       };
 
-      const action = { type: ActionTypes.CREATE_SNAPS_START };
+      const action = { type: ActionTypes.CREATE_SNAPS_CLEAR };
 
       expect(repositoriesStatus(state, action)).toEqual({});
     });

--- a/test/unit/src/common/reducers/t_select-repositories-form.js
+++ b/test/unit/src/common/reducers/t_select-repositories-form.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 
 import { selectRepositoriesForm } from '../../../../../src/common/reducers/select-repositories-form';
-import { TOGGLE_REPOSITORY } from '../../../../../src/common/actions/select-repositories-form';
+import * as ActionTypes from '../../../../../src/common/actions/select-repositories-form';
 
 describe('The selectRepositoriesForm reducer', () => {
   let initialState;
@@ -18,7 +18,7 @@ describe('The selectRepositoriesForm reducer', () => {
 
       beforeEach(() => {
         state = selectRepositoriesForm(initialState, {
-          type: TOGGLE_REPOSITORY,
+          type: ActionTypes.TOGGLE_REPOSITORY,
           payload: { fullName: 'foo/bar' }
         });
       });
@@ -47,14 +47,34 @@ describe('The selectRepositoriesForm reducer', () => {
 
       beforeEach(() => {
         state = selectRepositoriesForm(initialState, {
-          type: TOGGLE_REPOSITORY,
+          type: ActionTypes.TOGGLE_REPOSITORY,
           payload: { fullName: 'foo/bar' }
         });
       });
 
-      it('should note have a selected repository "foo/bar"', () => {
+      it('should not have a selected repository "foo/bar"', () => {
         expect(state).toEqual({ selectedRepos: [] });
       });
+    });
+  });
+
+  context('when all selected repositories are unselected', () => {
+    let state;
+
+    beforeEach(() => {
+      initialState = {
+        selectedRepos: [
+          { fullName: 'foo/bar' },
+          { fullName: 'foo/baz' }
+        ]
+      };
+      state = selectRepositoriesForm(initialState, {
+        type: ActionTypes.UNSELECT_ALL_REPOSITORIES
+      });
+    });
+
+    it('should have no selected repositories', () => {
+      expect(state).toEqual({ selectedRepos: [] });
     });
   });
 });


### PR DESCRIPTION
Clear out any previous state each time we mount the SelectRepositoryList
component, so that it doesn't get confused into believing that it just
finished adding repositories and redirect the user back to the
dashboard.

Fixes #204.