### PR TITLE
Clear snap cache when name registered

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -12,6 +12,8 @@ If true, set secure session cookies.
 
 ### MEMCACHED\_HOST
 
+- **Example**: `localhost:11211`
+
 The host name of the memcached service.
 
 ### MEMCACHED\_SESSION\_SECRET

--- a/docs/memcached.md
+++ b/docs/memcached.md
@@ -1,0 +1,14 @@
+# Memchached entries
+
+## `url_prefix:https://github.com/:owner/`
+
+Caches list of snaps (enabled repositories) for given GitHub user (via URL prefix).
+
+## `url:https://github.com/:owner/:name`
+
+Caches snap data for given repository URL.
+
+## `snapcraft_data:https://github.com/:owner/:name`
+
+Caches JSON subset of data from `snapcraft.yaml` found in given repository.
+Currently it contains only a snap name.

--- a/docs/memcached.md
+++ b/docs/memcached.md
@@ -1,14 +1,14 @@
-# Memchached entries
+# Memcached entries
 
-## `url_prefix:https://github.com/:owner/`
+## `lp:url_prefix:https://github.com/:owner/`
 
 Caches list of snaps (enabled repositories) for given GitHub user (via URL prefix).
 
-## `url:https://github.com/:owner/:name`
+## `lp:url:https://github.com/:owner/:name`
 
 Caches snap data for given repository URL.
 
-## `snapcraft_data:https://github.com/:owner/:name`
+## `lp:snapcraft_data:https://github.com/:owner/:name`
 
 Caches JSON subset of data from `snapcraft.yaml` found in given repository.
 Currently it contains only a snap name.

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -81,7 +81,7 @@ class BuildDetails extends Component {
         { isFetching &&
           <div className={styles.spinner}><Spinner /></div>
         }
-        { snap &&
+        { snap && snap.store_name &&
           <HelpInstallSnap
             headline='To test the latest successful build on your PC or cloud instance:'
             name={ snap.store_name }

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -70,7 +70,7 @@ class Builds extends Component {
         { error &&
           <Message status='error'>{ error.message || error }</Message>
         }
-        { snap &&
+        { snap && snap.store_name &&
           <HelpInstallSnap
             headline='To test this snap on your PC or cloud instance:'
             name={ snap.store_name }

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -85,11 +85,11 @@ export const getUser = (req, res) => {
 };
 
 // memcached cache id helper
-export const getSnapNameCacheId = (repositoryUrl) => `snapcraft_data:${repositoryUrl}`;
+export const getSnapcraftYamlCacheId = (repositoryUrl) => `snapcraft_data:${repositoryUrl}`;
 
 export const getSnapcraftData = (repositoryUrl, token) => {
   const { owner, name } = parseGitHubRepoUrl(repositoryUrl);
-  const cacheId = getSnapNameCacheId(repositoryUrl);
+  const cacheId = getSnapcraftYamlCacheId(repositoryUrl);
 
   return getMemcached().get(cacheId)
     .catch((err) => {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -439,18 +439,6 @@ export const findSnap = (req, res) => {
     .catch((error) => sendError(res, error));
 };
 
-const memcachedDel = (cachedId) => {
-  return new Promise((resolve, reject) => {
-    getMemcached().del(cachedId, (err) => {
-      if (err) {
-        logger.error(`Error deleting ${cachedId} from memcached:`, err);
-        reject(err);
-      }
-      resolve();
-    });
-  });
-};
-
 const clearSnapCache = (repositoryUrl) => {
   const repository = parseGitHubUrl(repositoryUrl);
   const enabledReposCacheId = getUrlPrefixCacheId(getRepoUrlPrefix(repository.owner));
@@ -460,9 +448,9 @@ const clearSnapCache = (repositoryUrl) => {
   logger.info(`Clearing caches for ${repositoryUrl}: ${enabledReposCacheId}, ${snapCacheId}, ${snapNameCacheId}`);
 
   return Promise.all([
-    memcachedDel(enabledReposCacheId),
-    memcachedDel(snapCacheId),
-    memcachedDel(snapNameCacheId)
+    getMemcached().del(enabledReposCacheId),
+    getMemcached().del(snapCacheId),
+    getMemcached().del(snapNameCacheId)
   ]);
 };
 

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -12,7 +12,7 @@ import logging from '../logging';
 
 const logger = logging.getLogger('express');
 
-import { getSnapNameCacheId } from './github';
+import { getSnapcraftYamlCacheId } from './github';
 
 // XXX cjwatson 2016-12-08: Hardcoded for now, but should eventually be
 // configurable.
@@ -443,7 +443,7 @@ const clearSnapCache = (repositoryUrl) => {
   const repository = parseGitHubUrl(repositoryUrl);
   const enabledReposCacheId = getUrlPrefixCacheId(getRepoUrlPrefix(repository.owner));
   const snapCacheId = getRepositoryUrlCacheId(repositoryUrl);
-  const snapNameCacheId = getSnapNameCacheId(repositoryUrl);
+  const snapNameCacheId = getSnapcraftYamlCacheId(repositoryUrl);
 
   logger.info(`Clearing caches for ${repositoryUrl}: ${enabledReposCacheId}, ${snapCacheId}, ${snapNameCacheId}`);
 

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -1,18 +1,11 @@
 import 'isomorphic-fetch';
 
 import { conf } from '../helpers/config';
-import { getMemcached } from '../helpers/memcached';
-import { getRepoUrlPrefix, getUrlPrefixCacheId } from './launchpad';
-import parseGitHubUrl from 'parse-github-url';import logging from '../logging';
-
-const logger = logging.getLogger('express');
 
 export const registerName = (req, res) => {
   const snapName = req.body.snap_name;
   const root = req.body.root;
   const discharge = req.body.discharge;
-  const repositoryUrl = parseGitHubUrl(req.body.repository_url);
-  const cacheId = getUrlPrefixCacheId(getRepoUrlPrefix(repositoryUrl.owner));
 
   return fetch(`${conf.get('STORE_API_URL')}/register-name/`, {
     method: 'POST',
@@ -24,11 +17,7 @@ export const registerName = (req, res) => {
     body: JSON.stringify({ snap_name: snapName })
   }).then((response) => {
     return response.json().then((json) => {
-      return getMemcached().del(cacheId)
-        .catch((err) => {
-          logger.error(`Error deleting ${cacheId} from memcached:`, err);
-        })
-        .then(() => res.status(response.status).send(json));
+      return res.status(response.status).send(json);
     });
   });
 };

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -5,7 +5,7 @@ import { conf } from '../helpers/config';
 import { getMemcached } from '../helpers/memcached';
 import getLaunchpad from '../launchpad';
 import logging from '../logging';
-import { getSnapNameCacheId } from './github';
+import { getSnapcraftYamlCacheId } from './github';
 import { internalFindSnap, internalGetSnapcraftYaml } from './launchpad';
 
 const logger = logging.getLogger('express');
@@ -59,7 +59,7 @@ export const notify = (req, res) => {
     return res.status(200).send();
   } else {
     const repositoryUrl = getGitHubRepoUrl(owner, name);
-    const cacheId = getSnapNameCacheId(repositoryUrl);
+    const cacheId = getSnapcraftYamlCacheId(repositoryUrl);
     const lpClient = getLaunchpad();
     // Clear snap name cache before starting.
     // XXX cjwatson 2017-02-16: We could be smarter about this by looking at

--- a/src/server/helpers/memcached.js
+++ b/src/server/helpers/memcached.js
@@ -76,8 +76,13 @@ export const getMemcached = () => {
 };
 
 // Test affordance
-export const setupInMemoryMemcached = () => {
+export const setupInMemoryMemcached = (cache) => {
   memcached = promisifyMemcached(getInMemoryMemcachedStub());
+
+  // copy initial cache values
+  for (const key in cache) {
+    memcached.cache[key] = cache[key];
+  }
 };
 
 export const resetMemcached = () => {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -984,25 +984,15 @@ describe('The Launchpad API endpoint', () => {
                   macaroon: 'dummy-macaroon'
                 })
                 .end((err) => {
-                  if (err) {
-                    done(err);
-                  }
-
                   lpScope.done();
-                  // all the snap related caches should be cleared
-                  Promise.all([
-                    getMemcached().get(getUrlPrefixCacheId(urlPrefix), (err, result) => {
-                      expect(result).toNotExist();
-                    }),
-                    getMemcached().get(getRepositoryUrlCacheId(repositoryUrl), (err, result) => {
-                      expect(result).toNotExist();
-                    }),
-                    getMemcached().get(getSnapNameCacheId(repositoryUrl), (err, result) => {
-                      expect(result).toNotExist();
-                    })
-                  ])
-                  .then(() => done())
-                  .catch((err) => done(err));
+                  // it's our own in memory memcached stub,
+                  // so we can rely on internal .cache
+                  expect(getMemcached().cache).toExcludeKeys([
+                    getUrlPrefixCacheId(urlPrefix),
+                    getRepositoryUrlCacheId(repositoryUrl),
+                    getSnapNameCacheId(repositoryUrl)
+                  ]);
+                  done(err);
                 });
             });
           });

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -9,7 +9,7 @@ import {
   setupInMemoryMemcached
 } from '../../../../../src/server/helpers/memcached';
 import launchpad from '../../../../../src/server/routes/launchpad';
-import { getSnapNameCacheId } from '../../../../../src/server/handlers/github';
+import { getSnapcraftYamlCacheId } from '../../../../../src/server/handlers/github';
 import {
   getUrlPrefixCacheId,
   getRepositoryUrlCacheId
@@ -536,7 +536,7 @@ describe('The Launchpad API endpoint', () => {
         setupInMemoryMemcached();
         getMemcached().cache[getUrlPrefixCacheId(urlPrefix)] = testSnaps;
         testSnaps.map((snap) => {
-          const cacheId = getSnapNameCacheId(snap.git_repository_url);
+          const cacheId = getSnapcraftYamlCacheId(snap.git_repository_url);
           getMemcached().cache[cacheId] = contents[snap.git_repository_url];
         });
       });
@@ -964,7 +964,7 @@ describe('The Launchpad API endpoint', () => {
               // fill snap listing and snapcraft.yaml data caches
               getMemcached().set(getUrlPrefixCacheId(urlPrefix), [snap]);
               getMemcached().set(
-                getSnapNameCacheId(repositoryUrl),
+                getSnapcraftYamlCacheId(repositoryUrl),
                 { name: 'test-snap-name' }
               );
             });
@@ -990,7 +990,7 @@ describe('The Launchpad API endpoint', () => {
                   expect(getMemcached().cache).toExcludeKeys([
                     getUrlPrefixCacheId(urlPrefix),
                     getRepositoryUrlCacheId(repositoryUrl),
-                    getSnapNameCacheId(repositoryUrl)
+                    getSnapcraftYamlCacheId(repositoryUrl)
                   ]);
                   done(err);
                 });

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -533,8 +533,10 @@ describe('The Launchpad API endpoint', () => {
           'https://github.com/test-user/test-snap': {}
         };
 
-        setupInMemoryMemcached();
-        getMemcached().cache[getUrlPrefixCacheId(urlPrefix)] = testSnaps;
+        setupInMemoryMemcached({
+          [getUrlPrefixCacheId(urlPrefix)]: testSnaps
+        });
+
         testSnaps.map((snap) => {
           const cacheId = getSnapcraftYamlCacheId(snap.git_repository_url);
           getMemcached().cache[cacheId] = contents[snap.git_repository_url];
@@ -950,7 +952,7 @@ describe('The Launchpad API endpoint', () => {
             const repositoryUrl = 'https://github.com/anowner/aname';
             let snap;
 
-            before(() => {
+            beforeEach(() => {
               snap = {
                 resource_type_link: `${lpApiBase}/#snap`,
                 self_link: `${lpApiBase}/~test-user/+snap/test-snap`,
@@ -958,18 +960,20 @@ describe('The Launchpad API endpoint', () => {
                 git_repository_url: repositoryUrl
               };
 
-              setupInMemoryMemcached();
+              // fill snap listing and snapcraft.yaml data caches
+              setupInMemoryMemcached({
+                [getUrlPrefixCacheId(urlPrefix)]: [ snap ],
+                [getSnapcraftYamlCacheId(repositoryUrl)]: {
+                  name: 'test-snap-name'
+                }
+              });
               // find snap by url cache will be filled by API call
 
-              // fill snap listing and snapcraft.yaml data caches
-              getMemcached().set(getUrlPrefixCacheId(urlPrefix), [snap]);
-              getMemcached().set(
-                getSnapcraftYamlCacheId(repositoryUrl),
-                { name: 'test-snap-name' }
-              );
+              // getMemcached().cache[getUrlPrefixCacheId(urlPrefix)] = [ snap ];
+              // getMemcached().cache
             });
 
-            after(() => {
+            afterEach(() => {
               resetMemcached();
             });
 

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -4,7 +4,7 @@ import Express from 'express';
 import nock from 'nock';
 import supertest from 'supertest';
 
-import { getSnapNameCacheId } from '../../../../../src/server/handlers/github';
+import { getSnapcraftYamlCacheId } from '../../../../../src/server/handlers/github';
 import { conf } from '../../../../../src/server/helpers/config';
 import {
   getMemcached,
@@ -138,7 +138,7 @@ describe('The WebHook API endpoint', () => {
         });
 
         it('clears snap name from memcached', (done) => {
-          const cacheId = getSnapNameCacheId(
+          const cacheId = getSnapcraftYamlCacheId(
             'https://github.com/anowner/aname'
           );
           getMemcached().cache[cacheId] = 'snap1';
@@ -217,7 +217,7 @@ describe('The WebHook API endpoint', () => {
           });
 
           it('clears snap name from memcached', (done) => {
-            const cacheId = getSnapNameCacheId(
+            const cacheId = getSnapcraftYamlCacheId(
               'https://github.com/anowner/aname'
             );
             getMemcached().cache[cacheId] = 'snap1';
@@ -291,7 +291,7 @@ describe('The WebHook API endpoint', () => {
           // XXX cjwatson 2017-02-16: The code under test should cache the
           // returned snap name instead, but this will do for now.
           it('clears snap name from memcached', (done) => {
-            const cacheId = getSnapNameCacheId(
+            const cacheId = getSnapcraftYamlCacheId(
               'https://github.com/anowner/aname'
             );
             getMemcached().cache[cacheId] = 'snap1';


### PR DESCRIPTION
Launchpad sets the `store_name` for a snap once it's authorized.
So after a successful authorize call we need to clear all snap related caches to make sure they will be updated with fresh data about snap.