### PR TITLE
request user snaps before redirecting to dashboard from

### DIFF
--- a/src/common/actions/snaps.js
+++ b/src/common/actions/snaps.js
@@ -42,6 +42,20 @@ export function fetchUserSnaps(owner) {
   };
 }
 
+function shouldFetchUserSnaps(state) {
+  const snaps = state.snaps;
+
+  return !snaps.isFetching;
+}
+
+export function fetchUserSnapsIfNeeded(owner) {
+  return function(dispatch, getState) {
+    if (shouldFetchUserSnaps(getState())) {
+      return dispatch(fetchUserSnaps(owner));
+    }
+  };
+}
+
 export function fetchSnapsSuccess(snaps) {
   return {
     type: FETCH_SNAPS_SUCCESS,

--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
-import { fetchUserSnaps } from '../../actions/snaps';
+import { fetchUserSnapsIfNeeded } from '../../actions/snaps';
 import { fetchBuilds } from '../../actions/snap-builds';
 import { LinkButton } from '../vanilla/button';
 import { HeadingThree } from '../vanilla/heading';
@@ -36,7 +36,7 @@ class RepositoriesHome extends Component {
     const owner = this.props.user.login;
 
     if (authenticated) {
-      this.props.dispatch(fetchUserSnaps(owner));
+      this.props.dispatch(fetchUserSnapsIfNeeded(owner));
     }
 
     this.fetchData(this.props);

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { fetchUserSnaps } from '../../actions/snaps';
+import { fetchUserSnapsIfNeeded } from '../../actions/snaps';
 import { fetchBuilds } from '../../actions/snap-builds';
 import { fetchUserRepositories } from '../../actions/repositories';
 import SelectRepositoryList from '../select-repository-list';
@@ -16,7 +16,7 @@ class SelectRepositoriesPage extends Component {
 
     if (authenticated) {
       this.props.dispatch(fetchUserRepositories());
-      this.props.dispatch(fetchUserSnaps(owner));
+      this.props.dispatch(fetchUserSnapsIfNeeded(owner));
     }
 
     this.fetchData(this.props);

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -36,7 +36,7 @@ export class SelectRepositoryListComponent extends Component {
     const owner = nextProps.user.login;
     if (ids.length && ids.every((id) => repositoriesStatus[id].success)) {
       this.props.dispatch(fetchUserSnapsIfNeeded(owner));
-      this.props.router.push('/dashboard/');
+      this.props.router.push('/dashboard');
     }
   }
 

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -14,6 +14,7 @@ import PageLinks from '../page-links';
 import Button, { LinkButton } from '../vanilla/button';
 import { HeadingThree } from '../vanilla/heading';
 import { fetchUserRepositories } from '../../actions/repositories';
+import { fetchUserSnapsIfNeeded } from '../../actions/snaps';
 import { hasRepository } from '../../helpers/repositories';
 import styles from './styles.css';
 
@@ -32,8 +33,10 @@ export class SelectRepositoryListComponent extends Component {
   componentWillReceiveProps(nextProps) {
     const repositoriesStatus = nextProps.repositoriesStatus;
     const ids = Object.keys(repositoriesStatus);
+    const owner = nextProps.user.login;
     if (ids.length && ids.every((id) => repositoriesStatus[id].success)) {
-      this.props.router.push('/dashboard');
+      this.props.dispatch(fetchUserSnapsIfNeeded(owner));
+      this.props.router.push('/dashboard/');
     }
   }
 
@@ -86,6 +89,7 @@ export class SelectRepositoryListComponent extends Component {
 
   onSubmit() {
     const { selectedRepos } = this.props.selectRepositoriesForm;
+
     if (selectedRepos.length) {
       this.props.dispatch(createSnaps(selectedRepos));
     }
@@ -172,17 +176,19 @@ export class SelectRepositoryListComponent extends Component {
 }
 
 SelectRepositoryListComponent.propTypes = {
-  snaps: PropTypes.object,
+  dispatch: PropTypes.func.isRequired,
+  onSelectRepository: PropTypes.func,
   repositories: PropTypes.object,
   repositoriesStatus: PropTypes.object,
-  selectRepositoriesForm: PropTypes.object,
-  onSelectRepository: PropTypes.func,
   router: PropTypes.object.isRequired,
-  dispatch: PropTypes.func.isRequired
+  selectRepositoriesForm: PropTypes.object,
+  snaps: PropTypes.object,
+  user: PropTypes.object
 };
 
 function mapStateToProps(state) {
   const {
+    user,
     snaps,
     repositories,
     repositoriesStatus,
@@ -190,6 +196,7 @@ function mapStateToProps(state) {
   } = state;
 
   return {
+    user,
     snaps,
     repositories,
     repositoriesStatus,
@@ -197,4 +204,6 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(withRouter(SelectRepositoryListComponent));
+export default connect(mapStateToProps)(
+  withRouter(SelectRepositoryListComponent)
+);

--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -31,7 +31,7 @@ export function snaps(state = {
   isFetching: false,
   success: false,
   error: null,
-  snaps: null,
+  snaps: null
 }, action) {
   switch(action.type) {
     case ActionTypes.FETCH_SNAPS:

--- a/test/unit/src/common/actions/t_snaps.js
+++ b/test/unit/src/common/actions/t_snaps.js
@@ -3,11 +3,13 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import nock from 'nock';
 import { isFSA } from 'flux-standard-action';
+import { FETCH_SNAPS } from '../../../../../src/common/actions/snaps.js';
 
 import { conf } from '../../../../../src/server/helpers/config';
 
 import {
   fetchUserSnaps,
+  fetchUserSnapsIfNeeded,
   fetchSnapsSuccess,
   fetchSnapsError,
   removeSnap,
@@ -21,10 +23,12 @@ const mockStore = configureMockStore(middlewares);
 
 describe('repositories actions', () => {
   const initialState = {
-    isFetching: false,
-    success: false,
-    error: null,
-    snaps: null
+    snaps: {
+      isFetching: false,
+      success: false,
+      error: null,
+      snaps: null
+    }
   };
 
   let store;
@@ -76,6 +80,25 @@ describe('repositories actions', () => {
 
     it('should create a valid flux standard action', () => {
       expect(isFSA(action)).toBe(true);
+    });
+  });
+
+  context('fetchUserSnapsIfNeeded', function() {
+    const expectedAction = {
+      type: ActionTypes.FETCH_SNAPS
+    };
+
+    it('should fetch if not already fetching', function() {
+      store.dispatch(fetchUserSnapsIfNeeded('foo'));
+      expect(store.getActions()).toInclude(expectedAction);
+    });
+
+    it('should not fetch if already fetching', function() {
+      initialState.snaps.isFetching = true;
+      store.dispatch(fetchUserSnapsIfNeeded('foo'));
+
+      expect(store.getState().snaps.isFetching).toBe(true);
+      expect(store.getActions()).toExclude(expectedAction);
     });
   });
 


### PR DESCRIPTION
In the case where a user has no enabled repos, and visits dashboard/selected-repositories, the `repositories-list` component onMount has stale props. `mapStateToProps` is called both too early (when we indeed have no snaps) and too late (already redirected), and as such the component redirects back to dashboard/selected-repositories because the list of snaps is 0, but we've had a successful fetch.

By dispatching the fetchUserSnaps action early, when we know we're going to redirect, the `repositories-list` component has up to date props and does the right thing. In order to avoid fetching when we're already fetching, we check in the action if a dispatch is required based on `[snaps: isFetching]`.

This is a solution, not the solution. The solution involved figuring out why mapStateToProps isn't being called at the point we'd like it to, which will take a little more investigation.

## To QA

* remove all snaps
* enable 1 snap
* add selected snap
* dashboard/select-repositories should redirect to /dashboard (and not bounce back)