### PR TITLE
Convert all uses of memcached to promises

### DIFF
--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -92,7 +92,9 @@ export const getSnapcraftData = (repositoryUrl, token) => {
   const cacheId = getSnapNameCacheId(repositoryUrl);
 
   return getMemcached().get(cacheId)
-    .catch(() => undefined)
+    .catch((err) => {
+      logger.error(`Error getting ${cacheId} from memcached:`, err);
+    })
     .then((result) => {
       if (result !== undefined) {
         return result;

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -91,11 +91,11 @@ export const getSnapcraftData = (repositoryUrl, token) => {
   const { owner, name } = parseGitHubRepoUrl(repositoryUrl);
   const cacheId = getSnapNameCacheId(repositoryUrl);
 
-  return new Promise((resolve) => {
-    getMemcached().get(cacheId, (err, result) => {
-
-      if (!err && result !== undefined) {
-        return resolve(result);
+  return getMemcached().get(cacheId)
+    .catch(() => undefined)
+    .then((result) => {
+      if (result !== undefined) {
+        return result;
       }
 
       return internalGetSnapcraftYaml(owner, name, token)
@@ -107,13 +107,11 @@ export const getSnapcraftData = (repositoryUrl, token) => {
             }
           }
 
-          return getMemcached().set(cacheId, snapcraftData, 3600, () => {
-            return resolve(snapcraftData);
-          });
+          return getMemcached().set(cacheId, snapcraftData, 3600)
+            .then(() => snapcraftData);
         })
-        .catch(() => resolve(null));
+        .catch(() => null);
     });
-  });
 };
 
 export const listRepositories = (req, res) => {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -313,7 +313,9 @@ export const internalFindSnap = async (repositoryUrl) => {
   const lpClient = getLaunchpad();
 
   return getMemcached().get(cacheId)
-    .catch(() => undefined)
+    .catch((err) => {
+      logger.error(`Error getting ${cacheId} from memcached:`, err);
+    })
     .then((result) => {
       if (result !== undefined) {
         return lpClient.wrap_resource(result.self_link, result);
@@ -358,7 +360,9 @@ const internalFindSnapsByPrefix = (urlPrefix) => {
   const lpClient = getLaunchpad();
 
   return getMemcached().get(cacheId)
-    .catch(() => undefined)
+    .catch((err) => {
+      logger.error(`Error getting ${cacheId} from memcached:`, err);
+    })
     .then((result) => {
       if (result !== undefined) {
         return result.map((entry) => {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -289,21 +289,21 @@ export const newSnap = (req, res) => {
       const urlPrefix = getRepoUrlPrefix(owner);
       const cacheId = getUrlPrefixCacheId(urlPrefix);
 
-      getMemcached().del(cacheId, (err) => {
-        if (err) {
+      return getMemcached().del(cacheId)
+        .catch((err) => {
           logger.error(`Error deleting ${cacheId} from memcached:`, err);
-        }
-      });
-
-      snapUrl = result.self_link;
-      logger.info(`Created ${snapUrl}`);
-      return res.status(201).send({
-        status: 'success',
-        payload: {
-          code: 'snap-created',
-          message: snapUrl
-        }
-      });
+        })
+        .then(() => {
+          snapUrl = result.self_link;
+          logger.info(`Created ${snapUrl}`);
+          return res.status(201).send({
+            status: 'success',
+            payload: {
+              code: 'snap-created',
+              message: snapUrl
+            }
+          });
+        });
     })
     .catch((error) => sendError(res, error));
 };
@@ -312,45 +312,44 @@ export const internalFindSnap = async (repositoryUrl) => {
   const cacheId = getRepositoryUrlCacheId(repositoryUrl);
   const lpClient = getLaunchpad();
 
-  return new Promise((resolve, reject) => {
-    getMemcached().get(cacheId, (err, result) => {
-      if (!err && result !== undefined) {
-        return resolve(lpClient.wrap_resource(result.self_link, result));
+  return getMemcached().get(cacheId)
+    .catch(() => undefined)
+    .then((result) => {
+      if (result !== undefined) {
+        return lpClient.wrap_resource(result.self_link, result);
       }
 
-      lpClient.named_get('/+snaps', 'findByURL', {
+      return lpClient.named_get('/+snaps', 'findByURL', {
         parameters: { url: repositoryUrl }
       })
-      .catch((error) => {
-        if (error.response.status === 404) {
-          return reject(new PreparedError(404, RESPONSE_SNAP_NOT_FOUND));
-        }
-        // At least for the moment, we just wrap the error we get from
-        // Launchpad.
-        error.response.text().then((text) => {
-          return reject(new PreparedError(error.response.status, {
-            status: 'error',
-            payload: {
-              code: 'lp-error',
-              message: text
-            }
-          }));
-        });
-      })
-      .then(async (result) => {
-        const username = conf.get('LP_API_USERNAME');
-        // https://github.com/babel/babel-eslint/issues/415
-        for await (const entry of result) { // eslint-disable-line semi
-          if (entry.owner_link.endsWith(`/~${username}`)) {
-            return getMemcached().set(cacheId, entry, 3600, () => {
-              return resolve(entry);
-            });
+        .catch((error) => {
+          if (error.response.status === 404) {
+            throw new PreparedError(404, RESPONSE_SNAP_NOT_FOUND);
           }
-        }
-        return reject(new PreparedError(404, RESPONSE_SNAP_NOT_FOUND));
-      });
+          // At least for the moment, we just wrap the error we get from
+          // Launchpad.
+          return error.response.text().then((text) => {
+            throw new PreparedError(error.response.status, {
+              status: 'error',
+              payload: {
+                code: 'lp-error',
+                message: text
+              }
+            });
+          });
+        })
+        .then(async (result) => {
+          const username = conf.get('LP_API_USERNAME');
+          // https://github.com/babel/babel-eslint/issues/415
+          for await (const entry of result) { // eslint-disable-line semi
+            if (entry.owner_link.endsWith(`/~${username}`)) {
+              return getMemcached().set(cacheId, entry, 3600)
+                .then(() => entry);
+            }
+          }
+          throw new PreparedError(404, RESPONSE_SNAP_NOT_FOUND);
+        });
     });
-  });
 };
 
 const internalFindSnapsByPrefix = (urlPrefix) => {
@@ -358,40 +357,39 @@ const internalFindSnapsByPrefix = (urlPrefix) => {
   const cacheId = getUrlPrefixCacheId(urlPrefix);
   const lpClient = getLaunchpad();
 
-  return new Promise((resolve, reject) => {
-    getMemcached().get(cacheId, (err, result) => {
-      if (!err && result !== undefined) {
-        return resolve(result.map((entry) => {
+  return getMemcached().get(cacheId)
+    .catch(() => undefined)
+    .then((result) => {
+      if (result !== undefined) {
+        return result.map((entry) => {
           return lpClient.wrap_resource(entry.self_link, entry);
-        }));
+        });
       }
 
-      lpClient.named_get('/+snaps', 'findByURLPrefix', {
+      return lpClient.named_get('/+snaps', 'findByURLPrefix', {
         parameters: {
           url_prefix: urlPrefix,
           owner: `/~${username}`
         }
       })
-      .then(result => {
-        return getMemcached().set(cacheId, result.entries, 3600, () => {
-          return resolve(result.entries);
+        .then((result) => {
+          return getMemcached().set(cacheId, result.entries, 3600)
+            .then(() => result.entries);
+        })
+        .catch((error) => {
+          // At least for the moment, we just wrap the error we get from
+          // Launchpad.
+          return error.response.text().then((text) => {
+            throw new PreparedError(error.response.status, {
+              status: 'error',
+              payload: {
+                code: 'lp-error',
+                message: text
+              }
+            });
+          });
         });
-      })
-      .catch((error) => {
-        // At least for the moment, we just wrap the error we get from
-        // Launchpad.
-        error.response.text().then((text) => {
-          return reject(new PreparedError(error.response.status, {
-            status: 'error',
-            payload: {
-              code: 'lp-error',
-              message: text
-            }
-          }));
-        });
-      });
     });
-  });
 };
 
 export const findSnaps = (req, res) => {
@@ -533,15 +531,15 @@ export const deleteSnap = (req, res) => {
       const prefixCacheId = getUrlPrefixCacheId(urlPrefix);
       const repoCacheId = getRepositoryUrlCacheId(req.body.repository_url);
 
-      getMemcached().del(prefixCacheId, (err) => {
-        if (err) {
+      return getMemcached().del(prefixCacheId)
+        .catch((err) => {
           logger.error(`Error deleting ${prefixCacheId} from memcached:`, err);
-        }
-        getMemcached().del(repoCacheId, (err) => {
-          if (err) {
-            logger.error(`Error deleting ${repoCacheId} from memcached:`, err);
-          }
-
+        })
+        .then(() => getMemcached().del(repoCacheId))
+        .catch((err) => {
+          logger.error(`Error deleting ${repoCacheId} from memcached:`, err);
+        })
+        .then(() => {
           return res.status(200).send({
             status: 'success',
             payload: {
@@ -550,7 +548,6 @@ export const deleteSnap = (req, res) => {
             }
           });
         });
-      });
     })
     .catch((error) => sendError(res, error));
 };

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -24,13 +24,11 @@ export const registerName = (req, res) => {
     body: JSON.stringify({ snap_name: snapName })
   }).then((response) => {
     return response.json().then((json) => {
-      getMemcached().del(cacheId, (err) => {
-        if (err) {
+      return getMemcached().del(cacheId)
+        .catch((err) => {
           logger.error(`Error deleting ${cacheId} from memcached:`, err);
-        }
-
-        res.status(response.status).send(json);
-      });
+        })
+        .then(() => res.status(response.status).send(json));
     });
   });
 };

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -64,6 +64,7 @@ export const notify = (req, res) => {
     // XXX cjwatson 2017-02-16: We could be smarter about this by looking at
     // the content of the push event.
     return getMemcached().del(getSnapNameCacheId(repositoryUrl))
+      .catch(() => undefined)
       .then(() => internalFindSnap(repositoryUrl))
       .then((snap) => {
         if (!snap.auto_build) {

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -59,12 +59,15 @@ export const notify = (req, res) => {
     return res.status(200).send();
   } else {
     const repositoryUrl = getGitHubRepoUrl(owner, name);
+    const cacheId = getSnapNameCacheId(repositoryUrl);
     const lpClient = getLaunchpad();
     // Clear snap name cache before starting.
     // XXX cjwatson 2017-02-16: We could be smarter about this by looking at
     // the content of the push event.
-    return getMemcached().del(getSnapNameCacheId(repositoryUrl))
-      .catch(() => undefined)
+    return getMemcached().del(cacheId)
+      .catch((err) => {
+        logger.error(`Error deleting ${cacheId} from memcached:`, err);
+      })
       .then(() => internalFindSnap(repositoryUrl))
       .then((snap) => {
         if (!snap.auto_build) {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -399,15 +399,10 @@ describe('The Launchpad API endpoint', () => {
           .get('/launchpad/snaps/list')
           .query({ owner: 'anowner' })
           .end((err) => {
-            if (err) {
-              done(err);
-            }
-            getMemcached().get(cacheId, (err, memcachedSnaps) => {
-              expect(memcachedSnaps.length).toEqual(testSnaps.length);
-              expect(memcachedSnaps[0]).toContain(testSnaps[0]);
-
-              done(err);
-            });
+            const memcachedSnaps = getMemcached().cache[cacheId];
+            expect(memcachedSnaps.length).toEqual(testSnaps.length);
+            expect(memcachedSnaps[0]).toContain(testSnaps[0]);
+            done(err);
           });
         });
 
@@ -540,12 +535,10 @@ describe('The Launchpad API endpoint', () => {
         };
 
         setupInMemoryMemcached();
-        getMemcached().set(getUrlPrefixCacheId(urlPrefix), testSnaps);
+        getMemcached().cache[getUrlPrefixCacheId(urlPrefix)] = testSnaps;
         testSnaps.map((snap) => {
-          getMemcached().set(
-            getSnapNameCacheId(snap.git_repository_url),
-            contents[snap.git_repository_url]
-          );
+          const cacheId = getSnapNameCacheId(snap.git_repository_url);
+          getMemcached().cache[cacheId] = contents[snap.git_repository_url];
         });
       });
 
@@ -745,7 +738,7 @@ describe('The Launchpad API endpoint', () => {
 
       before(() => {
         setupInMemoryMemcached();
-        getMemcached().set(getRepositoryUrlCacheId(repositoryUrl), snap);
+        getMemcached().cache[getRepositoryUrlCacheId(repositoryUrl)] = snap;
       });
 
       after(() => {
@@ -1474,7 +1467,7 @@ describe('The Launchpad API endpoint', () => {
           .delete(`/devel${lp_snap_path}`)
           .reply(200, 'null', { 'Content-Type': 'application/json' });
         setupInMemoryMemcached();
-        getMemcached().set(getUrlPrefixCacheId(urlPrefix), [testSnap]);
+        getMemcached().cache[getUrlPrefixCacheId(urlPrefix)] = [testSnap];
       });
 
       afterEach(() => {
@@ -1541,8 +1534,10 @@ describe('The Launchpad API endpoint', () => {
           .delete(`/devel${lp_snap_path}`)
           .reply(200, 'null', { 'Content-Type': 'application/json' });
         setupInMemoryMemcached();
-        getMemcached().set(getUrlPrefixCacheId(urlPrefix), [testSnap]);
-        getMemcached().set(getRepositoryUrlCacheId(repositoryUrl), testSnap);
+        const urlPrefixCacheId = getUrlPrefixCacheId(urlPrefix);
+        const urlCacheId = getRepositoryUrlCacheId(repositoryUrl);
+        getMemcached().cache[urlPrefixCacheId] = [testSnap];
+        getMemcached().cache[urlCacheId] = testSnap;
       });
 
       afterEach(() => {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -8,8 +8,8 @@ import {
   resetMemcached,
   setupInMemoryMemcached
 } from '../../../../../src/server/helpers/memcached';
-import getSnapNameCacheId from '../../../../../src/server/helpers/github';
 import launchpad from '../../../../../src/server/routes/launchpad';
+import { getSnapNameCacheId } from '../../../../../src/server/handlers/github';
 import {
   getUrlPrefixCacheId,
   getRepositoryUrlCacheId
@@ -509,8 +509,7 @@ describe('The Launchpad API endpoint', () => {
       const urlPrefix = 'https://github.com/anowner/';
       let testSnaps;
 
-      before(() => {
-
+      beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
         const lp_api_base = `${lp_api_url}/devel`;
 
@@ -542,7 +541,7 @@ describe('The Launchpad API endpoint', () => {
         });
       });
 
-      after(() => {
+      afterEach(() => {
         resetMemcached();
       });
 


### PR DESCRIPTION
This is much easier to use, especially in conjunction with other code
using promises.  The test stubs already used promises, but this had a
dangerous gotcha: code that expected memcached methods to return
promises would work under test but fail in production, as was the case
with the webhook implementation.  Using promises everywhere avoids this
problem.

I considered using one of the existing memcached/promise integration
libraries, but all the ones I could find depended on some specific
promise library, and it's so easy to do by hand that it wasn't worth the
hassle.