### PR TITLE
update the wordmark to orange

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "vsicons.presets.angular": false
+}

--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router';
 import { signOut } from '../../actions/auth-store';
 import styles from './header.css';
 
-const wordmark = 'https://assets.ubuntu.com/v1/d45097a4-snapcraft.io-logotype.svg';
+const wordmark = 'https://assets.ubuntu.com/v1/8fd73196-orange-logo.svg';
 
 class Header extends Component {
   render() {


### PR DESCRIPTION
Update the wordmark to an orange version. Please don’t land until we’ve had approval from Evan on this.

<img width="1268" alt="screenshot 2017-03-02 11 40 08" src="https://cloud.githubusercontent.com/assets/6909617/23505775/0b661720-ff3d-11e6-9326-93ed48740521.png">
