### PR TITLE
Change "Register" button text to "Register Name"

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -296,7 +296,7 @@ class RepositoryRow extends Component {
         actionSpinner = true;
         actionText = 'Checking...';
       } else {
-        actionText = 'Register Name';
+        actionText = 'Register name';
       }
     } else {
       actionDisabled = !!registerNameStatus.error;

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -296,7 +296,7 @@ class RepositoryRow extends Component {
         actionSpinner = true;
         actionText = 'Checking...';
       } else {
-        actionText = 'Register';
+        actionText = 'Register Name';
       }
     } else {
       actionDisabled = !!registerNameStatus.error;


### PR DESCRIPTION
The actionText on the Register button should change from “Register” to “Register Name” 