### PR TITLE
Add stub PostgreSQL relations

### DIFF
--- a/charm/metadata.yaml
+++ b/charm/metadata.yaml
@@ -9,3 +9,7 @@ series:
 requires:
   cache: 
     interface: memcache
+  db:
+    interface: pgsql
+  db-admin:
+    interface: pgsql


### PR DESCRIPTION
Allow the charm to have `db` and `db-admin` relations on the `pgsql`
interface.  These don't do anything yet, but having stubs in place lets
us move on to the next phase of a stepped rollout.