### PR TITLE
Store GitHub user information in a database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ version-info.txt
 # Environment variables
 .env
 environments/development.env
+
+# Development and test SQLite databases
+/dev.sqlite3
+/test.sqlite3

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,10 @@ build: $(PAYLOAD)
 deploy: build
 	juju deploy $(CHARMDIR)
 	juju deploy memcached
+	juju deploy postgresql
 	juju add-relation $(NAME) memcached
+	juju add-relation $(NAME) postgresql:db
+	juju add-relation $(NAME) postgresql:db-admin
 	juju config $(NAME) session_secret='its a secret' \
 		environment=$(DEPLOY_ENV) \
 		memcache_session_secret='its another secret'

--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -4,11 +4,14 @@ interface/interface-conn-check      git+ssh://git.launchpad.net/~ubuntuone-hacke
 interface/interface-http            lp:~ubuntuone-hackers/ols-charm-deps/interface-http;revno=17
 interface/interface-juju-info       lp:~ubuntuone-hackers/ols-charm-deps/interface-juju-info;revno=6
 interface/interface-memcache        git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/interface-memcache;revno=5ccddd9
+interface/interface-pgsql           git+ssh://git.launchpad.net/interface-pgsql;revno=v2.0.1
 
 layer                               @
 layer/layer-apt                     git+ssh://git.launchpad.net/layer-apt;revno=608bdf5
 layer/layer-basic                   lp:~ubuntuone-hackers/ols-charm-deps/layer-basic;revno=62
+layer/layer-leadership              git+ssh://git.launchpad.net/layer-leadership;revno=8846afc
 layer/layer-ols                     lp:~ubuntuone-hackers/ols-charm-deps/layer-ols;revno=13
 layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=3
+layer/layer-ols-pg                  lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-pg;revno=3
 
 wheels                              git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/wheels

--- a/charm/config.yaml
+++ b/charm/config.yaml
@@ -32,3 +32,5 @@ options:
     http_proxy:
         type: string
         description: HTTP proxy URL
+    db_roles:
+        default: "snap_build"

--- a/charm/dependencies-devel.txt
+++ b/charm/dependencies-devel.txt
@@ -1,7 +1,8 @@
 bzr
 charm-tools
-python-codetree
 git
+libpq-dev
 make
+python-codetree
 rsync
 virtualenv

--- a/charm/layer.yaml
+++ b/charm/layer.yaml
@@ -1,13 +1,23 @@
 repo: git@github.com:canonical-ols/build.snapcraft.io.git
 includes:
+    - layer:leadership
     - layer:ols-http
+    - layer:ols-pg
     - interface:memcache
 options:
+    basic:
+        packages:
+            - python3-psycopg2
     ols:
         service_name: snap-build
         user: ubuntu
         tarball_payload: false
-
+# Ignore the migrate action from layer:ols-pg for now, since we handle that
+# in response to leadership election instead.  Perhaps in future we should
+# supply our own version of this action.
+ignore:
+    - actions
+    - actions.yaml
 exclude:
     - tmp
     - Makefile

--- a/charm/metadata.yaml
+++ b/charm/metadata.yaml
@@ -9,7 +9,3 @@ series:
 requires:
   cache: 
     interface: memcache
-  db:
-    interface: pgsql
-  db-admin:
-    interface: pgsql

--- a/charm/templates/knexfile.js.j2
+++ b/charm/templates/knexfile.js.j2
@@ -1,0 +1,14 @@
+//  This file is managed by Juju; ANY CHANGES WILL BE OVERWRITTEN
+// --------------------------------------------------------------
+
+module.exports = {
+
+  '{{ environment }}': {
+    client: 'pg',
+    connection: '{{ db_conn }}',
+    migrations: {
+      tableName: 'knex_migrations'
+    }
+  }
+
+}

--- a/charm/templates/snap-build_systemd.j2
+++ b/charm/templates/snap-build_systemd.j2
@@ -18,6 +18,7 @@ Environment='LP_API_TOKEN_SECRET={{ lp_api_token_secret }}'
 Environment='GITHUB_AUTH_CLIENT_ID={{ github_auth_client_id }}'
 Environment='GITHUB_AUTH_CLIENT_SECRET={{ github_auth_client_secret }}'
 Environment='GITHUB_WEBHOOK_SECRET={{ github_webhook_secret }}'
+Environment='KNEX_CONFIG_PATH={{ knex_config_path }}'
 Environment='HTTP_PROXY={{ http_proxy }}'
 Environment='TRUSTED_NETWORKS={{ trusted_networks | join(",") }}'
 WorkingDirectory={{ working_dir }}

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,25 @@
+module.exports = {
+
+  development: {
+    client: 'sqlite3',
+    connection: {
+      filename: './dev.sqlite3'
+    },
+    migrations: {
+      tableName: 'knex_migrations'
+    },
+    useNullAsDefault: false
+  },
+
+  test: {
+    client: 'sqlite3',
+    connection: {
+      filename: './test.sqlite3'
+    },
+    migrations: {
+      tableName: 'knex_migrations'
+    },
+    useNullAsDefault: false
+  }
+
+};

--- a/migrations/20170302155852_user.js
+++ b/migrations/20170302155852_user.js
@@ -8,6 +8,7 @@ exports.up = function(knex, Promise) {
       table.text('name');
       table.text('login').notNullable();
       table.timestamps();
+      table.timestamp('last_login_at').notNullable();
     })
   ]);
 };

--- a/migrations/20170302155852_user.js
+++ b/migrations/20170302155852_user.js
@@ -1,0 +1,20 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('github_user', function(table) {
+      // The GitHub ID would do as a primary key, but this approach works
+      // better with Bookshelf's `Model.isNew` method.
+      table.increments();
+      table.integer('github_id').notNullable();
+      table.text('name');
+      table.text('login').notNullable();
+      table.text('avatar_url');
+      table.timestamps();
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.dropTable('github_user')
+  ]);
+};

--- a/migrations/20170302155852_user.js
+++ b/migrations/20170302155852_user.js
@@ -7,7 +7,6 @@ exports.up = function(knex, Promise) {
       table.integer('github_id').notNullable();
       table.text('name');
       table.text('login').notNullable();
-      table.text('avatar_url');
       table.timestamps();
     })
   ]);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,11 +17,23 @@
     "ansi-styles": {
       "version": "2.2.1"
     },
+    "ap": {
+      "version": "0.2.0"
+    },
     "argparse": {
       "version": "1.0.9"
     },
+    "arr-diff": {
+      "version": "2.0.0"
+    },
+    "arr-flatten": {
+      "version": "1.0.1"
+    },
     "array-flatten": {
       "version": "1.1.1"
+    },
+    "array-unique": {
+      "version": "0.2.1"
     },
     "asap": {
       "version": "2.0.5"
@@ -94,6 +106,9 @@
     "bintrees": {
       "version": "1.0.1"
     },
+    "bluebird": {
+      "version": "3.4.7"
+    },
     "body-parser": {
       "version": "1.15.2",
       "dependencies": {
@@ -102,8 +117,22 @@
         }
       }
     },
+    "bookshelf": {
+      "version": "0.10.3",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4"
+        }
+      }
+    },
     "boom": {
       "version": "2.10.1"
+    },
+    "braces": {
+      "version": "1.8.5"
+    },
+    "buffer-writer": {
+      "version": "1.0.1"
     },
     "builtin-modules": {
       "version": "1.1.1"
@@ -179,6 +208,9 @@
     "crc": {
       "version": "3.4.1"
     },
+    "create-error": {
+      "version": "0.3.1"
+    },
     "cryptiles": {
       "version": "2.0.5"
     },
@@ -225,6 +257,9 @@
     },
     "destroy": {
       "version": "1.0.4"
+    },
+    "detect-file": {
+      "version": "0.1.0"
     },
     "dns-prefetch-control": {
       "version": "0.1.0"
@@ -292,6 +327,15 @@
     "etag": {
       "version": "1.7.0"
     },
+    "expand-brackets": {
+      "version": "0.1.5"
+    },
+    "expand-range": {
+      "version": "1.8.2"
+    },
+    "expand-tilde": {
+      "version": "1.2.2"
+    },
     "express": {
       "version": "4.14.0",
       "dependencies": {
@@ -315,6 +359,9 @@
         "chalk": {
           "version": "0.4.0"
         },
+        "lodash": {
+          "version": "4.11.2"
+        },
         "strip-ansi": {
           "version": "0.1.1"
         }
@@ -322,6 +369,9 @@
     },
     "extend": {
       "version": "3.0.0"
+    },
+    "extglob": {
+      "version": "0.3.2"
     },
     "extsprintf": {
       "version": "1.0.2"
@@ -338,11 +388,29 @@
     "fbjs": {
       "version": "0.8.6"
     },
+    "filename-regex": {
+      "version": "2.0.0"
+    },
+    "fill-range": {
+      "version": "2.2.3"
+    },
     "finalhandler": {
       "version": "0.5.0"
     },
     "find-up": {
       "version": "1.1.2"
+    },
+    "findup-sync": {
+      "version": "0.4.3"
+    },
+    "flagged-respawn": {
+      "version": "0.3.2"
+    },
+    "for-in": {
+      "version": "1.0.2"
+    },
+    "for-own": {
+      "version": "0.1.5"
     },
     "foreach": {
       "version": "2.0.5"
@@ -359,6 +427,9 @@
     "fresh": {
       "version": "0.3.0"
     },
+    "fs-exists-sync": {
+      "version": "0.1.0"
+    },
     "generate-function": {
       "version": "2.0.0"
     },
@@ -367,6 +438,9 @@
     },
     "generic-names": {
       "version": "1.0.2"
+    },
+    "generic-pool": {
+      "version": "2.5.4"
     },
     "get-caller-file": {
       "version": "1.0.2"
@@ -379,11 +453,23 @@
         }
       }
     },
+    "glob-base": {
+      "version": "0.3.0"
+    },
+    "glob-parent": {
+      "version": "2.0.0"
+    },
     "glob-to-regexp": {
       "version": "0.1.0"
     },
     "global": {
       "version": "4.3.1"
+    },
+    "global-modules": {
+      "version": "0.2.3"
+    },
+    "global-prefix": {
+      "version": "0.1.5"
     },
     "globals": {
       "version": "9.14.0"
@@ -430,6 +516,9 @@
     "hoist-non-react-statics": {
       "version": "1.2.0"
     },
+    "homedir-polyfill": {
+      "version": "1.0.1"
+    },
     "hosted-git-info": {
       "version": "2.1.5"
     },
@@ -466,8 +555,14 @@
     "in-publish": {
       "version": "2.0.0"
     },
+    "inflection": {
+      "version": "1.12.0"
+    },
     "inherits": {
       "version": "2.0.3"
+    },
+    "ini": {
+      "version": "1.3.4"
     },
     "inline-process-browser": {
       "version": "1.0.0"
@@ -484,14 +579,41 @@
     "is-arrayish": {
       "version": "0.2.1"
     },
+    "is-buffer": {
+      "version": "1.1.4"
+    },
     "is-builtin-module": {
+      "version": "1.0.0"
+    },
+    "is-dotfile": {
+      "version": "1.0.2"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3"
+    },
+    "is-extendable": {
+      "version": "0.1.1"
+    },
+    "is-extglob": {
       "version": "1.0.0"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0"
     },
+    "is-glob": {
+      "version": "2.0.1"
+    },
     "is-my-json-valid": {
       "version": "2.15.0"
+    },
+    "is-number": {
+      "version": "2.1.0"
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1"
+    },
+    "is-primitive": {
+      "version": "2.0.0"
     },
     "is-property": {
       "version": "1.0.2"
@@ -505,8 +627,22 @@
     "is-utf8": {
       "version": "0.2.1"
     },
+    "is-windows": {
+      "version": "0.2.0"
+    },
     "isarray": {
       "version": "0.0.1"
+    },
+    "isexe": {
+      "version": "1.1.2"
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
     },
     "isomorphic-fetch": {
       "version": "2.2.1"
@@ -563,11 +699,31 @@
         }
       }
     },
+    "kind-of": {
+      "version": "3.1.0"
+    },
+    "knex": {
+      "version": "0.12.7",
+      "dependencies": {
+        "interpret": {
+          "version": "0.6.6"
+        },
+        "minimist": {
+          "version": "1.1.3"
+        },
+        "readable-stream": {
+          "version": "1.1.14"
+        }
+      }
+    },
     "lcid": {
       "version": "1.0.0"
     },
     "lie": {
       "version": "3.0.2"
+    },
+    "liftoff": {
+      "version": "2.2.5"
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -584,7 +740,7 @@
       "version": "1.4.3"
     },
     "lodash": {
-      "version": "4.11.2"
+      "version": "4.17.4"
     },
     "lodash-es": {
       "version": "4.17.2"
@@ -640,6 +796,9 @@
     "methods": {
       "version": "1.1.2"
     },
+    "micromatch": {
+      "version": "2.3.11"
+    },
     "mime": {
       "version": "1.3.4"
     },
@@ -651,6 +810,12 @@
     },
     "min-document": {
       "version": "2.19.0"
+    },
+    "minimist": {
+      "version": "0.0.8"
+    },
+    "mkdirp": {
+      "version": "0.5.1"
     },
     "moment": {
       "version": "2.17.1"
@@ -670,6 +835,9 @@
     "normalize-package-data": {
       "version": "2.3.5"
     },
+    "normalize-path": {
+      "version": "2.0.1"
+    },
     "normalize.css": {
       "version": "5.0.0"
     },
@@ -688,6 +856,9 @@
     "object-keys": {
       "version": "1.0.11"
     },
+    "object.omit": {
+      "version": "2.0.1"
+    },
     "on-finished": {
       "version": "2.3.0"
     },
@@ -697,14 +868,26 @@
     "openid": {
       "version": "2.0.6"
     },
+    "os-homedir": {
+      "version": "1.0.2"
+    },
     "os-locale": {
       "version": "1.4.0"
+    },
+    "packet-reader": {
+      "version": "0.2.0"
     },
     "parse-github-url": {
       "version": "0.3.2"
     },
+    "parse-glob": {
+      "version": "3.0.4"
+    },
     "parse-json": {
       "version": "2.2.0"
+    },
+    "parse-passwd": {
+      "version": "1.0.0"
     },
     "parseurl": {
       "version": "1.3.1"
@@ -712,11 +895,39 @@
     "path-exists": {
       "version": "2.1.0"
     },
+    "path-parse": {
+      "version": "1.0.5"
+    },
     "path-to-regexp": {
       "version": "0.1.7"
     },
     "path-type": {
       "version": "1.1.0"
+    },
+    "pg": {
+      "version": "6.1.2",
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2"
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3"
+    },
+    "pg-pool": {
+      "version": "1.6.0",
+      "dependencies": {
+        "generic-pool": {
+          "version": "2.4.2"
+        }
+      }
+    },
+    "pg-types": {
+      "version": "1.11.0"
+    },
+    "pgpass": {
+      "version": "1.0.1"
     },
     "pify": {
       "version": "2.3.0"
@@ -756,6 +967,21 @@
     "postcss-modules-values": {
       "version": "1.2.2"
     },
+    "postgres-array": {
+      "version": "1.0.2"
+    },
+    "postgres-bytea": {
+      "version": "1.0.0"
+    },
+    "postgres-date": {
+      "version": "1.0.3"
+    },
+    "postgres-interval": {
+      "version": "1.0.2"
+    },
+    "preserve": {
+      "version": "0.2.0"
+    },
     "private": {
       "version": "0.1.7"
     },
@@ -782,6 +1008,9 @@
     },
     "random-bytes": {
       "version": "1.0.0"
+    },
+    "randomatic": {
+      "version": "1.1.6"
     },
     "range-parser": {
       "version": "1.2.0"
@@ -850,6 +1079,9 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2"
+    },
     "redbox-react": {
       "version": "1.3.3"
     },
@@ -868,6 +1100,9 @@
     "regenerator-runtime": {
       "version": "0.9.6"
     },
+    "regex-cache": {
+      "version": "0.4.3"
+    },
     "regexpu-core": {
       "version": "1.0.0"
     },
@@ -876,6 +1111,12 @@
     },
     "regjsparser": {
       "version": "0.1.5"
+    },
+    "repeat-element": {
+      "version": "1.1.2"
+    },
+    "repeat-string": {
+      "version": "1.6.1"
     },
     "request": {
       "version": "2.79.0",
@@ -891,8 +1132,17 @@
     "require-main-filename": {
       "version": "1.0.1"
     },
+    "resolve": {
+      "version": "1.3.2"
+    },
+    "resolve-dir": {
+      "version": "0.1.1"
+    },
     "retry": {
       "version": "0.6.0"
+    },
+    "safe-buffer": {
+      "version": "5.0.1"
     },
     "seekout": {
       "version": "1.0.2"
@@ -947,6 +1197,9 @@
     "spdx-license-ids": {
       "version": "1.2.2"
     },
+    "split": {
+      "version": "1.0.0"
+    },
     "sprintf-js": {
       "version": "1.0.3"
     },
@@ -997,6 +1250,9 @@
     "through2": {
       "version": "0.6.5"
     },
+    "tildify": {
+      "version": "1.0.0"
+    },
     "to-fast-properties": {
       "version": "1.0.2"
     },
@@ -1031,6 +1287,9 @@
     "url-value-parser": {
       "version": "1.0.0"
     },
+    "user-home": {
+      "version": "1.1.1"
+    },
     "util-extend": {
       "version": "1.0.3"
     },
@@ -1039,6 +1298,9 @@
     },
     "uuid": {
       "version": "3.0.0"
+    },
+    "v8flags": {
+      "version": "2.0.11"
     },
     "validate-npm-package-license": {
       "version": "3.0.1"
@@ -1054,6 +1316,9 @@
     },
     "whatwg-fetch": {
       "version": "2.0.1"
+    },
+    "which": {
+      "version": "1.2.12"
     },
     "which-module": {
       "version": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "description": "User interface layer for the Snapcraft Build site",
   "main": "src/server/index.js",
   "scripts": {
-    "start": "node ./webpack/webpack-dev-server",
+    "start": "npm run migrate:latest && node ./webpack/webpack-dev-server",
     "start-build": "node dist/server/",
     "start-mock-service": "DEBUG=express:* node mocks/service/index.js",
     "build": "./scripts/build.sh",
     "lint": "eslint -c .eslintrc.js '**/*.js'",
-    "test": "nyc npm run test:unit && npm run test:routes && npm run lint",
+    "test": "npm run test:setup-db && nyc npm run test:unit && npm run test:routes && npm run lint",
+    "test:setup-db": "rm -f test.sqlite3 && NODE_ENV=test npm run migrate:latest",
     "test:unit": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*",
-    "test:routes": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/routes/**/*"
+    "test:routes": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/routes/**/*",
+    "migrate:latest": "knex migrate:latest",
+    "migrate:rollback": "knex migrate:rollback"
   },
   "repository": {
     "type": "git",
@@ -31,6 +34,7 @@
   "dependencies": {
     "babel-polyfill": "^6.16.0",
     "body-parser": "^1.15.2",
+    "bookshelf": "^0.10.3",
     "chalk": "^1.1.3",
     "classnames": "^2.2.5",
     "connect-memcached": "^0.2.0",
@@ -47,6 +51,7 @@
     "ipaddr.js": "^1.1.1",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.7.0",
+    "knex": "^0.12.7",
     "localforage": "^1.4.3",
     "macaroons.js": "^0.3.6",
     "memcached": "^2.2.2",
@@ -55,6 +60,7 @@
     "oauth": "^0.9.14",
     "openid": "^2.0.6",
     "parse-github-url": "^0.3.2",
+    "pg": "^6.1.2",
     "qs": "^6.3.0",
     "raven": "^0.12.3",
     "react": "^15.4.0",
@@ -106,6 +112,7 @@
     "react-addons-test-utils": "^15.4.0",
     "redux-mock-store": "^1.2.1",
     "sinon": "^1.17.6",
+    "sqlite3": "^3.1.8",
     "std-mocks": "^1.0.1",
     "strip-ansi": "^3.0.1",
     "style-loader": "^0.13.1",

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -17,5 +17,6 @@ export default {
   GITHUB_AUTH_REDIRECT_URL: 'http://localhost:8000/auth/verify',
   GITHUB_AUTH_CLIENT_ID: '389a7b4c2ade662c0bf4',
   GITHUB_AUTH_CLIENT_SECRET: 'ea482b47a4830d38a838f48be43ab28002c33187',
-  GITHUB_WEBHOOK_SECRET: 'dummy-webhook-secret'
+  GITHUB_WEBHOOK_SECRET: 'dummy-webhook-secret',
+  KNEX_CONFIG_PATH: 'knexfile.js'
 };

--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -1,0 +1,29 @@
+import path from 'path';
+import knex from 'knex';
+import Bookshelf from 'bookshelf';
+
+import { conf } from '../helpers/config';
+import logging from '../logging';
+
+let knexConfigPath = conf.get('KNEX_CONFIG_PATH');
+if (!path.isAbsolute(knexConfigPath)) {
+  knexConfigPath = path.join('../../..', knexConfigPath);
+}
+const knexConfig = require(knexConfigPath);
+
+const logger = logging.getLogger('express');
+
+let environment = process.env.NODE_ENV;
+if (!environment) {
+  environment = 'development';
+}
+const config = knexConfig[environment];
+if (!config) {
+  logger.error(`Unable to find knex config for ${environment}`);
+  process.exit(1);
+}
+
+const connection = knex(config);
+const db = new Bookshelf(connection);
+
+export default db;

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -1,0 +1,6 @@
+import db from '../index';
+
+export const GitHubUser = db.Model.extend({
+  tableName: 'github_user',
+  hasTimestamps: true
+});

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -1,5 +1,14 @@
 import db from '../index';
 
+/* Schema:
+ *   id: automatic serial number
+ *   github_id: ID from GitHub
+ *   name: display name from GitHub
+ *   login: login name from GitHub
+ *   created_at: creation date
+ *   updated_at: update date
+ *   last_login_at: last login date
+ */
 export const GitHubUser = db.Model.extend({
   tableName: 'github_user',
   hasTimestamps: true

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -1,6 +1,7 @@
 import request from 'request';
 import logging from '../logging';
 
+import { GitHubUser } from '../db/models/github-user';
 import { conf } from '../helpers/config';
 import { requestUser } from './github';
 
@@ -75,6 +76,25 @@ export const verify = (req, res, next) => {
     req.session.githubAuthenticated = true;
     req.session.token = body.access_token;
     req.session.user = userResponse.body;
+
+    // Save user info to DB
+    try {
+      let dbUser = await GitHubUser.where({ github_id: userResponse.body.id })
+        .fetch();
+      if (dbUser === null) {
+        dbUser = GitHubUser.forge({ github_id: userResponse.body.id });
+      }
+      await dbUser.set({
+        name: userResponse.body.name || null,
+        login: userResponse.body.login,
+        avatar_url: userResponse.body.avatar_url || null
+      });
+      if (dbUser.hasChanged()) {
+        await dbUser.save();
+      }
+    } catch (error) {
+      return next(error);
+    }
 
     // Redirect to logged in URL
     res.redirect('/dashboard');

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -86,7 +86,8 @@ export const verify = (req, res, next) => {
       }
       await dbUser.set({
         name: userResponse.body.name || null,
-        login: userResponse.body.login
+        login: userResponse.body.login,
+        last_login_at: new Date()
       });
       if (dbUser.hasChanged()) {
         await dbUser.save();

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -86,8 +86,7 @@ export const verify = (req, res, next) => {
       }
       await dbUser.set({
         name: userResponse.body.name || null,
-        login: userResponse.body.login,
-        avatar_url: userResponse.body.avatar_url || null
+        login: userResponse.body.login
       });
       if (dbUser.hasChanged()) {
         await dbUser.save();

--- a/test/routes/src/server/routes/t_github-auth.js
+++ b/test/routes/src/server/routes/t_github-auth.js
@@ -120,7 +120,7 @@ describe('The login route', () => {
             .query({ code: 'foo', state: 'bar' })
             .send();
           const dbUser = await GitHubUser.where({ github_id: 123 }).fetch();
-          expect(dbUser.attributes).toMatch({
+          expect(dbUser.serialize()).toMatch({
             github_id: 123,
             login: 'anowner'
           });

--- a/test/routes/src/server/routes/t_github-auth.js
+++ b/test/routes/src/server/routes/t_github-auth.js
@@ -5,7 +5,8 @@ import expect from 'expect';
 import url from 'url';
 
 import auth from '../../../../../src/server/routes/github-auth';
-import { conf } from '../../../../../src/server/helpers/config.js';
+import { GitHubUser } from '../../../../../src/server/db/models/github-user';
+import { conf } from '../../../../../src/server/helpers/config';
 
 const GITHUB_AUTH_LOGIN_URL = conf.get('GITHUB_AUTH_LOGIN_URL');
 const GITHUB_AUTH_CLIENT_ID = conf.get('GITHUB_AUTH_CLIENT_ID');
@@ -94,10 +95,11 @@ describe('The login route', () => {
       });
 
       context('when user data retrieved from GH', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           nock(conf.get('GITHUB_API_ENDPOINT'))
             .get('/user')
-            .reply(200, { login: 'anowner' });
+            .reply(200, { id: 123, login: 'anowner' });
+          await GitHubUser.query('truncate').fetch();
         });
 
         it('should call GitHub API endpoint to get an auth token', (done) => {
@@ -110,6 +112,18 @@ describe('The login route', () => {
               done(err);
             }
           );
+        });
+
+        it('should save user data in database', async () => {
+          await supertest(app)
+            .get('/auth/verify')
+            .query({ code: 'foo', state: 'bar' })
+            .send();
+          const dbUser = await GitHubUser.where({ github_id: 123 }).fetch();
+          expect(dbUser.attributes).toMatch({
+            github_id: 123,
+            login: 'anowner'
+          });
         });
 
         it('should redirect request to the dashboard select repositories view', (done) => {


### PR DESCRIPTION
We now use the Bookshelf ORM and the Knex query builder, which gives us
a promise-based interface to multiple databases with minimal
boilerplate.

In development, we use SQLite by default, since that involves minimal
setup.  In staging and production, we use PostgreSQL, so this comes with
charm changes to ensure that we have access to a suitable database.

At the moment, user information is saved to both the session and the
database.  This is obviously duplicative, and we should perhaps consider
having just an ID in the session and fetching the rest from the database
as needed.  Similarly, perhaps some of the things we use memcached for
would make more sense in a more persistent database instead.

Part of #360.