### PR TITLE
Fixes #266: Fixed mocked requests in login route tests

### DIFF
--- a/test/routes/src/server/routes/t_login.js
+++ b/test/routes/src/server/routes/t_login.js
@@ -67,8 +67,8 @@ describe('login routes', () => {
       it('should redirect from /login/authenticate to SSO', () => {
         return supertest(app)
           .get('/login/authenticate')
-          .expect(res => {
-            expect(res.statusCode).toEqual(302);
+          .expect(302)
+          .then((res) => {
             const expectedBaseUrl = url.parse(UBUNTU_SSO_URL);
             expect(url.parse(res.header.location)).toMatch({
               protocol: expectedBaseUrl.protocol,
@@ -81,7 +81,7 @@ describe('login routes', () => {
       it('should include verify url in redirect header', () => {
         return supertest(app)
           .get('/login/authenticate')
-          .expect(res => {
+          .then((res) => {
             const parsedLocation = url.parse(res.header.location, true);
             expect(parsedLocation.query['openid.return_to'])
               .toEqual(OPENID_VERIFY_URL);
@@ -93,7 +93,7 @@ describe('login routes', () => {
          'header', () => {
         return supertest(app)
           .get('/login/authenticate')
-          .expect(res => {
+          .then((res) => {
             const parsedLocation = url.parse(res.header['location'], true);
             expect(parsedLocation.query).toExcludeKey('openid.ns.macaroon');
             expect(parsedLocation.query)
@@ -109,8 +109,8 @@ describe('login routes', () => {
           .get('/login/authenticate')
           .query({ 'starting_url': 'http://www.example.com/origin' })
           .query({ 'caveat_id': 'dummy caveat' })
-          .expect(res => {
-            expect(res.statusCode).toEqual(302);
+          .expect(302)
+          .then((res) => {
             const expectedBaseUrl = url.parse(UBUNTU_SSO_URL);
             expect(url.parse(res.header.location)).toMatch({
               protocol: expectedBaseUrl.protocol,
@@ -125,7 +125,7 @@ describe('login routes', () => {
           .get('/login/authenticate')
           .query({ 'starting_url': 'http://www.example.com/origin' })
           .query({ 'caveat_id': 'dummy caveat' })
-          .expect(res => {
+          .then((res) => {
             const parsedLocation = url.parse(res.header['location'], true);
             const expectedReturnTo =
               OPENID_VERIFY_URL +
@@ -143,7 +143,7 @@ describe('login routes', () => {
           .get('/login/authenticate')
           .query({ 'starting_url': 'http://www.example.com/origin' })
           .query({ 'caveat_id': expectedCaveatId })
-          .expect(res => {
+          .then((res) => {
             const parsedLocation = url.parse(res.header['location'], true);
             expect(parsedLocation.query['openid.ns.macaroon'])
               .toEqual('http://ns.login.ubuntu.com/2016/openid-macaroon');
@@ -168,8 +168,8 @@ describe('login routes', () => {
       it('GET returns the macaroon', () => {
         return supertest(app)
           .get('/login/sso-discharge')
-          .expect((res) => {
-            expect(res.statusCode).toEqual(200);
+          .expect(200)
+          .then((res) => {
             expect(res.body).toEqual({
               status: 'success',
               payload: {
@@ -183,8 +183,8 @@ describe('login routes', () => {
       it('DELETE deletes the macaroon', () => {
         return supertest(app)
           .delete('/login/sso-discharge')
-          .expect((res) => {
-            expect(res.statusCode).toEqual(204);
+          .expect(204)
+          .then(() => {
             expect(session.ssoDischarge).toNotExist();
           });
       });
@@ -198,8 +198,8 @@ describe('login routes', () => {
       it('GET returns 404', () => {
         return supertest(app)
           .get('/login/sso-discharge')
-          .expect((res) => {
-            expect(res.statusCode).toEqual(404);
+          .expect(404)
+          .then((res) => {
             expect(res.body).toEqual({
               status: 'error',
               payload: {
@@ -213,8 +213,8 @@ describe('login routes', () => {
       it('DELETE does nothing', () => {
         return supertest(app)
           .delete('/login/sso-discharge')
-          .expect((res) => {
-            expect(res.statusCode).toEqual(204);
+          .expect(204)
+          .then(() => {
             expect(session.ssoDischarge).toNotExist();
           });
       });

--- a/test/routes/src/server/routes/t_login.js
+++ b/test/routes/src/server/routes/t_login.js
@@ -19,49 +19,50 @@ describe('login routes', () => {
   });
   app.use(login);
 
-  beforeEach(() => {
-    nock(UBUNTU_SSO_URL)
-      .get('/')
-      .reply(
-        200, [
-          '<?xml version="1.0"?>',
-          '<xrds:XRDS',
-          '    xmlns="xri://$xrd*($v*2.0)"',
-          '    xmlns:xrds="xri://$xrds">',
-          '  <XRD>',
-          '    <Service priority="0">',
-          '      <Type>http://specs.openid.net/auth/2.0/server</Type>',
-          '      <Type>http://openid.net/srv/ax/1.0</Type>',
-          '      <Type>http://openid.net/extensions/sreg/1.1</Type>',
-          '      <Type>http://ns.launchpad.net/2007/openid-teams</Type>',
-          '      <Type>http://ns.login.ubuntu.com/2016/openid-macaroon</Type>',
-          `      <URI>${UBUNTU_SSO_URL}/+openid</URI>`,
-          '    </Service>',
-          '  </XRD>',
-          '</xrds:XRDS>'
-        ].join('\n') + '\n',
-        { 'Content-Type': 'application/xrds+xml' });
-    nock(UBUNTU_SSO_URL)
-      .post('/+openid')
-      .reply(
-        200, [
-          'assoc_handle:{HMAC-SHA256}{5855f159}{F2z7DQ==}',
-          'assoc_type:HMAC-SHA256',
-          // Fixed mock keys for testing.  We just need to get far enough to
-          // get past openid.associate.
-          'dh_server_public:AMZnmSsNwiqdfff0SpwNjW/rILcNfCym/bLP5khI3wI7XcZxB8mJk6JqE3+KR3uAisTa3qgR/2mFYN4ruD8lS5rdJnkXnLAqGrpQDUTKlzxB/Nk5w3XvsJkslmeTtka+h8lMIypY+m3tOiTYKR+pkX++OHsLwRldC6qxJH0ZWTat',
-          'enc_mac_key:RMGAA+oKkhayYZlqmxt2E7BmjVyO5eyMULQyD9ZEXvc=',
-          'expires_in:1209600',
-          'ns:http://specs.openid.net/auth/2.0',
-          'session_type:DH-SHA256'
-        ].join('\n') + '\n');
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe('authenticate', () => {
+    let sso;
+
+    beforeEach(() => {
+      sso = nock(UBUNTU_SSO_URL)
+        .get('/')
+        .reply(
+          200, [
+            '<?xml version="1.0"?>',
+            '<xrds:XRDS',
+            '    xmlns="xri://$xrd*($v*2.0)"',
+            '    xmlns:xrds="xri://$xrds">',
+            '  <XRD>',
+            '    <Service priority="0">',
+            '      <Type>http://specs.openid.net/auth/2.0/server</Type>',
+            '      <Type>http://openid.net/srv/ax/1.0</Type>',
+            '      <Type>http://openid.net/extensions/sreg/1.1</Type>',
+            '      <Type>http://ns.launchpad.net/2007/openid-teams</Type>',
+            '      <Type>http://ns.login.ubuntu.com/2016/openid-macaroon</Type>',
+            `      <URI>${UBUNTU_SSO_URL}/+openid</URI>`,
+            '    </Service>',
+            '  </XRD>',
+            '</xrds:XRDS>'
+          ].join('\n') + '\n',
+          { 'Content-Type': 'application/xrds+xml' })
+        .post('/+openid')
+        .reply(
+          200, [
+            'assoc_handle:{HMAC-SHA256}{5855f159}{F2z7DQ==}',
+            'assoc_type:HMAC-SHA256',
+            // Fixed mock keys for testing.  We just need to get far enough to
+            // get past openid.associate.
+            'dh_server_public:AMZnmSsNwiqdfff0SpwNjW/rILcNfCym/bLP5khI3wI7XcZxB8mJk6JqE3+KR3uAisTa3qgR/2mFYN4ruD8lS5rdJnkXnLAqGrpQDUTKlzxB/Nk5w3XvsJkslmeTtka+h8lMIypY+m3tOiTYKR+pkX++OHsLwRldC6qxJH0ZWTat',
+            'enc_mac_key:RMGAA+oKkhayYZlqmxt2E7BmjVyO5eyMULQyD9ZEXvc=',
+            'expires_in:1209600',
+            'ns:http://specs.openid.net/auth/2.0',
+            'session_type:DH-SHA256'
+          ].join('\n') + '\n');
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
     context('with no options', () => {
       it('should redirect from /login/authenticate to SSO', (done) => {
         supertest(app)
@@ -74,7 +75,10 @@ describe('login routes', () => {
               host: expectedBaseUrl.host
             });
           })
-          .end(done);
+          .end((err) => {
+            sso.done();
+            done(err);
+          });
       });
 
       it('should include verify url in redirect header', (done) => {
@@ -85,7 +89,10 @@ describe('login routes', () => {
             expect(parsedLocation.query['openid.return_to'])
               .toEqual(OPENID_VERIFY_URL);
           })
-          .end(done);
+          .end((err) => {
+            sso.done();
+            done(err);
+          });
       });
 
       it('should not include macaroon extension in redirect ' +
@@ -98,7 +105,10 @@ describe('login routes', () => {
             expect(parsedLocation.query)
               .toExcludeKey('openid.macaroon.caveat_id');
           })
-          .end(done);
+          .end((err) => {
+            sso.done();
+            done(err);
+          });
       });
     });
 
@@ -116,7 +126,10 @@ describe('login routes', () => {
               host: expectedBaseUrl.host
             });
           })
-          .end(done);
+          .end((err) => {
+            sso.done();
+            done(err);
+          });
       });
 
       it('should include verify url in redirect header', (done) => {
@@ -133,7 +146,10 @@ describe('login routes', () => {
             expect(parsedLocation.query['openid.return_to'])
               .toEqual(expectedReturnTo);
           })
-          .end(done);
+          .end((err) => {
+            sso.done();
+            done(err);
+          });
       });
 
       it('should include macaroon extension in redirect header', (done) => {
@@ -149,7 +165,10 @@ describe('login routes', () => {
             expect(parsedLocation.query['openid.macaroon.caveat_id'])
               .toEqual(expectedCaveatId);
           })
-          .end(done);
+          .end((err) => {
+            sso.done();
+            done(err);
+          });
       });
     });
   });

--- a/test/routes/src/server/routes/t_login.js
+++ b/test/routes/src/server/routes/t_login.js
@@ -64,8 +64,8 @@ describe('login routes', () => {
     });
 
     context('with no options', () => {
-      it('should redirect from /login/authenticate to SSO', (done) => {
-        supertest(app)
+      it('should redirect from /login/authenticate to SSO', () => {
+        return supertest(app)
           .get('/login/authenticate')
           .expect(res => {
             expect(res.statusCode).toEqual(302);
@@ -74,47 +74,38 @@ describe('login routes', () => {
               protocol: expectedBaseUrl.protocol,
               host: expectedBaseUrl.host
             });
-          })
-          .end((err) => {
             sso.done();
-            done(err);
           });
       });
 
-      it('should include verify url in redirect header', (done) => {
-        supertest(app)
+      it('should include verify url in redirect header', () => {
+        return supertest(app)
           .get('/login/authenticate')
           .expect(res => {
             const parsedLocation = url.parse(res.header.location, true);
             expect(parsedLocation.query['openid.return_to'])
               .toEqual(OPENID_VERIFY_URL);
-          })
-          .end((err) => {
             sso.done();
-            done(err);
           });
       });
 
       it('should not include macaroon extension in redirect ' +
-         'header', (done) => {
-        supertest(app)
+         'header', () => {
+        return supertest(app)
           .get('/login/authenticate')
           .expect(res => {
             const parsedLocation = url.parse(res.header['location'], true);
             expect(parsedLocation.query).toExcludeKey('openid.ns.macaroon');
             expect(parsedLocation.query)
               .toExcludeKey('openid.macaroon.caveat_id');
-          })
-          .end((err) => {
             sso.done();
-            done(err);
           });
       });
     });
 
     context('with options', () => {
-      it('should redirect from /login/authenticate to SSO', (done) => {
-        supertest(app)
+      it('should redirect from /login/authenticate to SSO', () => {
+        return supertest(app)
           .get('/login/authenticate')
           .query({ 'starting_url': 'http://www.example.com/origin' })
           .query({ 'caveat_id': 'dummy caveat' })
@@ -125,15 +116,12 @@ describe('login routes', () => {
               protocol: expectedBaseUrl.protocol,
               host: expectedBaseUrl.host
             });
-          })
-          .end((err) => {
             sso.done();
-            done(err);
           });
       });
 
-      it('should include verify url in redirect header', (done) => {
-        supertest(app)
+      it('should include verify url in redirect header', () => {
+        return supertest(app)
           .get('/login/authenticate')
           .query({ 'starting_url': 'http://www.example.com/origin' })
           .query({ 'caveat_id': 'dummy caveat' })
@@ -145,16 +133,13 @@ describe('login routes', () => {
               '&caveat_id=dummy%20caveat';
             expect(parsedLocation.query['openid.return_to'])
               .toEqual(expectedReturnTo);
-          })
-          .end((err) => {
             sso.done();
-            done(err);
           });
       });
 
-      it('should include macaroon extension in redirect header', (done) => {
+      it('should include macaroon extension in redirect header', () => {
         const expectedCaveatId = 'dummy caveat';
-        supertest(app)
+        return supertest(app)
           .get('/login/authenticate')
           .query({ 'starting_url': 'http://www.example.com/origin' })
           .query({ 'caveat_id': expectedCaveatId })
@@ -164,10 +149,7 @@ describe('login routes', () => {
               .toEqual('http://ns.login.ubuntu.com/2016/openid-macaroon');
             expect(parsedLocation.query['openid.macaroon.caveat_id'])
               .toEqual(expectedCaveatId);
-          })
-          .end((err) => {
             sso.done();
-            done(err);
           });
       });
     });
@@ -183,8 +165,8 @@ describe('login routes', () => {
         delete session.ssoDischarge;
       });
 
-      it('GET returns the macaroon', (done) => {
-        supertest(app)
+      it('GET returns the macaroon', () => {
+        return supertest(app)
           .get('/login/sso-discharge')
           .expect((res) => {
             expect(res.statusCode).toEqual(200);
@@ -195,28 +177,26 @@ describe('login routes', () => {
                 discharge: 'dummy macaroon'
               }
             });
-          })
-          .end(done);
+          });
       });
 
-      it('DELETE deletes the macaroon', (done) => {
-        supertest(app)
+      it('DELETE deletes the macaroon', () => {
+        return supertest(app)
           .delete('/login/sso-discharge')
           .expect((res) => {
             expect(res.statusCode).toEqual(204);
             expect(session.ssoDischarge).toNotExist();
-          })
-          .end(done);
+          });
       });
     });
 
-    context('if user is logged in but has no SSO discharge', (done) => {
+    context('if user is logged in but has no SSO discharge', () => {
       beforeEach(() => {
         delete session.ssoDischarge;
       });
 
       it('GET returns 404', () => {
-        supertest(app)
+        return supertest(app)
           .get('/login/sso-discharge')
           .expect((res) => {
             expect(res.statusCode).toEqual(404);
@@ -227,18 +207,16 @@ describe('login routes', () => {
                 message: 'No SSO discharge macaroon stored'
               }
             });
-          })
-          .end(done);
+          });
       });
 
-      it('DELETE does nothing', (done) => {
-        supertest(app)
+      it('DELETE does nothing', () => {
+        return supertest(app)
           .delete('/login/sso-discharge')
           .expect((res) => {
             expect(res.statusCode).toEqual(204);
             expect(session.ssoDischarge).toNotExist();
-          })
-          .end(done);
+          });
       });
     });
   });


### PR DESCRIPTION
Fix for #266

Login route tests were failing randomly on some dev environments.

It turned out it was issue with usage of `nock`.

Tests for authentication routes were mocking SSO requests, but these mock were also being created (and never called) for discharge macaroon routes. And for some reason it made nock go nuts sometimes.

This PR moves mocks into authentication context, so they are only created when they are needed.
Also added checks if all mocks are satisfied.