### PR TITLE
Convert internal LP client to async/await

### DIFF
--- a/src/server/launchpad/resources.js
+++ b/src/server/launchpad/resources.js
@@ -117,7 +117,7 @@ export class Entry extends Resource {
   }
 
   /** Write modifications to this entry back to the web service. */
-  lp_save(config) {
+  async lp_save(config) {
     const representation = {};
     for (const attribute of this.dirty_attributes) {
       representation[attribute] = this[attribute];
@@ -127,8 +127,8 @@ export class Entry extends Resource {
       headers['If-Match'] = this['http_etag'];
     }
     const uri = normalizeURI(this.lp_client.base_uri, this['self_link']);
-    return this.lp_client.patch(uri, representation, config, headers)
-      .then(() => { this.dirty_attributes = []; });
+    await this.lp_client.patch(uri, representation, config, headers);
+    this.dirty_attributes = [];
   }
 
   /** Delete this entry. */


### PR DESCRIPTION
This is a small proof-of-concept to see if people like this before I
start sending PRs to convert the whole codebase.  I find this style
easier to read and less error-prone, especially around error handling,
and it generally decreases indentation levels.

I'm deliberately not converting tests at the same time as the code under
test, to provide better assurance that I haven't applied a mistaken
conversion to both.