### PR TITLE
Fixes for passing repository to build details page

### DIFF
--- a/src/common/containers/with-repository.js
+++ b/src/common/containers/with-repository.js
@@ -8,7 +8,8 @@ function withRepository(WrappedComponent) {
   class WithRepository extends Component {
 
     componentDidMount() {
-      if (!this.props.repository && this.props.fullName) {
+      if ((!this.props.repository && this.props.fullName) ||
+          (this.props.repository.fullName !== this.props.fullName)) {
         this.props.dispatch(setGitHubRepository(this.props.fullName));
       }
     }
@@ -22,7 +23,11 @@ function withRepository(WrappedComponent) {
     render() {
       const { fullName, ...passThroughProps } = this.props; // eslint-disable-line no-unused-vars
 
-      return (this.props.repository
+      // only render if current repo in the store matches repo in URL params
+      const { repository } = this.props;
+      const isReady = repository && repository.fullName === fullName;
+
+      return (isReady
         ? <WrappedComponent {...passThroughProps} />
         : null
       );

--- a/test/unit/src/common/containers/t_with-repository.js
+++ b/test/unit/src/common/containers/t_with-repository.js
@@ -25,26 +25,13 @@ describe('WithRepository', () => {
 
   let store;
 
+  // renderDummy helper shallow renders wrapped component and assigns these:
   let wrapper;  // WithRepository rendered wrapper
   let instance; // WithRepository wrapper instance
   let wrapped;  // wrapped Dummy component
 
-  const setupDummy = (repository = REPO, params = PARAMS) => {
-    store = mockStore({ repository });
-
-    const DummyWithRepo = withRepository(Dummy);
-
-    // shallow render container component
-    const dummyWithRepo = shallow(<DummyWithRepo store={store} params={params}/>);
-
-    // get child components/instances from rendered component
-    wrapper = dummyWithRepo.first();
-    instance = wrapper.shallow().instance();
-    wrapped = wrapper.dive();
-  };
-
   beforeEach(() => {
-    setupDummy();
+    renderDummy();
   });
 
   it('should get repository from the store', () => {
@@ -73,7 +60,7 @@ describe('WithRepository', () => {
 
   context('when repo is not in the store', () => {
     beforeEach(() => {
-      setupDummy(null);
+      renderDummy(null);
     });
 
     it('should not render wrapped component', () => {
@@ -90,7 +77,7 @@ describe('WithRepository', () => {
 
   context('when repo in the store is different then in params', () => {
     beforeEach(() => {
-      setupDummy({ fullName: 'and-now-for-something/completely-different' });
+      renderDummy({ fullName: 'and-now-for-something/completely-different' });
     });
 
     it('should not render wrapped component', () => {
@@ -105,6 +92,21 @@ describe('WithRepository', () => {
     });
   });
 
+  // Shallow render Dummy component wrapped in withRepository container
+  // with given repository (mocked in the store) and URL params.
+  // Assigns wrapper, instance and wrapped variables later used in tests.
+  const renderDummy = (repository = REPO, params = PARAMS) => {
+    store = mockStore({ repository });
 
+    const DummyWithRepo = withRepository(Dummy);
+
+    // shallow render container component
+    const dummyWithRepo = shallow(<DummyWithRepo store={store} params={params}/>);
+
+    // get child components/instances from rendered component
+    wrapper = dummyWithRepo.first();
+    instance = wrapper.shallow().instance();
+    wrapped = wrapper.dive();
+  };
 
 });

--- a/test/unit/src/common/containers/t_with-repository.js
+++ b/test/unit/src/common/containers/t_with-repository.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import expect from 'expect';
+import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import withRepository from '../../../../../src/common/containers/with-repository';
+
+const middlewares = [ thunk ];
+const mockStore = configureMockStore(middlewares);
+
+// Dummy test component to wrap
+const Dummy = () => <span>Dummy</span>;
+
+import { SET_GITHUB_REPOSITORY } from '../../../../../src/common/actions/create-snap';
+
+describe('WithRepository', () => {
+  const PARAMS = {
+    owner: 'anowner',
+    name: 'aname'
+  };
+  const REPO = {
+    fullName: 'anowner/aname'
+  };
+
+  let store;
+
+  let wrapper;  // WithRepository rendered wrapper
+  let instance; // WithRepository wrapper instance
+  let wrapped;  // wrapped Dummy component
+
+  const setupDummy = (repository = REPO, params = PARAMS) => {
+    store = mockStore({ repository });
+
+    const DummyWithRepo = withRepository(Dummy);
+
+    // shallow render container component
+    const dummyWithRepo = shallow(<DummyWithRepo store={store} params={params}/>);
+
+    // get child components/instances from rendered component
+    wrapper = dummyWithRepo.first();
+    instance = wrapper.shallow().instance();
+    wrapped = wrapper.dive();
+  };
+
+  beforeEach(() => {
+    setupDummy();
+  });
+
+  it('should get repository from the store', () => {
+    expect(wrapper.prop('repository')).toEqual(REPO);
+  });
+
+  it('should get fullName from URL params', () => {
+    expect(wrapper.prop('fullName')).toEqual(`${PARAMS.owner}/${PARAMS.name}`);
+  });
+
+  context('when current repo is already in the store', () => {
+    it('should render wrapped component', () => {
+      expect(wrapped.is(Dummy)).toBe(true);
+    });
+
+    it('should pass repository to wrapped component', () => {
+      expect(wrapped.prop('repository')).toBe(REPO);
+    });
+
+    it('should not dispatch action to set repo in store', () => {
+      instance.componentDidMount();
+
+      expect(store.getActions()).notToHaveActionOfType(SET_GITHUB_REPOSITORY);
+    });
+  });
+
+  context('when repo is not in the store', () => {
+    beforeEach(() => {
+      setupDummy(null);
+    });
+
+    it('should not render wrapped component', () => {
+      expect(wrapped.type()).toBe(null);
+    });
+
+    it('should dispatch action to set repo in store', () => {
+      // manually calling componentDidMount to avoid full render
+      instance.componentDidMount();
+
+      expect(store.getActions()).toHaveActionOfType(SET_GITHUB_REPOSITORY);
+    });
+  });
+
+  context('when repo in the store is different then in params', () => {
+    beforeEach(() => {
+      setupDummy({ fullName: 'and-now-for-something/completely-different' });
+    });
+
+    it('should not render wrapped component', () => {
+      expect(wrapped.type()).toBe(null);
+    });
+
+    it('should dispatch action to set repo in store', () => {
+      // manually calling componentDidMount to avoid full render
+      instance.componentDidMount();
+
+      expect(store.getActions()).toHaveActionOfType(SET_GITHUB_REPOSITORY);
+    });
+  });
+
+
+
+});


### PR DESCRIPTION
Fixes #373

The issue was caused by `withRepository` container that was passing repository data from the store to build details page even if the repository in the store was different from the one in the URL.

With this PR we make sure to properly set repository in the store when it doesn't match the one in the URL. Also if these repos don't match child component is not rendered (until value in the store is properly propagated).