### PR TITLE
Fix TRUSTED_NETWORKS parsing

### DIFF
--- a/src/server/middleware/trusted-networks.js
+++ b/src/server/middleware/trusted-networks.js
@@ -4,8 +4,8 @@ import ipaddr from 'ipaddr.js';
 
 import { conf } from '../helpers/config';
 
-const confNetworks = conf.get('TRUSTED_NETWORKS');
-const rawNetworks = confNetworks ? confNetworks.split(',') : [];
+const rawNetworks = conf.get('TRUSTED_NETWORKS', '').split(',')
+  .filter((ip) => ip);
 const networks = rawNetworks.map((cidr) => ipaddr.parseCIDR(cidr));
 
 export default (req, res, next) => {

--- a/src/server/middleware/trusted-networks.js
+++ b/src/server/middleware/trusted-networks.js
@@ -4,7 +4,8 @@ import ipaddr from 'ipaddr.js';
 
 import { conf } from '../helpers/config';
 
-const rawNetworks = conf.get('TRUSTED_NETWORKS', '').split(',');
+const confNetworks = conf.get('TRUSTED_NETWORKS');
+const rawNetworks = confNetworks ? confNetworks.split(',') : [];
 const networks = rawNetworks.map((cidr) => ipaddr.parseCIDR(cidr));
 
 export default (req, res, next) => {


### PR DESCRIPTION
`''.split(',')` returns `['']`, not `[]`, and `''` doesn't parse as an
IP address range.