### PR TITLE
Link only to completed builds

### DIFF
--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -59,8 +59,7 @@ const BuildRow = (props) => {
 BuildRow.propTypes = {
   // params from URL
   repository: PropTypes.shape({
-    owner: PropTypes.string,
-    name: PropTypes.string
+    fullName: PropTypes.string
   }),
 
   // build properties

--- a/src/common/components/build-row/index.js
+++ b/src/common/components/build-row/index.js
@@ -11,6 +11,7 @@ const BuildRow = (props) => {
     repository,
     architecture,
     buildId,
+    buildLogUrl,
     duration,
     colour,
     statusMessage,
@@ -24,10 +25,18 @@ const BuildRow = (props) => {
     humanDuration = '';
   }
 
+  // only link to builds that have log available
+  const buildUrl = buildLogUrl
+    ? `/${repository.fullName}/builds/${buildId}`
+    : null;
+
   return (
     <Row key={ buildId }>
       <Data col="20">
-        <Link to={`/${repository.fullName}/builds/${buildId}`}>{`#${buildId}`}</Link>
+        { buildUrl
+          ? <Link to={buildUrl}>{`#${buildId}`}</Link>
+          : <span>{`#${buildId}`}</span>
+        }
       </Data>
       <Data col="20">
         {architecture}
@@ -36,7 +45,12 @@ const BuildRow = (props) => {
         {humanDuration}
       </Data>
       <Data col="40">
-        <BuildStatus colour={colour} statusMessage={statusMessage} dateStarted={dateStarted} />
+        <BuildStatus
+          link={buildUrl}
+          colour={colour}
+          statusMessage={statusMessage}
+          dateStarted={dateStarted}
+        />
       </Data>
     </Row>
   );
@@ -51,6 +65,7 @@ BuildRow.propTypes = {
 
   // build properties
   buildId:  PropTypes.string,
+  buildLogUrl: PropTypes.string,
   architecture: PropTypes.string,
   colour:  PropTypes.oneOf(['green', 'yellow', 'red', 'grey']),
   statusMessage: PropTypes.string,

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -197,7 +197,14 @@ class RepositoryRow extends Component {
       registerNameStatus.snapName : snap.store_name
     );
 
-    const hasBuilt = latestBuild && snap.snapcraft_data;
+    const hasBuilt = !!(latestBuild && snap.snapcraft_data);
+    const hasLog = !!(hasBuilt && latestBuild.buildLogUrl);
+
+    // only link to builds that have log available
+    const latestBuildUrl = hasLog
+      ? `/${fullName}/builds/${latestBuild.buildId}`
+      : null;
+
     const isActive = (
       showNameMismatchDropdown ||
       showUnconfiguredDropdown ||
@@ -228,14 +235,10 @@ class RepositoryRow extends Component {
           { this.renderSnapName.call(this, registeredName, showRegisterNameInput) }
         </Data>
         <Data col="30">
-          {/*
-            TODO: show 'Loading' when waiting for status?
-              and also show 'Never built' when no builds available
-          */}
           { hasBuilt
             ? (
               <BuildStatus
-                link={ `/${fullName}/builds/${latestBuild.buildId}`}
+                link={ latestBuildUrl }
                 colour={ latestBuild.colour }
                 statusMessage={ latestBuild.statusMessage }
                 dateStarted={ latestBuild.dateStarted }

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -357,31 +357,29 @@ class RepositoryRow extends Component {
 
 RepositoryRow.propTypes = {
   snap: PropTypes.shape({
-    resource_type_link: PropTypes.string,
     git_repository_url: PropTypes.string,
-    self_link: PropTypes.string,
     store_name: PropTypes.string,
     snapcraft_data: PropTypes.object
   }),
   latestBuild: PropTypes.shape({
     buildId: PropTypes.string,
-    status: PropTypes.string,
+    buildLogUrl: PropTypes.string,
+    colour: PropTypes.string,
+    dateStarted: PropTypes.string,
     statusMessage: PropTypes.string
   }),
   fullName: PropTypes.string,
   authStore: PropTypes.shape({
     authenticated: PropTypes.bool,
-    hasDischarge: PropTypes.bool,
-    isFetching: PropTypes.bool,
-    signedAgreement: PropTypes.bool,
     userName: PropTypes.string
   }),
   registerNameStatus: PropTypes.shape({
-    isFetching: PropTypes.bool,
-    success: PropTypes.bool,
-    error: PropTypes.object
+    success: PropTypes.bool
   }),
   dispatch: PropTypes.func.isRequired
 };
 
+// FIXME:
+// `connect` shouldn't be used just to add dispatch to props
+// this makes it much harder to test it as it get wrapped
 export default connect()(RepositoryRow);

--- a/test/unit/src/common/components/build-row/t_build-row.js
+++ b/test/unit/src/common/components/build-row/t_build-row.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import expect from 'expect';
+import { shallow } from 'enzyme';
+import { Link } from 'react-router';
+
+import BuildRow from '../../../../../../src/common/components/build-row';
+import { Row } from '../../../../../../src/common/components/vanilla/table-interactive';
+
+describe('<BuildRow />', function() {
+  const TEST_BUILD = {
+    buildId:  '1234',
+    buildLogUrl: 'http://example.com/12344567890_BUILDING.txt.gz',
+    architecture: 'arch',
+    colour: 'green',
+    statusMessage: 'Build test status',
+    dateStarted: '2017-03-07T12:29:45.297305+00:00',
+    duration: '0:01:24.425045'
+  };
+  const TEST_REPO = {
+    fullName: 'anowner/aname'
+  };
+
+  let element;
+
+  context('when build log is available', () => {
+    beforeEach(() => {
+      element = shallow(<BuildRow repository={TEST_REPO} {...TEST_BUILD} />);
+    });
+
+    it('should render Row', () => {
+      expect(element.type()).toBe(Row);
+    });
+
+    it('should contain Link to build page', () => {
+      const expectedUrl = `/${TEST_REPO.fullName}/builds/${TEST_BUILD.buildId}`;
+      expect(element.find(Link).length).toBe(1);
+      expect(element.find(Link).prop('to')).toBe(expectedUrl);
+    });
+
+    it('should contain BuildStatus linked to build page', () => {
+      const expectedUrl = `/${TEST_REPO.fullName}/builds/${TEST_BUILD.buildId}`;
+      expect(element.find('BuildStatus').length).toBe(1);
+      expect(element.find('BuildStatus').prop('link')).toBe(expectedUrl);
+    });
+  });
+
+  context('when build log is not yet available', () => {
+    beforeEach(() => {
+      const buildWithoutLog = {
+        ...TEST_BUILD,
+        buildLogUrl: null
+      };
+
+      element = shallow(<BuildRow repository={TEST_REPO} {...buildWithoutLog} />);
+    });
+
+    it('should not contain Link to build page', () => {
+      expect(element.find(Link).length).toBe(0);
+    });
+
+    it('should contain BuildStatus not linked to build page', () => {
+      expect(element.find('BuildStatus').length).toBe(1);
+      expect(element.find('BuildStatus').prop('link')).toBe(null);
+    });
+  });
+});

--- a/test/unit/src/common/components/repository-row/t_repository-row.js
+++ b/test/unit/src/common/components/repository-row/t_repository-row.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import expect from 'expect';
+import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import RepositoryRow from '../../../../../../src/common/components/repository-row';
+import { Row } from '../../../../../../src/common/components/vanilla/table-interactive';
+
+const middlewares = [ thunk ];
+const mockStore = configureMockStore(middlewares);
+
+describe('<RepositoryRow />', () => {
+  const snap = {
+    git_repository_url: 'https://github.com/anowner/aname',
+    store_name: 'test-snap',
+    snapcraft_data: { name: 'test-snap' }
+  };
+  const latestBuild = {
+    buildId:  '1234',
+    buildLogUrl: 'http://example.com/12344567890_BUILDING.txt.gz',
+    architecture: 'arch',
+    colour: 'green',
+    statusMessage: 'Build test status',
+    dateStarted: '2017-03-07T12:29:45.297305+00:00',
+    duration: '0:01:24.425045'
+  };
+  const fullName = 'anowner/aname';
+  const authStore = {
+    authenticated: true,
+    userName: 'store-user'
+  };
+  const registerNameStatus = {
+    success: true
+  };
+
+  let store;
+  let view;
+
+  beforeEach(() => {
+    store = mockStore({});
+  });
+
+  context('when latest build log is available', () => {
+    beforeEach(() => {
+      // shallow render container component and get view from it
+      view = shallow(
+        <RepositoryRow
+          store={store}
+          snap={snap}
+          latestBuild={latestBuild}
+          fullName={fullName}
+          authStore={authStore}
+          registerNameStatus={registerNameStatus}
+        />)
+        .find('RepositoryRow').dive();
+    });
+
+    it('should render Row', () => {
+      expect(view.type()).toEqual(Row);
+    });
+
+    it('should contain BuildStatus linked to build page', () => {
+      const expectedUrl = `/${fullName}/builds/${latestBuild.buildId}`;
+      expect(view.find('BuildStatus').length).toBe(1);
+      expect(view.find('BuildStatus').prop('link')).toBe(expectedUrl);
+    });
+  });
+
+  context('when latest build log is not yet available', () => {
+    beforeEach(() => {
+      const buildWithoutLog = {
+        ...latestBuild,
+        buildLogUrl: null
+      };
+
+      // shallow render container component and get view from it
+      view = shallow(
+        <RepositoryRow
+          store={store}
+          snap={snap}
+          latestBuild={buildWithoutLog}
+          fullName={fullName}
+          authStore={authStore}
+          registerNameStatus={registerNameStatus}
+        />)
+        .find('RepositoryRow').dive();
+    });
+
+    it('should contain BuildStatus not linked to build page', () => {
+      expect(view.find('BuildStatus').length).toBe(1);
+      expect(view.find('BuildStatus').prop('link')).toBe(null);
+    });
+  });
+
+});


### PR DESCRIPTION
Fixes #416 

Because we currently only show log of completed builds, we want to 'hide' build details pages until log is available.

This mean links from dashboard or repo details to build pages should only be rendered when build log is already available.