### PR TITLE
Add build-essential to dependencies-devel

### DIFF
--- a/charm/dependencies-devel.txt
+++ b/charm/dependencies-devel.txt
@@ -1,3 +1,4 @@
+build-essential
 bzr
 charm-tools
 git


### PR DESCRIPTION
Otherwise the sqlite3 module can't be built in JenkaaS, which can't
download precompiled binaries.