### PR TITLE
Add a bsi_github_users_total metric

### DIFF
--- a/src/server/metrics/github-users.js
+++ b/src/server/metrics/github-users.js
@@ -1,0 +1,12 @@
+import promClient from 'prom-client';
+
+import { GitHubUser } from '../db/models/github-user';
+
+const gitHubUsersTotal = new promClient.Gauge(
+  'bsi_github_users_total',
+  'Total number of GitHub users who have ever logged in.'
+);
+
+export default async function updateGitHubUsersTotal() {
+  gitHubUsersTotal.set(await GitHubUser.count());
+}

--- a/src/server/metrics/index.js
+++ b/src/server/metrics/index.js
@@ -1,0 +1,17 @@
+import updateGitHubUsersTotal from './github-users';
+
+let existingInterval = null;
+
+export default async function startAllMetrics() {
+  if (existingInterval !== null) {
+    clearInterval(existingInterval);
+  }
+
+  async function updateAllMetrics() {
+    await updateGitHubUsersTotal();
+  }
+
+  await updateAllMetrics();
+  existingInterval = setInterval(updateAllMetrics, 10000);
+  return existingInterval;
+}

--- a/src/server/metrics/index.js
+++ b/src/server/metrics/index.js
@@ -2,13 +2,13 @@ import updateGitHubUsersTotal from './github-users';
 
 let existingInterval = null;
 
+async function updateAllMetrics() {
+  await updateGitHubUsersTotal();
+}
+
 export default async function startAllMetrics() {
   if (existingInterval !== null) {
     clearInterval(existingInterval);
-  }
-
-  async function updateAllMetrics() {
-    await updateGitHubUsersTotal();
   }
 
   await updateAllMetrics();

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -8,6 +8,7 @@ import expressWinston from 'express-winston';
 import raven from 'raven';
 import favicon from 'serve-favicon';
 
+import startAllMetrics from './metrics/';
 import * as routes from './routes/';
 import { conf } from './helpers/config';
 import sessionConfig from './helpers/session';
@@ -48,7 +49,9 @@ app.use(expressWinston.logger({
 app.use(helmet());
 app.use(session(sessionConfig(conf)));
 app.use(Express.static(__dirname + '/../public', { maxAge: '365d' }));
+
 const metricsBundle = promBundle({ autoregister: false });
+startAllMetrics();
 app.use(metricsBundle);
 
 // routes

--- a/test/unit/src/server/metrics/t_github-users.js
+++ b/test/unit/src/server/metrics/t_github-users.js
@@ -1,0 +1,30 @@
+import expect from 'expect';
+import promClient from 'prom-client';
+
+import { GitHubUser } from '../../../../../src/server/db/models/github-user';
+import updateGitHubUsersTotal from '../../../../../src/server/metrics/github-users';
+
+describe('The GitHub users metric', () => {
+  beforeEach(async () => {
+    await GitHubUser.query('truncate').fetch();
+  });
+
+  it('returns the number of rows in GitHubUser', async () => {
+    for (let i = 0; i < 5; i++) {
+      const user = GitHubUser.forge({
+        github_id: i,
+        name: null,
+        login: `person-${i}`,
+        last_login_at: new Date()
+      });
+      await user.save();
+    }
+    await updateGitHubUsersTotal();
+    const metricName = 'bsi_github_users_total';
+    expect(promClient.register.getSingleMetric(metricName).get()).toMatch({
+      name: metricName,
+      type: 'gauge',
+      values: [{ value: 5 }]
+    });
+  });
+});


### PR DESCRIPTION
This shows the number of GitHub users who have ever logged in (since the
creation of the database table, at least).

Part of #360.