### PR TITLE
Upgrade to layer-ols r17

### DIFF
--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -10,7 +10,7 @@ layer                               @
 layer/layer-apt                     git+ssh://git.launchpad.net/layer-apt;revno=608bdf5
 layer/layer-basic                   lp:~ubuntuone-hackers/ols-charm-deps/layer-basic;revno=62
 layer/layer-leadership              git+ssh://git.launchpad.net/layer-leadership;revno=8846afc
-layer/layer-ols                     lp:~ubuntuone-hackers/ols-charm-deps/layer-ols;revno=13
+layer/layer-ols                     lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols;revno=17
 layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=3
 layer/layer-ols-pg                  lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-pg;revno=3
 


### PR DESCRIPTION
This adds the `trusted_networks` charm configuration option, which we
use.