### PR TITLE
Use "npm install --nodedir=/usr" in charm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ clean:
 $(DIST):
 	rm -rf $(DISTDIR)
 	mkdir -p $(DISTDIR)
-	npm install || (cat npm-debug.log && exit 1)
+	npm install --nodedir=/usr || (cat npm-debug.log && exit 1)
 	npm run build
-	npm install --production || (cat npm-debug.log && exit 1)
+	npm install --nodedir=/usr --production || (cat npm-debug.log && exit 1)
 	touch $@
 
 $(PAYLOAD): $(CHARM) $(DIST) version-info build-exclude.txt $(SRC) $(SRC)/* $(SRC_PREQS)


### PR DESCRIPTION
Our dependencies now include sqlite3, which needs to build a dependency
using node-gyp.  By default this will try to fetch a header bundle from
nodejs.org, which isn't permitted in JenkaaS.  Tell it that it can use
the perfectly good headers in /usr instead.