### PR TITLE
Added snapcraft.yaml path do snapcraft_data

### DIFF
--- a/docs/memcached.md
+++ b/docs/memcached.md
@@ -11,4 +11,5 @@ Caches snap data for given repository URL.
 ## `lp:snapcraft_data:https://github.com/:owner/:name`
 
 Caches JSON subset of data from `snapcraft.yaml` found in given repository.
-Currently it contains only a snap name.
+Currently it contains only a snap `name` from `snapcraft.yaml` file and a `path`
+to snapcraft.yaml file in given repository.

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -101,12 +101,19 @@ export const getSnapcraftData = async (repositoryUrl, token) => {
   try {
     const snapcraftYaml = await internalGetSnapcraftYaml(owner, name, token);
     const snapcraftData = {};
-    for (const index of Object.keys(snapcraftYaml)) {
+    for (const index of Object.keys(snapcraftYaml.contents)) {
       if (SNAPCRAFT_INFO_WHITELIST.indexOf(index) >= 0) {
-        snapcraftData[index] = snapcraftYaml[index];
+        snapcraftData[index] = snapcraftYaml.contents[index];
       }
     }
 
+    // copy snapcraft.yaml path from repo into snapcraftData
+    //
+    // XXX we are mixing our custom `path` into data from snapcraft.yaml file
+    // currently there is no `path` defined in snapcraft syntax
+    // https://snapcraft.io/docs/build-snaps/syntax
+    // and also we whitelist only `name`, so no collision should occur
+    snapcraftData.path = snapcraftYaml.path;
     await getMemcached().set(cacheId, snapcraftData, 3600);
     return snapcraftData;
   } catch (error) {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -211,7 +211,10 @@ export const internalGetSnapcraftYaml = async (owner, name, token) => {
     try {
       const response = await fetchSnapcraftYaml(path, owner, name, token);
       try {
-        return yaml.safeLoad(response.body);
+        return {
+          contents: yaml.safeLoad(response.body),
+          path
+        };
       } catch (e) {
         throw new PreparedError(400, RESPONSE_SNAPCRAFT_YAML_PARSE_FAILED);
       }
@@ -241,7 +244,8 @@ export const getSnapcraftYaml = async (req, res) => {
       status: 'success',
       payload: {
         code: 'snapcraft-yaml-found',
-        contents: snapcraftYaml
+        path: snapcraftYaml.path,
+        contents: snapcraftYaml.contents
       }
     });
   } catch (error) {

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -37,12 +37,8 @@ describe('The GitHub API endpoint', () => {
       });
 
       afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('should satisfy all request mocks', async () => {
-        await apiResponse;
         scope.done();
+        nock.cleanAll();
       });
 
       it('should successfully return', async () => {
@@ -75,12 +71,8 @@ describe('The GitHub API endpoint', () => {
       });
 
       afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('should satisfy all request mocks', async () => {
-        await apiResponse;
         scope.done();
+        nock.cleanAll();
       });
 
       it('should successfully return', async () => {
@@ -114,12 +106,8 @@ describe('The GitHub API endpoint', () => {
       });
 
       afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('should satisfy all request mocks', async () => {
-        await apiResponse;
         scope.done();
+        nock.cleanAll();
       });
 
       it('should successfully return', async () => {
@@ -153,12 +141,8 @@ describe('The GitHub API endpoint', () => {
       });
 
       afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('should satisfy all request mocks', async () => {
-        await apiResponse;
         scope.done();
+        nock.cleanAll();
       });
 
       it('should return 404 error', async () => {

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -22,6 +22,12 @@ describe('The GitHub API endpoint', () => {
   describe('get snapcraft.yaml route', () => {
     const fullName = 'anowner/aname';
 
+    let apiResponse;
+
+    beforeEach(() => {
+      apiResponse = supertest(app).get(`/github/snapcraft-yaml/${fullName}`);
+    });
+
     context('when snap/snapcraft.yaml is valid', () => {
 
       beforeEach(() => {
@@ -34,24 +40,26 @@ describe('The GitHub API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should successfully return', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(200, done);
+      it('should satisfy all request mocks', async () => {
+        await apiResponse;
+        scope.done();
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasStatus('success'))
-          .end(done);
+      it('should successfully return', async () => {
+        await apiResponse.expect(200);
       });
 
-      it('should return a body with a "snapcraft-yaml-found" message', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasMessage('snapcraft-yaml-found'))
-          .end(done);
+      it('should return a "success" status', async () => {
+        await apiResponse.expect(hasStatus('success'));
+      });
+
+      it('should return a body with a "snapcraft-yaml-found" message', async () => {
+        await apiResponse.expect(hasMessage('snapcraft-yaml-found'));
+      });
+
+      it('should return a path to snap/snapcraft.yaml', async () => {
+        const response = await apiResponse;
+        expect(response.body.payload.path).toBe('snap/snapcraft.yaml');
       });
 
     });
@@ -70,26 +78,27 @@ describe('The GitHub API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should successfully return', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(200, done);
+      it('should satisfy all request mocks', async () => {
+        await apiResponse;
+        scope.done();
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasStatus('success'))
-          .end(done);
+      it('should successfully return', async () => {
+        await apiResponse.expect(200);
       });
 
-      it('should return a body with a "snapcraft-yaml-found" message', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasMessage('snapcraft-yaml-found'))
-          .end(done);
+      it('should return a "success" status', async () => {
+        await apiResponse.expect(hasStatus('success'));
       });
 
+      it('should return a body with a "snapcraft-yaml-found" message', async () => {
+        await apiResponse.expect(hasMessage('snapcraft-yaml-found'));
+      });
+
+      it('should return a path to snapcraft.yaml', async () => {
+        const response = await apiResponse;
+        expect(response.body.payload.path).toBe('snapcraft.yaml');
+      });
     });
 
     context('when /.snapcraft.yaml is valid', () => {
@@ -108,26 +117,27 @@ describe('The GitHub API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should successfully return', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(200, done);
+      it('should satisfy all request mocks', async () => {
+        await apiResponse;
+        scope.done();
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasStatus('success'))
-          .end(done);
+      it('should successfully return', async () => {
+        await apiResponse.expect(200);
       });
 
-      it('should return a body with a "snapcraft-yaml-found" message', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasMessage('snapcraft-yaml-found'))
-          .end(done);
+      it('should return a "success" status', async () => {
+        await apiResponse.expect(hasStatus('success'));
       });
 
+      it('should return a body with a "snapcraft-yaml-found" message', async () => {
+        await apiResponse.expect(hasMessage('snapcraft-yaml-found'));
+      });
+
+      it('should return a path to .snapcraft.yaml', async () => {
+        const response = await apiResponse;
+        expect(response.body.payload.path).toBe('.snapcraft.yaml');
+      });
     });
 
     context('when there is no valid snapcraft.yaml file', () => {
@@ -146,24 +156,21 @@ describe('The GitHub API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should return 404 error', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(404, done);
+      it('should satisfy all request mocks', async () => {
+        await apiResponse;
+        scope.done();
       });
 
-      it('should return a "error" status', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasStatus('error'))
-          .end(done);
+      it('should return 404 error', async () => {
+        await apiResponse.expect(404);
       });
 
-      it('should return a body with a "snapcraft-yaml-found" message', (done) => {
-        supertest(app)
-          .get('/github/snapcraft-yaml/anowner/aname')
-          .expect(hasMessage('github-snapcraft-yaml-not-found'))
-          .end(done);
+      it('should return a "error" status', async () => {
+        await apiResponse.expect(hasStatus('error'));
+      });
+
+      it('should return a body with a "snapcraft-yaml-not-found" message', async () => {
+        await apiResponse.expect(hasMessage('github-snapcraft-yaml-not-found'));
       });
 
     });

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -357,13 +357,9 @@ describe('The Launchpad API endpoint', () => {
       });
 
       afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('should satisfy all request mocks', async () => {
-        await apiResponse;
         lpApi.done();
         ghApi.done();
+        nock.cleanAll();
       });
 
       it('should return a 200 response', async () => {
@@ -440,12 +436,8 @@ describe('The Launchpad API endpoint', () => {
       });
 
       afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('should satisfy all request mocks', async () => {
-        await apiResponse;
         lpApi.done();
+        nock.cleanAll();
       });
 
       it('should return a 200 response', async () => {
@@ -481,12 +473,8 @@ describe('The Launchpad API endpoint', () => {
       });
 
       afterEach(() => {
-        nock.cleanAll();
-      });
-
-      it('should satisfy all request mocks', async () => {
-        await apiResponse;
         lpApi.done();
+        nock.cleanAll();
       });
 
       it('should return an error response', async () => {

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -404,20 +404,15 @@ describe('The Launchpad API endpoint', () => {
           resetMemcached();
         });
 
-        it('should store snaps in memcached', (done) => {
-
+        it('should store snaps in memcached', async () => {
           const urlPrefix = 'https://github.com/anowner/';
           const cacheId = getUrlPrefixCacheId(urlPrefix);
 
-          supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .end((err) => {
-            const memcachedSnaps = getMemcached().cache[cacheId];
-            expect(memcachedSnaps.length).toEqual(testSnaps.length);
-            expect(memcachedSnaps[0]).toContain(testSnaps[0]);
-            done(err);
-          });
+          await apiResponse;
+          const memcachedSnaps = getMemcached().cache[cacheId];
+          expect(memcachedSnaps.length).toEqual(testSnaps.length);
+          expect(memcachedSnaps[0]).toContain(testSnaps[0]);
+          expect(memcachedSnaps[1]).toContain(testSnaps[1]);
         });
 
       });

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -293,12 +293,28 @@ describe('The Launchpad API endpoint', () => {
   });
 
   describe('list snaps route', () => {
+    let apiResponse;
+
+    beforeEach(() => {
+      apiResponse = supertest(app)
+        .get('/launchpad/snaps/list')
+        .query({ owner: 'anowner' });
+    });
 
     context('when snaps exist', () => {
+      const contents = {
+        'https://github.com/another-user/test-snap': { name: 'snap1' },
+        'https://github.com/test-user/test-snap': { name: 'snap2' }
+      };
+
       let testSnaps;
+
+      let lpApi;
+      let ghApi;
 
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
+        const gh_api_url = conf.get('GITHUB_API_ENDPOINT');
         const lp_api_base = `${lp_api_url}/devel`;
 
         testSnaps = [
@@ -306,7 +322,7 @@ describe('The Launchpad API endpoint', () => {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~another-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~another-user`,
-            git_repository_url: 'http://github.com/another-user/test-snap'
+            git_repository_url: 'https://github.com/another-user/test-snap'
           },
           {
             resource_type_link: `${lp_api_base}/#snap`,
@@ -316,12 +332,7 @@ describe('The Launchpad API endpoint', () => {
           }
         ];
 
-        const contents = {
-          'https://github.com/another-user/test-snap': { name: 'snap1' },
-          'https://github.com/test-user/test-snap': {}
-        };
-
-        const api = nock(lp_api_url)
+        lpApi = nock(lp_api_url)
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURLPrefix',
@@ -335,16 +346,12 @@ describe('The Launchpad API endpoint', () => {
           });
 
         testSnaps.map((snap) => {
-          const fullName = snap.git_repository_url.replace('http://github.com/', '');
-          const scope = api.get(
-            `/repos/${fullName}/contents/snapcraft.yaml`
-          );
+          const fullName = snap.git_repository_url.replace('https://github.com/', '');
           const repoContents = contents[snap.git_repository_url];
-          if (repoContents !== undefined) {
-            return scope.reply(200, repoContents);
-          } else {
-            return scope.reply(404);
-          }
+
+          ghApi = nock(gh_api_url)
+            .get(`/repos/${fullName}/contents/snap/snapcraft.yaml`)
+            .reply(200, repoContents);
         });
 
       });
@@ -353,33 +360,39 @@ describe('The Launchpad API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should return a 200 response', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .expect(200, done);
+      it('should satisfy all request mocks', async () => {
+        await apiResponse;
+        lpApi.done();
+        ghApi.done();
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .expect(hasStatus('success'))
-          .end(done);
+      it('should return a 200 response', async () => {
+        await apiResponse.expect(200);
       });
 
-      it('should return "snaps-found" message with the correct snaps', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .end((err, res) => {
-            const responseSnaps = res.body.payload.snaps;
+      it('should return a "success" status', async () => {
+        await apiResponse.expect(hasStatus('success'));
+      });
 
-            expect(responseSnaps.length).toEqual(testSnaps.length);
-            expect(responseSnaps[0]).toContain(testSnaps[0]);
+      it('should return "snaps-found" message with the correct snaps', async () => {
+        const response = await apiResponse.expect(hasMessage('snaps-found'));
+        const responseSnaps = response.body.payload.snaps;
 
-            done(err);
-          });
+        expect(responseSnaps.length).toEqual(testSnaps.length);
+        expect(responseSnaps[0]).toContain(testSnaps[0]);
+        expect(responseSnaps[1]).toContain(testSnaps[1]);
+      });
+
+      it('should return snaps with snapcraft_data', async () => {
+        const response = await apiResponse;
+        const snap = response.body.payload.snaps[0];
+
+        expect(snap).toContain({
+          snapcraft_data: contents[snap.git_repository_url]
+        });
+        expect(snap).toContain({
+          snapcraft_data: { path: 'snap/snapcraft.yaml' }
+        });
       });
 
       context('using memcached', () => {
@@ -412,12 +425,12 @@ describe('The Launchpad API endpoint', () => {
     });
 
     context('when snaps don\'t exist', () => {
-
+      let lpApi;
 
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
 
-        nock(lp_api_url)
+        lpApi = nock(lp_api_url)
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURLPrefix',
@@ -435,39 +448,34 @@ describe('The Launchpad API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should return a 200 response', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .expect(200, done);
+      it('should satisfy all request mocks', async () => {
+        await apiResponse;
+        lpApi.done();
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .expect(hasStatus('success'))
-          .end(done);
+      it('should return a 200 response', async () => {
+        await apiResponse.expect(200);
       });
 
-      it('should return "snaps-found" message with empty list', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .end((err, res) => {
-            const responseSnaps = res.body.payload.snaps;
+      it('should return a "success" status', async () => {
+        await apiResponse.expect(hasStatus('success'));
+      });
 
-            expect(responseSnaps.length).toEqual(0);
+      it('should return "snaps-found" message with empty list', async () => {
+        const response = await apiResponse;
+        const responseSnaps = response.body.payload.snaps;
 
-            done(err);
-          });
+        expect(responseSnaps.length).toEqual(0);
       });
     });
 
     context('when LP returns error', () => {
+      let lpApi;
+
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
-        nock(lp_api_url)
+
+        lpApi = nock(lp_api_url)
           .get('/devel/+snaps')
           .query({
             'ws.op': 'findByURLPrefix',
@@ -481,27 +489,21 @@ describe('The Launchpad API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should return an error response', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .expect(501, done);
+      it('should satisfy all request mocks', async () => {
+        await apiResponse;
+        lpApi.done();
       });
 
-      it('should return an "error" status', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .expect(hasStatus('error'))
-          .end(done);
+      it('should return an error response', async () => {
+        await apiResponse.expect(501);
       });
 
-      it('should return a body with an "lp-error" message', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .expect(hasMessage('lp-error', 'Something went quite wrong.'))
-          .end(done);
+      it('should return an "error" status', async () => {
+        await apiResponse.expect(hasStatus('error'));
+      });
+
+      it('should return a body with an "lp-error" message', async() => {
+        await apiResponse.expect(hasMessage('lp-error', 'Something went quite wrong.'));
       });
     });
 
@@ -531,7 +533,7 @@ describe('The Launchpad API endpoint', () => {
 
         const contents = {
           'https://github.com/another-user/test-snap': { name: 'snap1' },
-          'https://github.com/test-user/test-snap': {}
+          'https://github.com/test-user/test-snap': { name: 'snap2' }
         };
 
         setupInMemoryMemcached({
@@ -548,33 +550,21 @@ describe('The Launchpad API endpoint', () => {
         resetMemcached();
       });
 
-      it('should return a 200 response', (done) => {
-        supertest(app)
-        .get('/launchpad/snaps/list')
-        .query({ owner: 'anowner' })
-          .expect(200, done);
+      it('should return a 200 response', async () => {
+        await apiResponse.expect(200);
       });
 
-      it('should return a "success" status', (done) => {
-        supertest(app)
-        .get('/launchpad/snaps/list')
-        .query({ owner: 'anowner' })
-          .expect(hasStatus('success'))
-          .end(done);
+      it('should return a "success" status', async () => {
+        await apiResponse.expect(hasStatus('success'));
       });
 
-      it('should return "snaps-found" message with the correct snaps', (done) => {
-        supertest(app)
-          .get('/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .end((err, res) => {
-            const responseSnaps = res.body.payload.snaps;
+      it('should return "snaps-found" message with the correct snaps', async () => {
+        const response = await apiResponse;
+        const responseSnaps = response.body.payload.snaps;
 
-            expect(responseSnaps.length).toEqual(testSnaps.length);
-            expect(responseSnaps[0]).toContain(testSnaps[0]);
-
-            done(err);
-          });
+        expect(responseSnaps.length).toEqual(testSnaps.length);
+        expect(responseSnaps[0]).toContain(testSnaps[0]);
+        expect(responseSnaps[1]).toContain(testSnaps[1]);
       });
 
     });


### PR DESCRIPTION
Fixes #297

It's not a UI change, but something that is needed to allow us to provide a link to edit snapcraft.yaml file in repo.

Snapcraft.yaml can currently be in one of 3 possible locations, so we not only need to know that file exists, but also where it is in repository.

`snapcraft_data` that we pass together with snap (enabled repository) currently contains just a snap `name` from snapcraft.yaml. While it was meant to be a representation of contents of snapcraft.yaml it seems the only reasonable place to add the file path.