### PR TITLE
Array.prototype.find() rather than .filter()

### DIFF
--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -3,11 +3,9 @@ import * as RegisterNameActionTypes from '../actions/register-name';
 import { getGitHubRepoUrl } from '../helpers/github-url';
 
 function findSnapByFullName(snaps, fullName) {
-  const snap = snaps.filter((snap) => {
+  return snaps.find((snap) => {
     return snap.git_repository_url === getGitHubRepoUrl(fullName);
-  })[0];
-
-  return snap;
+  });
 }
 
 function updateRegisteredName(snaps, fullName, snapName) {


### PR DESCRIPTION
filter creates a new array, find only a value (and stops when it gets to the value)