### PR TITLE
Fix crash when both IPv4/6 networks are trusted

### DIFF
--- a/src/server/middleware/trusted-networks.js
+++ b/src/server/middleware/trusted-networks.js
@@ -8,10 +8,22 @@ const rawNetworks = conf.get('TRUSTED_NETWORKS', '').split(',')
   .filter((ip) => ip);
 const networks = rawNetworks.map((cidr) => ipaddr.parseCIDR(cidr));
 
+const networksOfKind = (networks, kind) => {
+  return networks.filter(([subnet]) => subnet.kind() === kind);
+};
+
+export const matchNetworks = (ip, networks) => {
+  const addr = ipaddr.parse(ip);
+  if (addr.range() === 'loopback') {
+    return true;
+  }
+  return ipaddr.subnetMatch(addr, {
+    trusted: networksOfKind(networks, addr.kind())
+  }) === 'trusted';
+};
+
 export default (req, res, next) => {
-  const addr = ipaddr.parse(req.ip);
-  if (addr.range() === 'loopback' ||
-      ipaddr.subnetMatch(addr, { trusted: networks }) === 'trusted') {
+  if (matchNetworks(req.ip, networks)) {
     next();
   } else {
     res.status(403).send(`IP address ${req.ip} not in trusted network.`);

--- a/test/unit/src/server/middleware/t_trusted-networks.js
+++ b/test/unit/src/server/middleware/t_trusted-networks.js
@@ -1,0 +1,106 @@
+import expect from 'expect';
+import ipaddr from 'ipaddr.js';
+
+import { matchNetworks } from '../../../../../src/server/middleware/trusted-networks';
+
+describe.only('matchNetworks', () => {
+  context('with no trusted networks', () => {
+    it('accepts loopback IPv4 address', () => {
+      expect(matchNetworks('127.0.0.1', [])).toBe(true);
+    });
+
+    it('accepts loopback IPv6 address', () => {
+      expect(matchNetworks('::1', [])).toBe(true);
+    });
+
+    it('rejects another IPv4 address', () => {
+      expect(matchNetworks('8.8.8.8', [])).toBe(false);
+    });
+
+    it('rejects another IPv6 address', () => {
+      expect(matchNetworks('2001:db8::1', [])).toBe(false);
+    });
+  });
+
+  context('with only IPv4 trusted networks', () => {
+    const networks = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'].map(
+      (cidr) => ipaddr.parseCIDR(cidr)
+    );
+
+    it('accepts loopback IPv4 address', () => {
+      expect(matchNetworks('127.0.0.1', networks)).toBe(true);
+    });
+
+    it('accepts loopback IPv6 address', () => {
+      expect(matchNetworks('::1', networks)).toBe(true);
+    });
+
+    it('accepts trusted IPv4 address', () => {
+      expect(matchNetworks('10.0.0.1', networks)).toBe(true);
+      expect(matchNetworks('172.16.0.1', networks)).toBe(true);
+      expect(matchNetworks('192.168.0.1', networks)).toBe(true);
+    });
+
+    it('rejects another IPv4 address', () => {
+      expect(matchNetworks('192.0.2.1', networks)).toBe(false);
+    });
+
+    it('rejects another IPv6 address', () => {
+      expect(matchNetworks('2001:db8::1', networks)).toBe(false);
+    });
+  });
+
+  context('with only IPv6 trusted networks', () => {
+    const networks = ['2001:db8::/64'].map((cidr) => ipaddr.parseCIDR(cidr));
+
+    it('accepts loopback IPv4 address', () => {
+      expect(matchNetworks('127.0.0.1', networks)).toBe(true);
+    });
+
+    it('accepts loopback IPv6 address', () => {
+      expect(matchNetworks('::1', networks)).toBe(true);
+    });
+
+    it('accepts trusted IPv6 address', () => {
+      expect(matchNetworks('2001:db8::1', networks)).toBe(true);
+    });
+
+    it('rejects another IPv4 address', () => {
+      expect(matchNetworks('192.0.2.1', networks)).toBe(false);
+    });
+
+    it('rejects another IPv6 address', () => {
+      expect(matchNetworks('2001:db8:1::1', networks)).toBe(false);
+    });
+  });
+
+  context('with both IPv4 and IPv6 trusted networks', () => {
+    const networks = ['10.0.0.0/8', '2001:db8::/64'].map(
+      (cidr) => ipaddr.parseCIDR(cidr)
+    );
+
+    it('accepts loopback IPv4 address', () => {
+      expect(matchNetworks('127.0.0.1', networks)).toBe(true);
+    });
+
+    it('accepts loopback IPv6 address', () => {
+      expect(matchNetworks('::1', networks)).toBe(true);
+    });
+
+    it('accepts trusted IPv4 address', () => {
+      expect(matchNetworks('10.0.0.1', networks)).toBe(true);
+    });
+
+    it('accepts trusted IPv6 address', () => {
+      expect(matchNetworks('2001:db8::1', networks)).toBe(true);
+    });
+
+    it('rejects another IPv4 address', () => {
+      expect(matchNetworks('192.0.2.1', networks)).toBe(false);
+    });
+
+    it('rejects another IPv6 address', () => {
+      expect(matchNetworks('2001:db8:1::1', networks)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
It turns out that `ipaddr.subnetMatch` can only be asked to match
against networks of the same address kind, so if both IPv4 and IPv6
ranges were present in `TRUSTED_NETWORKS` then we would crash as soon as
we reached that point in the matching process.  Fix this.