### PR TITLE
update banner and workflow images on landing page

### DIFF
--- a/src/common/containers/landing.js
+++ b/src/common/containers/landing.js
@@ -27,7 +27,7 @@ class Landing extends Component {
 
               <ul className={ styles.banner }>
                 <li className={ styles.bannerImage }>
-                  <img src='https://assets.ubuntu.com/v1/dcae3c70-header-final-01.svg' />
+                  <img src='https://assets.ubuntu.com/v1/4feda3a7-header_strokes-to-path.svg' />
                 </li>
 
                 <li className={ styles.bannerLabel }>
@@ -92,7 +92,7 @@ class Landing extends Component {
         <section className={styles.section}>
 
           <div className={ `${styles.row} ${containerStyles.wrapper}`  }>
-            <img src='https://assets.ubuntu.com/v1/84ce5b81-workflow_text-to-path02.svg' width='100%' />
+            <img src='https://assets.ubuntu.com/v1/9ec98fa2-workflow_text-to-path.svg' width='100%' />
           </div>
 
           <div className={ styles.centeredButton }>


### PR DESCRIPTION
## Done

* updated images per design

## QA

1. go to the landing page
2. see the banner image is - https://assets.ubuntu.com/v1/4feda3a7-header_strokes-to-path.svg
3. see the workflow image is - https://assets.ubuntu.com/v1/9ec98fa2-workflow_text-to-path.svg

## Issue/Card

Fixes #362