### PR TITLE
Tighten up reactive state handling slightly

### DIFF
--- a/charm/reactive/snap-build.py
+++ b/charm/reactive/snap-build.py
@@ -80,6 +80,7 @@ def migrate(pgsql):
 @when('leadership.set.migrated')
 @when('cache.available')
 @when('db.master.available')
+@when('ols.pg.configured')
 @when('ols.service.installed')
 @restart_on_change({
     SYSTEMD_CONFIG: ['snap-build'],


### PR DESCRIPTION
`configure` should only run when the `ols.pg.configured` state is set;
otherwise it's possible for this function to run, set the unit's status
to "active", and then for `ols_pg_configured` to run immediately
afterwards and set the status back to "waiting".  This is usually
harmless since hook retries will cause things to settle down eventually,
but it can slow down deployments by several minutes.