### PR TITLE
Register appservers for Prometheus monitoring

### DIFF
--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -13,5 +13,6 @@ layer/layer-leadership              git+ssh://git.launchpad.net/layer-leadership
 layer/layer-ols                     lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols;revno=17
 layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=3
 layer/layer-ols-pg                  lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-pg;revno=3
+layer/layer-promreg-client          git+ssh://git.launchpad.net/~timkuhlman/prometheus-registration/+git/layer-promreg-client;revno=4c91c19
 
 wheels                              git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/wheels

--- a/charm/layer.yaml
+++ b/charm/layer.yaml
@@ -3,6 +3,7 @@ includes:
     - layer:leadership
     - layer:ols-http
     - layer:ols-pg
+    - layer:promreg-client
     - interface:memcache
 options:
     basic:

--- a/charm/reactive/snap-build.py
+++ b/charm/reactive/snap-build.py
@@ -9,6 +9,7 @@ import psycopg2
 from charmhelpers.core import hookenv
 from charmhelpers.core.host import restart_on_change
 from charmhelpers.core.templating import render
+from charms import promreg
 from charms.apt import queue_install
 from charms.leadership import leader_set
 from charms.reactive import when, when_not, set_state
@@ -178,3 +179,11 @@ def install_custom_nodejs():
         # us, we can't due to the conditional nature of installing these
         # packages *only* if the .deb file isn't used
         queue_install(['npm', 'nodejs', 'nodejs-legacy'])
+
+
+@when('service.configured')
+@when_not('service.promreg_done')
+def register_with_prometheus():
+    environment = hookenv.config('environment')
+    promreg.register(None, 8000, {'environment': environment})
+    set_state('service.promreg_done')


### PR DESCRIPTION
This won't become active until we set `promreg_url` and
`promreg_authtoken` in the Mojo spec, and we need to get an
authentication token and get firewall changes landed before we can do
that, but we might as well prepare for it now.

Part of #360.