### PR TITLE
rel=noopener

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,9 @@ module.exports = {
         'SwitchCase': 1
       }
     ],
+    'react/jsx-no-target-blank': [
+      2
+    ],
     'react/jsx-indent': [
       'error',
       2

--- a/src/common/components/help/install-snap/index.js
+++ b/src/common/components/help/install-snap/index.js
@@ -19,7 +19,15 @@ export default class HelpInstallSnap extends Component {
           </code>
         </pre>
         <p className={ styles.p }>
-          Don’t have snapd installed? <a className={ styles.external } href={ HELP_INSTALL_URL } target="_blank">Install it now</a>.
+          Don’t have snapd installed?  {' '}
+          <a
+            className={ styles.external }
+            href={ HELP_INSTALL_URL }
+            rel="noreferrer noopener"
+            target="_blank"
+          >
+            Install it now
+          </a>.
         </p>
       </div>
     );

--- a/src/common/components/repository-row/dropdowns/register-name-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/register-name-dropdown.js
@@ -15,7 +15,12 @@ const AGREEMENT_URL = `${conf.get('STORE_DEVPORTAL_URL')}/tos/`;
 const Agreement = (props) => {
   const checkbox = <input type="checkbox" onChange={ props.onChange } />;
   const link = (
-    <a className={ styles.external } href={ AGREEMENT_URL } target="_blank">
+    <a
+      className={ styles.external }
+      href={ AGREEMENT_URL }
+      target="_blank"
+      rel="noreferrer noopener"
+    >
       Developer Programme Agreement
     </a>
   );
@@ -129,7 +134,14 @@ const Caption = (props) => {
         <p><ErrorIcon /> Sorry, that name is already taken. Try a different name.</p>
         <p className={ styles.helpText }>
           If you think you should have sole rights to the name,
-          you can <a href={ FILE_NAME_CLAIM_URL } target='_blank'>file a claim</a>.
+          you can
+          <a
+            href={ FILE_NAME_CLAIM_URL }
+            target='_blank'
+            rel="noreferrer noopener"
+          >
+            file a claim
+          </a>.
         </p>
       </div>
     );

--- a/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/unconfigured-dropdown.js
@@ -40,14 +40,32 @@ const UnconfiguredDropdown = (props) => {
             installable, and runnable.
           </p>
           <p className={ styles.helpText }>
-            <a href={ LEARN_THE_BASICS_LINK } target="_blank">Learn the basics</a>,
-            or
-            <a href={ getTemplateUrl(snap) } target="_blank"> get started with a template</a>.
+            <a
+              href={ LEARN_THE_BASICS_LINK }
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Learn the basics
+            </a>,
+            or {' '}
+            <a
+              href={ getTemplateUrl(snap) }
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              get started with a template
+            </a>.
           </p>
           <p className={ styles.helpText }>
-            Don’t have snapcraft?
-            <a href={ INSTALL_IT_LINK } target="_blank"> Install it on your own PC </a>
-            for testing.
+            Don’t have snapcraft? {' '}
+            <a
+              href={ INSTALL_IT_LINK }
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Install it on your own PC
+            </a>
+            {' '} for testing.
           </p>
         </Data>
       </Row>

--- a/test/unit/src/server/middleware/t_trusted-networks.js
+++ b/test/unit/src/server/middleware/t_trusted-networks.js
@@ -3,7 +3,7 @@ import ipaddr from 'ipaddr.js';
 
 import { matchNetworks } from '../../../../../src/server/middleware/trusted-networks';
 
-describe.only('matchNetworks', () => {
+describe('matchNetworks', () => {
   context('with no trusted networks', () => {
     it('accepts loopback IPv4 address', () => {
       expect(matchNetworks('127.0.0.1', [])).toBe(true);


### PR DESCRIPTION
`<a target=_blank />` is considered a security risk, we don't really have user generated content but doesn't hurt to have the rule.

More about `rel=noopener` here: https://mathiasbynens.github.io/rel-noopener/

Lint rule is defined here: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md