### PR TITLE
Point Prometheus at public frontends

### DIFF
--- a/charm/config.yaml
+++ b/charm/config.yaml
@@ -1,4 +1,7 @@
 options:
+    base_url:
+        type: string
+        description: Base URL of the service
     session_secret:
         type: string
         description: Secret key for signing session cookie IDs

--- a/charm/templates/snap-build_systemd.j2
+++ b/charm/templates/snap-build_systemd.j2
@@ -6,6 +6,9 @@ Description=Build snaps from GitHub repositories
 
 [Service]
 Type=simple
+{%- if base_url %}
+Environment='BASE_URL={{ base_url }}'
+{%- endif %}
 Environment='SESSION_SECRET={{ session_secret }}'
 Environment='LOGS_PATH={{ logs_path }}'
 Environment='MEMCACHED_HOST={{ cache_hosts | join(",") }}'


### PR DESCRIPTION
Monitoring the individual appservers turns out to be awkward because
we'd have to expose the relevant port in security groups.  We don't
actually care about the per-unit monitoring anyway, only the
application-wide metrics that come from the database and can be
published by any appserver, so let's just point the monitoring server at
the frontend instead.

This requires the charm to know the application's base URL.  For this,
I've taken a dual approach: firstly, I've added a hack to fish it out of
the environment file for now, to minimise the number of steps needed to
get this deployed; and secondly, I've added a `base_url` charm
configuration option, which fits with the general goal of eventually
superseding the `.env` files.

Part of #360.