### PR TITLE
Added vanilla based breadcrumbs to build pages

### DIFF
--- a/src/common/components/vanilla/breadcrumbs/breadcrumbs.css
+++ b/src/common/components/vanilla/breadcrumbs/breadcrumbs.css
@@ -1,0 +1,14 @@
+/* based on
+  https://github.com/ubuntudesign/vanilla-design/blob/master/Breadcrumbs/breadcrumbs.md
+*/
+
+.breadcrumbs a {
+  color: $cool-grey;
+  margin-bottom: 4px
+}
+
+.breadcrumbs a:after {
+  content: '\203A';
+  display: inline-block;
+  margin: 0 8px;
+}

--- a/src/common/components/vanilla/breadcrumbs/index.js
+++ b/src/common/components/vanilla/breadcrumbs/index.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react';
+
+import style from './breadcrumbs.css';
+
+export default function Breadcrumbs({ children }) {
+  return (
+    <div className={ style.breadcrumbs }>
+      { children }
+    </div>
+  );
+}
+
+Breadcrumbs.propTypes = {
+  children: PropTypes.node
+};

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -10,6 +10,7 @@ import { Message } from '../components/forms';
 import HelpInstallSnap from '../components/help/install-snap';
 import { HeadingOne, HeadingThree } from '../components/vanilla/heading';
 import Spinner from '../components/spinner';
+import Breadcrumbs from '../components/vanilla/breadcrumbs';
 
 import withRepository from './with-repository';
 import withSnapBuilds from './with-snap-builds';
@@ -26,8 +27,12 @@ class BuildDetails extends Component {
         <Helmet
           title={`${repository.fullName} builds`}
         />
+        <Breadcrumbs>
+          <Link to={'/dashboard'}>My repos</Link>
+          <Link to={`/${repository.fullName}/builds`}>{repository.fullName}</Link>
+        </Breadcrumbs>
         <HeadingOne>
-          <Link to={`/${repository.fullName}/builds`}>{repository.fullName}</Link> build #{buildId}
+          Build #{buildId}
         </HeadingOne>
         { error &&
           <Message status='error'>{ error.message || error }</Message>

--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -7,6 +7,7 @@ import { Message } from '../components/forms';
 import Spinner from '../components/spinner';
 import HelpInstallSnap from '../components/help/install-snap';
 import { HeadingOne } from '../components/vanilla/heading';
+import Breadcrumbs from '../components/vanilla/breadcrumbs';
 
 import withRepository from './with-repository';
 import withSnapBuilds from './with-snap-builds';
@@ -26,8 +27,11 @@ class Builds extends Component {
         <Helmet
           title={`${repository.fullName} builds`}
         />
+        <Breadcrumbs>
+          <Link to={'/dashboard'}>My repos</Link>
+        </Breadcrumbs>
         <HeadingOne>
-          <Link to={`/${repository.fullName}/builds`}>{repository.fullName}</Link>
+          {repository.fullName}
         </HeadingOne>
         <BuildHistory repository={repository} />
         { isLoading &&

--- a/src/common/containers/container.css
+++ b/src/common/containers/container.css
@@ -7,7 +7,7 @@
 
 .container {
   composes: wrapper;
-  padding: 10px;
+  padding: 1em 0px;
   margin-bottom: 60px;
 }
 


### PR DESCRIPTION
Fixes #310

Repo details page:
<img width="1058" alt="screen shot 2017-03-15 at 10 14 09" src="https://cloud.githubusercontent.com/assets/83575/23941200/38403c50-0968-11e7-9123-aade63d55bfe.png">

Build details page:
<img width="1047" alt="screen shot 2017-03-15 at 10 14 22" src="https://cloud.githubusercontent.com/assets/83575/23941199/382b8580-0968-11e7-8d54-adba7f99ed39.png">