### PR TITLE
Add metric_type="kpi" label to GitHub users metric

### DIFF
--- a/src/server/metrics/github-users.js
+++ b/src/server/metrics/github-users.js
@@ -4,9 +4,10 @@ import { GitHubUser } from '../db/models/github-user';
 
 const gitHubUsersTotal = new promClient.Gauge(
   'bsi_github_users_total',
-  'Total number of GitHub users who have ever logged in.'
+  'Total number of GitHub users who have ever logged in.',
+  ['metric_type']
 );
 
 export default async function updateGitHubUsersTotal() {
-  gitHubUsersTotal.set(await GitHubUser.count());
+  gitHubUsersTotal.set({ metric_type: 'kpi' }, await GitHubUser.count());
 }

--- a/test/unit/src/server/metrics/t_github-users.js
+++ b/test/unit/src/server/metrics/t_github-users.js
@@ -30,10 +30,14 @@ describe('The GitHub users metric', () => {
     }
     await updateGitHubUsersTotal();
     const metricName = 'bsi_github_users_total';
-    expect(promClient.register.getSingleMetric(metricName).get()).toMatch({
-      name: metricName,
+    expect(promClient.register.getSingleMetric(metricName).get()).toEqual({
       type: 'gauge',
-      values: [{ value: 5 }]
+      name: metricName,
+      help: 'Total number of GitHub users who have ever logged in.',
+      values: [{
+        labels: { metric_type: 'kpi' },
+        value: 5
+      }]
     });
   });
 });


### PR DESCRIPTION
This is needed to make this metric selectable on
snappy.kpi.canonical.com.