### PR TITLE
Fix #395: Removed unnecessary lowercased URL params

### DIFF
--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -92,7 +92,7 @@ BuildDetails.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const buildId = ownProps.params.buildId.toLowerCase();
+  const buildId = ownProps.params.buildId;
   const build = ownProps.snapBuilds.builds.filter((build) => build.buildId === buildId)[0];
 
   return {

--- a/src/common/containers/with-repository.js
+++ b/src/common/containers/with-repository.js
@@ -42,8 +42,8 @@ function withRepository(WrappedComponent) {
   };
 
   const mapStateToProps = (state, ownProps) => {
-    const owner = ownProps.params.owner.toLowerCase();
-    const name = ownProps.params.name.toLowerCase();
+    const owner = ownProps.params.owner;
+    const name = ownProps.params.name;
     const fullName = `${owner}/${name}`;
     const repository = state.repository;
 

--- a/src/common/containers/with-snap-builds.js
+++ b/src/common/containers/with-snap-builds.js
@@ -45,7 +45,7 @@ function withSnapBuilds(WrappedComponent) {
     render() {
       const { snap, ...passThroughProps } = this.props; // eslint-disable-line no-unused-vars
 
-      return (this.props.snap
+      return (this.props.snapBuilds.success || this.props.snapBuilds.error
         ? <WrappedComponent {...passThroughProps} />
         : null
       );
@@ -56,6 +56,7 @@ function withSnapBuilds(WrappedComponent) {
   WithSnapBuilds.propTypes = {
     repository: PropTypes.object,
     snap: PropTypes.object,
+    snapBuilds: PropTypes.object,
     dispatch: PropTypes.func.isRequired
   };
 

--- a/test/unit/src/common/containers/t_with-repository.js
+++ b/test/unit/src/common/containers/t_with-repository.js
@@ -92,6 +92,19 @@ describe('WithRepository', () => {
     });
   });
 
+  context('when repo name is CamelCase', () => {
+    const camelCaseParams = { owner: 'AnOwner', name: 'AName' };
+
+    beforeEach(() => {
+      renderDummy(REPO, camelCaseParams);
+    });
+
+    it('should properly build fullName from URL params', () => {
+      const { owner, name } = camelCaseParams;
+      expect(wrapper.prop('fullName')).toEqual(`${owner}/${name}`);
+    });
+  });
+
   // Shallow render Dummy component wrapped in withRepository container
   // with given repository (mocked in the store) and URL params.
   // Assigns wrapper, instance and wrapped variables later used in tests.


### PR DESCRIPTION
Fix #395 

Empty build page seemed to be caused by BSI lowercasing repository name from URL, so instead of `MailHog` we were looking for snap for `mailhog` repo, which doesn't exist.

Therefore no snap was found and no builds shown.

Also, there was an issue that error was not passed to wrapped component, so whole page was rendered blank instead of properly showing error message (what snap cannot be found) - that would make it a lot easier to debug what is causing the problem.