### PR TITLE
Clean up database handling code

### DIFF
--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -25,5 +25,8 @@ if (!config) {
 
 const connection = knex(config);
 const db = new Bookshelf(connection);
+db.plugin('registry');
 
 export default db;
+
+require('./models');

--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -27,7 +27,6 @@ if (!config) {
 const connection = knex(config);
 const db = new Bookshelf(connection);
 db.plugin('registry');
+registerModels(db);
 
 export default db;
-
-registerModels(db);

--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -4,6 +4,7 @@ import Bookshelf from 'bookshelf';
 
 import { conf } from '../helpers/config';
 import logging from '../logging';
+import registerModels from './models';
 
 let knexConfigPath = conf.get('KNEX_CONFIG_PATH');
 if (!path.isAbsolute(knexConfigPath)) {
@@ -29,7 +30,4 @@ db.plugin('registry');
 
 export default db;
 
-// Import all our models here to ensure that they are added to the registry.
-// This needs to be require rather than import as otherwise we have problems
-// with circular dependencies.
-require('./models');
+registerModels(db);

--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -29,4 +29,7 @@ db.plugin('registry');
 
 export default db;
 
+// Import all our models here to ensure that they are added to the registry.
+// This needs to be require rather than import as otherwise we have problems
+// with circular dependencies.
 require('./models');

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -9,7 +9,7 @@ import db from '../index';
  *   updated_at: update date
  *   last_login_at: last login date
  */
-export const GitHubUser = db.model('GitHubUser', {
+db.model('GitHubUser', {
   tableName: 'github_user',
   hasTimestamps: true
 });

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -1,15 +1,15 @@
-import db from '../index';
-
-/* Schema:
- *   id: automatic serial number
- *   github_id: ID from GitHub
- *   name: display name from GitHub
- *   login: login name from GitHub
- *   created_at: creation date
- *   updated_at: update date
- *   last_login_at: last login date
- */
-db.model('GitHubUser', {
-  tableName: 'github_user',
-  hasTimestamps: true
-});
+export default function register(db) {
+  /* Schema:
+   *   id: automatic serial number
+   *   github_id: ID from GitHub
+   *   name: display name from GitHub
+   *   login: login name from GitHub
+   *   created_at: creation date
+   *   updated_at: update date
+   *   last_login_at: last login date
+   */
+  db.model('GitHubUser', {
+    tableName: 'github_user',
+    hasTimestamps: true
+  });
+}

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -9,7 +9,7 @@ import db from '../index';
  *   updated_at: update date
  *   last_login_at: last login date
  */
-export const GitHubUser = db.Model.extend({
+export const GitHubUser = db.model('GitHubUser', {
   tableName: 'github_user',
   hasTimestamps: true
 });

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -1,1 +1,5 @@
-import './github-user';
+import registerGitHubUser from './github-user';
+
+export default function register(db) {
+  registerGitHubUser(db);
+}

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -1,0 +1,1 @@
+require('./github-user');

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -1,1 +1,1 @@
-require('./github-user');
+import './github-user';

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -1,7 +1,7 @@
 import request from 'request';
 import logging from '../logging';
 
-import { GitHubUser } from '../db/models/github-user';
+import db from '../db';
 import { conf } from '../helpers/config';
 import { requestUser } from './github';
 
@@ -78,11 +78,12 @@ export const verify = (req, res, next) => {
     req.session.user = userResponse.body;
 
     // Save user info to DB
+    const gitHubUser = db.model('GitHubUser');
     try {
-      let dbUser = await GitHubUser.where({ github_id: userResponse.body.id })
+      let dbUser = await gitHubUser.where({ github_id: userResponse.body.id })
         .fetch();
       if (dbUser === null) {
-        dbUser = GitHubUser.forge({ github_id: userResponse.body.id });
+        dbUser = gitHubUser.forge({ github_id: userResponse.body.id });
       }
       await dbUser.set({
         name: userResponse.body.name || null,

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -78,24 +78,27 @@ export const verify = (req, res, next) => {
     req.session.user = userResponse.body;
 
     // Save user info to DB
-    const gitHubUser = db.model('GitHubUser');
-    try {
-      let dbUser = await gitHubUser.where({ github_id: userResponse.body.id })
-        .fetch();
-      if (dbUser === null) {
-        dbUser = gitHubUser.forge({ github_id: userResponse.body.id });
+    await db.transaction(async (trx) => {
+      const gitHubUser = db.model('GitHubUser');
+      try {
+        let dbUser = await gitHubUser
+          .where({ github_id: userResponse.body.id })
+          .fetch({ transacting: trx });
+        if (dbUser === null) {
+          dbUser = gitHubUser.forge({ github_id: userResponse.body.id });
+        }
+        await dbUser.set({
+          name: userResponse.body.name || null,
+          login: userResponse.body.login,
+          last_login_at: new Date()
+        });
+        if (dbUser.hasChanged()) {
+          await dbUser.save({}, { transacting: trx });
+        }
+      } catch (error) {
+        return next(error);
       }
-      await dbUser.set({
-        name: userResponse.body.name || null,
-        login: userResponse.body.login,
-        last_login_at: new Date()
-      });
-      if (dbUser.hasChanged()) {
-        await dbUser.save();
-      }
-    } catch (error) {
-      return next(error);
-    }
+    });
 
     // Redirect to logged in URL
     res.redirect('/dashboard');

--- a/src/server/metrics/github-users.js
+++ b/src/server/metrics/github-users.js
@@ -1,6 +1,6 @@
 import promClient from 'prom-client';
 
-import { GitHubUser } from '../db/models/github-user';
+import db from '../db';
 
 const gitHubUsersTotal = new promClient.Gauge(
   'bsi_github_users_total',
@@ -9,5 +9,6 @@ const gitHubUsersTotal = new promClient.Gauge(
 );
 
 export default async function updateGitHubUsersTotal() {
-  gitHubUsersTotal.set({ metric_type: 'kpi' }, await GitHubUser.count());
+  const gitHubUser = db.model('GitHubUser');
+  gitHubUsersTotal.set({ metric_type: 'kpi' }, await gitHubUser.count());
 }

--- a/src/server/metrics/github-users.js
+++ b/src/server/metrics/github-users.js
@@ -8,7 +8,9 @@ const gitHubUsersTotal = new promClient.Gauge(
   ['metric_type']
 );
 
-export default async function updateGitHubUsersTotal() {
-  const gitHubUser = db.model('GitHubUser');
-  gitHubUsersTotal.set({ metric_type: 'kpi' }, await gitHubUser.count());
+export default async function updateGitHubUsersTotal(trx) {
+  gitHubUsersTotal.set(
+    { metric_type: 'kpi' },
+    await db.model('GitHubUser').count('*', { transacting: trx })
+  );
 }

--- a/src/server/metrics/index.js
+++ b/src/server/metrics/index.js
@@ -1,9 +1,12 @@
+import db from '../db';
 import updateGitHubUsersTotal from './github-users';
 
 let existingInterval = null;
 
-async function updateAllMetrics() {
-  await updateGitHubUsersTotal();
+function updateAllMetrics() {
+  return db.transaction(async (trx) => {
+    await updateGitHubUsersTotal(trx);
+  });
 }
 
 export default async function startAllMetrics() {

--- a/test/routes/src/server/routes/t_github-auth.js
+++ b/test/routes/src/server/routes/t_github-auth.js
@@ -5,7 +5,7 @@ import expect from 'expect';
 import url from 'url';
 
 import auth from '../../../../../src/server/routes/github-auth';
-import { GitHubUser } from '../../../../../src/server/db/models/github-user';
+import db from '../../../../../src/server/db';
 import { conf } from '../../../../../src/server/helpers/config';
 
 const GITHUB_AUTH_LOGIN_URL = conf.get('GITHUB_AUTH_LOGIN_URL');
@@ -99,7 +99,7 @@ describe('The login route', () => {
           nock(conf.get('GITHUB_API_ENDPOINT'))
             .get('/user')
             .reply(200, { id: 123, login: 'anowner' });
-          await GitHubUser.query('truncate').fetch();
+          await db.model('GitHubUser').query('truncate').fetch();
         });
 
         it('should call GitHub API endpoint to get an auth token', (done) => {
@@ -119,7 +119,8 @@ describe('The login route', () => {
             .get('/auth/verify')
             .query({ code: 'foo', state: 'bar' })
             .send();
-          const dbUser = await GitHubUser.where({ github_id: 123 }).fetch();
+          const dbUser = await db.model('GitHubUser').where({ github_id: 123 })
+            .fetch();
           expect(dbUser.serialize()).toMatch({
             github_id: 123,
             login: 'anowner'

--- a/test/unit/src/server/metrics/t_github-users.js
+++ b/test/unit/src/server/metrics/t_github-users.js
@@ -18,26 +18,28 @@ describe('The GitHub users metric', () => {
     promClient.register.clear();
   });
 
-  it('returns the number of rows in GitHubUser', async () => {
-    for (let i = 0; i < 5; i++) {
-      const user = db.model('GitHubUser').forge({
-        github_id: i,
-        name: null,
-        login: `person-${i}`,
-        last_login_at: new Date()
+  it('returns the number of rows in GitHubUser', () => {
+    return db.transaction(async (trx) => {
+      for (let i = 0; i < 5; i++) {
+        const user = db.model('GitHubUser').forge({
+          github_id: i,
+          name: null,
+          login: `person-${i}`,
+          last_login_at: new Date()
+        });
+        await user.save({}, { transacting: trx });
+      }
+      await updateGitHubUsersTotal(trx);
+      const metricName = 'bsi_github_users_total';
+      expect(promClient.register.getSingleMetric(metricName).get()).toEqual({
+        type: 'gauge',
+        name: metricName,
+        help: 'Total number of GitHub users who have ever logged in.',
+        values: [{
+          labels: { metric_type: 'kpi' },
+          value: 5
+        }]
       });
-      await user.save();
-    }
-    await updateGitHubUsersTotal();
-    const metricName = 'bsi_github_users_total';
-    expect(promClient.register.getSingleMetric(metricName).get()).toEqual({
-      type: 'gauge',
-      name: metricName,
-      help: 'Total number of GitHub users who have ever logged in.',
-      values: [{
-        labels: { metric_type: 'kpi' },
-        value: 5
-      }]
     });
   });
 });

--- a/test/unit/src/server/metrics/t_github-users.js
+++ b/test/unit/src/server/metrics/t_github-users.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import promClient from 'prom-client';
 
-import { GitHubUser } from '../../../../../src/server/db/models/github-user';
+import db from '../../../../../src/server/db';
 
 describe('The GitHub users metric', () => {
   let updateGitHubUsersTotal;
@@ -11,7 +11,7 @@ describe('The GitHub users metric', () => {
     // to make sure it registers metrics when tests are run and cleared in after hook
     updateGitHubUsersTotal = require('../../../../../src/server/metrics/github-users').default;
 
-    await GitHubUser.query('truncate').fetch();
+    await db.model('GitHubUser').query('truncate').fetch();
   });
 
   afterEach(() => {
@@ -20,7 +20,7 @@ describe('The GitHub users metric', () => {
 
   it('returns the number of rows in GitHubUser', async () => {
     for (let i = 0; i < 5; i++) {
-      const user = GitHubUser.forge({
+      const user = db.model('GitHubUser').forge({
         github_id: i,
         name: null,
         login: `person-${i}`,


### PR DESCRIPTION
* Use the Bookshelf registry plugin

This will mean fewer problems with circular dependencies if the database
schema gets more complicated.

* Run database queries in transactions

At the moment we have no particular need for cleanly rolling back
transactions, but we will soon, and we might as well put good practice
in place now.

I considered using `bookshelf-transaction-manager` to avoid the
`{ transacting: trx }` boilerplate, but it ended up being much more
trouble than it was worth: it doesn't currently wrap all the Bookshelf
model/collection methods, which makes it very confusing and error-prone
to use.