### PR TITLE
Fixes #355 - reusing existing help box to show build debug instructions

### DIFF
--- a/src/common/components/help/install-snap/index.js
+++ b/src/common/components/help/install-snap/index.js
@@ -7,9 +7,9 @@ const HELP_INSTALL_URL = 'https://snapcraft.io/docs/core/install';
 
 export default class HelpInstallSnap extends Component {
   render() {
-    const { headline, name, revision } = this.props;
+    const { children, headline, name, revision } = this.props;
     const revOption = revision ? `--revision=${ revision }` : '';
-    const command = this.props.children || `sudo snap install --edge ${name} ${revOption}`;
+    const command = children || `sudo snap install --edge ${name} ${revOption}`;
 
     return (
       <div className={ styles.strip }>

--- a/src/common/components/help/install-snap/index.js
+++ b/src/common/components/help/install-snap/index.js
@@ -29,7 +29,12 @@ export default class HelpInstallSnap extends Component {
 
 HelpInstallSnap.propTypes = {
   headline: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  // name is only required if there is no children specified
+  name: (props, propName, componentName) => {
+    if (typeof props.children === 'undefined' && typeof props[propName] !== 'string') {
+      return new Error(`The prop '${propName}' in ${componentName} should be a string if no children are specified.`);
+    }
+  },
   revision: PropTypes.number,
   children: PropTypes.node
 };

--- a/src/common/components/help/install-snap/index.js
+++ b/src/common/components/help/install-snap/index.js
@@ -9,13 +9,14 @@ export default class HelpInstallSnap extends Component {
   render() {
     const { headline, name, revision } = this.props;
     const revOption = revision ? `--revision=${ revision }` : '';
+    const command = this.props.children || `sudo snap install --edge ${name} ${revOption}`;
 
     return (
       <div className={ styles.strip }>
         <HeadingThree>{ headline }</HeadingThree>
         <pre>
           <code className={ styles.cli }>
-            sudo snap install --edge { name } { revOption }
+            {command}
           </code>
         </pre>
         <p className={ styles.p }>
@@ -29,5 +30,6 @@ export default class HelpInstallSnap extends Component {
 HelpInstallSnap.propTypes = {
   headline: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  revision: PropTypes.number
+  revision: PropTypes.number,
+  children: PropTypes.node
 };

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -22,6 +22,27 @@ class BuildDetails extends Component {
     const { repository, buildId, build } = this.props;
     const { snap, error, isFetching } = this.props.snapBuilds;
 
+    const buildFailed = (build.statusMessage === 'Failed to build');
+    let helpBox;
+
+    if (buildFailed) {
+      // if build has failed show snapcraft debug instruction
+      helpBox = (
+        <HelpInstallSnap headline='To debug this build:'>
+          snap install --edge --classic snapcraft # if you don’t have snapcraft already<br/>
+          snapcraft cleanbuild --debug
+        </HelpInstallSnap>
+      );
+    } else if (snap && snap.store_name) {
+      // otherwise if we have snap name show install instructions
+      helpBox = (
+        <HelpInstallSnap
+          headline='To test the latest successful build on your PC or cloud instance:'
+          name={ snap.store_name }
+        />
+      );
+    }
+
     return (
       <div className={ styles.container }>
         <Helmet
@@ -58,14 +79,9 @@ class BuildDetails extends Component {
             </div>
           </div>
         }
+        { helpBox }
         { isFetching &&
           <div className={styles.spinner}><Spinner /></div>
-        }
-        { snap && snap.store_name &&
-          <HelpInstallSnap
-            headline='To test the latest successful build on your PC or cloud instance:'
-            name={ snap.store_name }
-          />
         }
       </div>
     );

--- a/test/unit/src/common/components/help/t_install_snap.js
+++ b/test/unit/src/common/components/help/t_install_snap.js
@@ -6,20 +6,45 @@ import HelpInstallSnap from '../../../../../../src/common/components/help/instal
 
 describe('<HelpInstallSnap />', function() {
 
-  const name = 'needleinhaystack';
-  const revision = 14159265358979;
-
   let wrapper;
+  const heading='This is just a test';
 
-  beforeEach(function() {
-    wrapper = shallow(<HelpInstallSnap name={ name } revision={ revision } />);
+  context('when rendered with name and revision', () => {
+    const name = 'needleinhaystack';
+    const revision = 14159265358979;
+
+    beforeEach(function() {
+      wrapper = shallow(<HelpInstallSnap heading={heading} name={ name } revision={ revision } />);
+    });
+
+    it('should include snap name', function() {
+      expect(wrapper.text()).toInclude(name);
+    });
+
+    it('should include revision number', function() {
+      expect(wrapper.text()).toInclude(revision);
+    });
+
+    it('should include help link', function() {
+      expect(wrapper.text()).toInclude('Don’t have snapd installed?');
+    });
   });
 
-  it('should include snap name', function() {
-    expect(/needleinhaystack/.test(wrapper.text())).toExist();
-  });
+  context('when rendered with children', () => {
+    beforeEach(function() {
+      wrapper = shallow(<HelpInstallSnap heading={heading}>command test</HelpInstallSnap>);
+    });
 
-  it('should include revision number', function() {
-    expect(/14159265358979/.test(wrapper.text())).toExist();
+    it('should include command passed as children', function() {
+      expect(wrapper.text()).toInclude('command test');
+    });
+
+    it('should not include snap install instructions', function() {
+      expect(wrapper.text()).toNotInclude('snap install');
+    });
+
+    it('should include help link', function() {
+      expect(wrapper.text()).toInclude('Don’t have snapd installed?');
+    });
   });
 });


### PR DESCRIPTION
<img width="1045" alt="screen shot 2017-03-16 at 15 49 48" src="https://cloud.githubusercontent.com/assets/83575/24002122/39b4cc06-0a60-11e7-83f6-2920c023e61d.png">
