### PR TITLE
Fix #302 - build status should link to repos page

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -238,12 +238,6 @@ export class RepositoryRowView extends Component {
     );
 
     const hasBuilt = !!(latestBuild && snap.snapcraft_data);
-    const hasLog = !!(hasBuilt && latestBuild.buildLogUrl);
-
-    // only link to builds that have log available
-    const latestBuildUrl = hasLog
-      ? `/user/${fullName}/${latestBuild.buildId}`
-      : null;
 
     const isActive = (
       showNameMismatchDropdown ||
@@ -279,7 +273,7 @@ export class RepositoryRowView extends Component {
           { hasBuilt
             ? (
               <BuildStatus
-                link={ latestBuildUrl }
+                link={ `/user/${fullName}` }
                 colour={ latestBuild.colour }
                 statusMessage={ latestBuild.statusMessage }
                 dateStarted={ latestBuild.dateStarted }

--- a/test/unit/src/common/components/repository-row/t_repository-row.js
+++ b/test/unit/src/common/components/repository-row/t_repository-row.js
@@ -100,8 +100,8 @@ describe('<RepositoryRowView />', () => {
       expect(view.type()).toEqual(Row);
     });
 
-    it('should contain BuildStatus linked to build page', () => {
-      const expectedUrl = `/user/${props.fullName}/${props.latestBuild.buildId}`;
+    it('should contain BuildStatus linked to repo page', () => {
+      const expectedUrl = `/user/${props.fullName}`;
 
       expect(view.find('BuildStatus').length).toBe(1);
       expect(view.find('BuildStatus').prop('link')).toBe(expectedUrl);
@@ -124,9 +124,11 @@ describe('<RepositoryRowView />', () => {
       props.latestBuild.buildLogUrl = buildLogUrl;
     });
 
-    it('should contain BuildStatus not linked to build page', () => {
+    it('should contain BuildStatus linked to repo page', () => {
+      const expectedUrl = `/user/${props.fullName}`;
+
       expect(view.find('BuildStatus').length).toBe(1);
-      expect(view.find('BuildStatus').prop('link')).toBe(null);
+      expect(view.find('BuildStatus').prop('link')).toBe(expectedUrl);
     });
   });
 


### PR DESCRIPTION
Links on build status in my repos list should link to repo details to show builds for all architectures, not just single build.