### PR TITLE
Fix #401 - show extended message for reserved names

### DIFF
--- a/src/common/components/repository-row/dropdowns/register-name-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/register-name-dropdown.js
@@ -11,6 +11,10 @@ import styles from './dropdowns.css';
 const FILE_NAME_CLAIM_URL = `${conf.get('STORE_DEVPORTAL_URL')}/click-apps/register-name/`;
 const AGREEMENT_URL = `${conf.get('STORE_DEVPORTAL_URL')}/tos/`;
 
+const getErrorCode = (error) => {
+  return error && error.json && error.json.payload && error.json.payload.code;
+};
+
 // partial component for rendering Developer Programme Aggreement checkbox
 const Agreement = (props) => {
   const checkbox = <input type="checkbox" onChange={ props.onChange } />;
@@ -114,19 +118,22 @@ const Caption = (props) => {
     );
   }
 
+  const errorCode = getErrorCode(registerNameStatus.error);
+
   if (registerNameStatus.success) {
     caption = (
       <div>
         <TickIcon /> Registered successfully
       </div>
     );
-  } else if ( registerNameStatus.error
-    && registerNameStatus.error.json
-    && registerNameStatus.error.json.payload
-    && registerNameStatus.error.json.payload.code === 'already_registered') {
+  } else if (errorCode === 'already_registered' || errorCode === 'reserved_name') {
+    const reason = (errorCode === 'reserved_name'
+      ? 'that name is reserved'
+      : 'that name is already taken'
+    );
     caption = (
       <div>
-        <p><ErrorIcon /> Sorry, that name is already taken. Try a different name.</p>
+        <p><ErrorIcon /> Sorry, { reason }. Try a different name.</p>
         <p className={ styles.helpText }>
           If you think you should have sole rights to the name,
           you can <a href={ FILE_NAME_CLAIM_URL } target='_blank'>file a claim</a>.


### PR DESCRIPTION
<img width="1047" alt="screen shot 2017-03-17 at 13 55 03" src="https://cloud.githubusercontent.com/assets/83575/24043976/772b71f2-0b19-11e7-9a2f-b7ec87384c98.png">

Some names may be reserved by Canonical.
We should show extended error message explaining how to claim the reserved name.

### QA

To test it try reserving name 'zeppelin'.
