### PR TITLE
Properly show spinner when user has no repositories

### DIFF
--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -55,7 +55,10 @@ class RepositoriesHome extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.snaps.success !== nextProps.snaps.success) {
+    const snapsLength = nextProps.snaps.snaps && nextProps.snaps.snaps.length;
+
+    if ((this.props.snaps.success !== nextProps.snaps.success)
+        || (snapsLength === 0)) {
       this.fetchData(nextProps);
     }
   }
@@ -89,9 +92,14 @@ class RepositoriesHome extends Component {
 
   render() {
     const { snaps } = this.props;
-    const hasSnaps = (snaps.snaps && Object.keys(snaps.snaps).length > 0);
-    // show spinner until we know if user has any enabled repos
-    return (snaps.isFetching && !hasSnaps)
+    const hasSnaps = (snaps.snaps && snaps.snaps.length > 0);
+
+    // show spinner if snaps data was not yet fetched (snaps list is empty)
+    // (to avoid spinner during polling we are not checking `success` or `isFetching`
+    //
+    // when snaps are loaded and user doesn't have any, they will be redirected
+    // to select repositories (so spinner won't be showing endlessly)
+    return !hasSnaps
       ? this.renderSpinner()
       : this.renderRepositoriesList();
   }

--- a/test/unit/src/common/components/repositories-home/t_repositories-home.js
+++ b/test/unit/src/common/components/repositories-home/t_repositories-home.js
@@ -18,6 +18,74 @@ describe('The RepositoriesHome component', () => {
     clock.restore();
   });
 
+  context('when snaps are not loaded', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      props = {
+        auth: {
+          authenticated: true
+        },
+        user: {},
+        snaps: {},
+        snapBuilds: {},
+        fetchBuilds: () => {},
+        updateSnaps: () => {},
+        router: {}
+      };
+
+      wrapper = shallow(<RepositoriesHome { ...props } />);
+    });
+
+    it('should render spinner', () => {
+      expect(wrapper.find('Spinner').length).toBe(1);
+    });
+  });
+
+  context('when user has no snaps', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      props = {
+        auth: {
+          authenticated: true
+        },
+        user: {},
+        snaps: {
+          success: true,
+          snaps: []
+        },
+        snapBuilds: {},
+        fetchBuilds: () => {},
+        updateSnaps: () => {},
+        router: {
+          replace: expect.createSpy()
+        }
+      };
+
+      wrapper = shallow(<RepositoriesHome { ...props } />);
+    });
+
+    it('should render spinner', () => {
+      expect(wrapper.find('Spinner').length).toBe(1);
+    });
+
+    context('and component recieves props', () => {
+      beforeEach(() => {
+        wrapper.instance().componentDidMount();
+        wrapper.instance().componentWillReceiveProps(props);
+      });
+
+      afterEach(() => {
+        wrapper.instance().componentWillUnmount();
+      });
+
+      it('should redirect to select repositories', () => {
+        expect(props.router.replace).toHaveBeenCalledWith('/select-repositories');
+      });
+    });
+  });
+
   context('when user is logged in', () => {
     let wrapper;
 


### PR DESCRIPTION
Fixes #507 

Showing spinner on 'My repos' until snaps data is properly fetched.
If user has no repos (because they never added one or removed all of them) they will be redirected to select repositories.

Current solution has one case when it works a bit weird (may be considered a bug):
When user has some repositories and adds new one, then they move back from 'select repositories' to 'my repositories' they will see their old list of repos (without the new one) until list gets refreshed.
There is also no spinner of any kind (because we don't want to show spinner during polling).
So there is a visual delay between adding a repo and it being rendered no the list.