### PR TITLE
Add developer uptake metrics

### DIFF
--- a/migrations/20170314122717_user-metrics.js
+++ b/migrations/20170314122717_user-metrics.js
@@ -1,0 +1,25 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('github_user', function(table) {
+      table.index(['login']);
+      table.integer('snaps_added');
+      table.integer('snaps_removed');
+      table.integer('names_registered');
+      table.integer('builds_requested');
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('github_user', function(table) {
+      table.dropIndex(['login']);
+      // Should use `table.dropColumns`, but see:
+      //   https://github.com/tgriesser/knex/issues/1979
+      table.dropColumn('builds_requested');
+      table.dropColumn('names_registered');
+      table.dropColumn('snaps_removed');
+      table.dropColumn('snaps_added');
+    })
+  ]);
+};

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -88,7 +88,8 @@ export async function internalRegisterName(root, discharge, snapName,
       repository_url: repositoryUrl,
       root,
       discharge
-    })
+    }),
+    credentials: 'same-origin'
   });
   if (response.status >= 200 && response.status < 300) {
     return response;

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -88,8 +88,7 @@ export async function internalRegisterName(root, discharge, snapName,
       repository_url: repositoryUrl,
       root,
       discharge
-    }),
-    credentials: 'same-origin'
+    })
   });
   if (response.status >= 200 && response.status < 300) {
     return response;

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -7,9 +7,32 @@ export default function register(db) {
    *   created_at: creation date
    *   updated_at: update date
    *   last_login_at: last login date
+   *   snaps_added: number of snaps added
+   *   snaps_removed: number of snaps removed
+   *   names_registered: number of snap names registered
+   *   builds_requested: number of snap builds requested
    */
   db.model('GitHubUser', {
     tableName: 'github_user',
     hasTimestamps: true
+  }, {
+    // Increment a metric for a user.  Where possible, this should be called
+    // at the *start* of a transaction spanning any external API calls that
+    // are tracked by the metric in question: this means that either a
+    // failure to increment the metric or a failure in the external API call
+    // will cause both to be rolled back.
+    incrementMetric: async (query, metricName, delta, options) => {
+      const row = await db.model('GitHubUser').where(query).fetch(options);
+      if (row) {
+        const value = row.get(metricName);
+        // Metrics may often require non-trivial initialization, for example
+        // when a metric is introduced to the site after the feature that
+        // it's measuring.  To cope with this, only increment a metric if it
+        // has already been initialized.
+        if (value !== undefined && value !== null) {
+          await row.save({ [metricName]: value + delta }, options);
+        }
+      }
+    }
   });
 }

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -416,12 +416,7 @@ const initializeMetrics = async (gitHubId, snaps) => {
       }
       if (rowData.names_registered === undefined ||
           rowData.names_registered === null) {
-        let namesRegistered = 0;
-        for (const snap of snaps) {
-          if (snap.store_name) {
-            namesRegistered += 1;
-          }
-        }
+        const namesRegistered = snaps.filter((snap) => snap.store_name).length;
         row.set({ names_registered: namesRegistered });
       }
       if (rowData.builds_requested === undefined ||

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import yaml from 'js-yaml';
 import parseGitHubUrl from 'parse-github-url';
 
+import db from '../db';
 import { conf } from '../helpers/config';
 import { getMemcached } from '../helpers/memcached';
 import requestGitHub from '../helpers/github';
@@ -281,20 +282,29 @@ export const newSnap = async (req, res) => {
   // We need admin permissions in order to be able to install a webhook later.
   try {
     const { owner } = await checkAdminPermissions(req.session, repositoryUrl);
-    const result = await requestNewSnap(repositoryUrl);
-    // as new snap is created we need to clear list of snaps from cache
-    const urlPrefix = getRepoUrlPrefix(owner);
-    const cacheId = getUrlPrefixCacheId(urlPrefix);
-
-    await getMemcached().del(cacheId);
-    const snapUrl = result.self_link;
-    logger.info(`Created ${snapUrl}`);
-    return res.status(201).send({
-      status: 'success',
-      payload: {
-        code: 'snap-created',
-        message: snapUrl
+    await db.transaction(async (trx) => {
+      if (req.session.user) {
+        await db.model('GitHubUser').incrementMetric(
+          { github_id: req.session.user.id }, 'snaps_added', 1,
+          { transacting: trx }
+        );
       }
+
+      const result = await requestNewSnap(repositoryUrl);
+      // as new snap is created we need to clear list of snaps from cache
+      const urlPrefix = getRepoUrlPrefix(owner);
+      const cacheId = getUrlPrefixCacheId(urlPrefix);
+
+      await getMemcached().del(cacheId);
+      const snapUrl = result.self_link;
+      logger.info(`Created ${snapUrl}`);
+      return res.status(201).send({
+        status: 'success',
+        payload: {
+          code: 'snap-created',
+          message: snapUrl
+        }
+      });
     });
   } catch (error) {
     return sendError(res, error);
@@ -384,6 +394,60 @@ const internalFindSnapsByPrefix = async (urlPrefix) => {
   }
 };
 
+// If we haven't yet initialized metrics related to the number of snaps for
+// this user, do that now making some reasonable assumptions about
+// historical data.  This may under-report if somebody manages to accumulate
+// more snaps than the Launchpad batch size (75) before triggering this, but
+// that shouldn't happen in practice.
+const initializeMetrics = async (gitHubId, snaps) => {
+  await db.transaction(async (trx) => {
+    const row = await db.model('GitHubUser')
+      .where({ github_id: gitHubId })
+      .fetch({ transacting: trx });
+    if (row) {
+      const rowData = row.serialize();
+      if (rowData.snaps_added === undefined ||
+          rowData.snaps_added === null) {
+        row.set({ snaps_added: snaps.length });
+      }
+      if (rowData.snaps_removed === undefined ||
+          rowData.snaps_removed === null) {
+        row.set({ snaps_removed: 0 });
+      }
+      if (rowData.names_registered === undefined ||
+          rowData.names_registered === null) {
+        let namesRegistered = 0;
+        for (const snap of snaps) {
+          if (snap.store_name) {
+            namesRegistered += 1;
+          }
+        }
+        row.set({ names_registered: namesRegistered });
+      }
+      if (rowData.builds_requested === undefined ||
+          rowData.builds_requested === null) {
+        // This is potentially quite an expensive piece of initialization,
+        // but only the first time that a user who's been using the site
+        // since before this code landed comes back, so some one-time
+        // expense is tolerable.
+        try {
+          let buildsRequested = 0;
+          for (const snap of snaps) {
+            const builds = await getLaunchpad().get(
+              snap.builds_collection_link
+            );
+            buildsRequested += builds.total_size;
+          }
+          row.set({ builds_requested: buildsRequested });
+        } catch (error) {
+          logger.error(`Failed to fetch builds from Launchpad: ${error}`);
+        }
+      }
+      await row.save({}, { transacting: trx });
+    }
+  });
+};
+
 export const findSnaps = async (req, res) => {
   const owner = req.query.owner || req.session.user.login;
   const urlPrefix = getRepoUrlPrefix(owner);
@@ -395,6 +459,9 @@ export const findSnaps = async (req, res) => {
       );
       return { ...snap, snapcraft_data: snapcraftData };
     }));
+    if (req.session.user) {
+      await initializeMetrics(req.session.user.id, snaps);
+    }
     return res.status(200).send({
       status: 'success',
       payload: {
@@ -507,7 +574,7 @@ export const getSnapBuilds = async (req, res) => {
   }
 };
 
-export const internalRequestSnapBuilds = async (snap) => {
+export const internalRequestSnapBuilds = async (snap, owner) => {
   // Request builds, then make sure that auto_build is enabled so that
   // future push events will cause the webhook to dispatch builds.  Doing
   // things in this order ensures that Launchpad's internal
@@ -520,14 +587,35 @@ export const internalRequestSnapBuilds = async (snap) => {
   if (!snap.auto_build) {
     await lpClient.patch(snap.self_link, { auto_build: true });
   }
+  // We can't do this properly transactionally (i.e. don't request builds if
+  // the DB connection fails), because we don't know how many builds we're
+  // going to request up-front.  If we find a way to fix that then we should
+  // rearrange this to increment the metric first and then roll it back if
+  // requesting builds fails.
+  try {
+    await db.transaction(async (trx) => {
+      // XXX cjwatson 2017-03-17: This will go wrong once we support
+      // organizations, since we have no way to know which developer to
+      // credit for the builds.  At the moment, the best we can do is to
+      // credit the owner of the repository.
+      await db.model('GitHubUser').incrementMetric(
+        { login: owner }, 'builds_requested', builds.length,
+        { transacting: trx }
+      );
+    });
+  } catch (error) {
+    logger.error(`Error incrementing builds_requested for ${owner}: ${error}`);
+  }
   return builds;
 };
 
 export const requestSnapBuilds = async (req, res) => {
   try {
-    await checkAdminPermissions(req.session, req.body.repository_url);
+    const { owner } = await checkAdminPermissions(
+      req.session, req.body.repository_url
+    );
     const snap = await internalFindSnap(req.body.repository_url);
-    const builds = await internalRequestSnapBuilds(snap);
+    const builds = await internalRequestSnapBuilds(snap, owner);
     return res.status(201).send({
       status: 'success',
       payload: {
@@ -546,19 +634,27 @@ export const deleteSnap = async (req, res) => {
       req.session, req.body.repository_url
     );
     const snap = await internalFindSnap(req.body.repository_url);
-    await snap.lp_delete();
-
-    const urlPrefix = getRepoUrlPrefix(owner);
-    const prefixCacheId = getUrlPrefixCacheId(urlPrefix);
-    const repoCacheId = getRepositoryUrlCacheId(req.body.repository_url);
-    await getMemcached().del(prefixCacheId);
-    await getMemcached().del(repoCacheId);
-    return res.status(200).send({
-      status: 'success',
-      payload: {
-        code: 'snap-deleted',
-        message: 'Snap deleted'
+    await db.transaction(async (trx) => {
+      if (req.session.user) {
+        await db.model('GitHubUser').incrementMetric(
+          { github_id: req.session.user.id }, 'snaps_removed', 1,
+          { transacting: trx }
+        );
       }
+      await snap.lp_delete();
+
+      const urlPrefix = getRepoUrlPrefix(owner);
+      const prefixCacheId = getUrlPrefixCacheId(urlPrefix);
+      const repoCacheId = getRepositoryUrlCacheId(req.body.repository_url);
+      await getMemcached().del(prefixCacheId);
+      await getMemcached().del(repoCacheId);
+      return res.status(200).send({
+        status: 'success',
+        payload: {
+          code: 'snap-deleted',
+          message: 'Snap deleted'
+        }
+      });
     });
   } catch (error) {
     return sendError(res, error);

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -1,6 +1,5 @@
 import 'isomorphic-fetch';
 
-import db from '../db';
 import { conf } from '../helpers/config';
 
 export const registerName = async (req, res) => {
@@ -8,28 +7,18 @@ export const registerName = async (req, res) => {
   const root = req.body.root;
   const discharge = req.body.discharge;
 
-  await db.transaction(async (trx) => {
-    // XXX cjwatson 2017-03-17: This may need to move somewhere else in
-    // order to support having the client call `register-name` on the store
-    // directly (see #272).
-    if (req.session && req.session.user) {
-      await db.model('GitHubUser').incrementMetric(
-        req.session.user.id, 'names_registered', 1, { transacting: trx }
-      );
-    }
-    const url = `${conf.get('STORE_API_URL')}/register-name/`;
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-      },
-      body: JSON.stringify({ snap_name: snapName })
-    });
-    const json = await response.json();
-    return res.status(response.status).send(json);
+  const url = `${conf.get('STORE_API_URL')}/register-name/`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({ snap_name: snapName })
   });
+  const json = await response.json();
+  return res.status(response.status).send(json);
 };
 
 export const getAccount = async (req, res) => {

--- a/src/server/handlers/webhook.js
+++ b/src/server/handlers/webhook.js
@@ -76,7 +76,7 @@ export const notify = async (req, res) => {
         // XXX cjwatson 2017-02-16: Cache returned snap name, if any.
         await internalGetSnapcraftYaml(owner, name);
       }
-      await internalRequestSnapBuilds(snap);
+      await internalRequestSnapBuilds(snap, owner);
       logger.info(`Requested builds of ${repositoryUrl}.`);
       return res.status(200).send();
     } catch (error) {

--- a/src/server/metrics/developer-uptake.js
+++ b/src/server/metrics/developer-uptake.js
@@ -1,0 +1,32 @@
+import promClient from 'prom-client';
+
+import db from '../db';
+
+const developerUptake = new promClient.Gauge(
+  'bsi_developer_uptake',
+  'Number of developers who have reached various steps.',
+  ['metric_type', 'step']
+);
+
+export default async function updateDeveloperUptake(trx) {
+  // "How many developers have ever logged in" is covered by
+  // `bsi_github_users_total` instead.
+  developerUptake.set(
+    { metric_type: 'kpi', step: 'enabled_repository' },
+    await db.model('GitHubUser')
+      .where('snaps_added', '>', 0)
+      .count('*', { transacting: trx })
+  );
+  developerUptake.set(
+    { metric_type: 'kpi', step: 'registered_name' },
+    await db.model('GitHubUser')
+      .where('names_registered', '>', 0)
+      .count('*', { transacting: trx })
+  );
+  developerUptake.set(
+    { metric_type: 'kpi', step: 'requested_build' },
+    await db.model('GitHubUser')
+      .where('builds_requested', '>', 0)
+      .count('*', { transacting: trx })
+  );
+}

--- a/src/server/metrics/index.js
+++ b/src/server/metrics/index.js
@@ -1,11 +1,13 @@
 import db from '../db';
 import updateGitHubUsersTotal from './github-users';
+import updateDeveloperUptake from './developer-uptake';
 
 let existingInterval = null;
 
 function updateAllMetrics() {
   return db.transaction(async (trx) => {
     await updateGitHubUsersTotal(trx);
+    await updateDeveloperUptake(trx);
   });
 }
 

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -9,6 +9,7 @@ import {
   setupInMemoryMemcached
 } from '../../../../../src/server/helpers/memcached';
 import launchpad from '../../../../../src/server/routes/launchpad';
+import db from '../../../../../src/server/db';
 import { getSnapcraftYamlCacheId } from '../../../../../src/server/handlers/github';
 import {
   getUrlPrefixCacheId,
@@ -18,7 +19,7 @@ import { conf } from '../../../../../src/server/helpers/config.js';
 
 describe('The Launchpad API endpoint', () => {
   const app = Express();
-  const session = { 'token': 'secret' };
+  const session = { token: 'secret', user: { id: 123, login: 'anowner' } };
   app.use((req, res, next) => {
     req.session = session;
     next();
@@ -64,10 +65,18 @@ describe('The Launchpad API endpoint', () => {
     context('when user has admin permissions on repository', () => {
       const snapName = 'dummy-test-snap';
 
-      beforeEach(() => {
+      beforeEach(async () => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
           .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: true } });
+        await db.model('GitHubUser').query('truncate').fetch();
+        await db.model('GitHubUser')
+          .forge({
+            github_id: session.user.id,
+            login: session.user.login,
+            last_login_at: new Date()
+          })
+          .save();
       });
 
       afterEach(() => {
@@ -108,6 +117,18 @@ describe('The Launchpad API endpoint', () => {
                 'lp-error',
                 'There is already a snap package with the same name and owner.'))
             .end(done);
+        });
+
+        it('should leave snaps_added unmodified', async () => {
+          const dbUser = await db.model('GitHubUser')
+            .where({ github_id: session.user.id })
+            .fetch();
+          await dbUser.save({ snaps_added: 1 });
+          await supertest(app)
+            .post('/launchpad/snaps')
+            .send({ repository_url: 'https://github.com/anowner/aname' });
+          await dbUser.refresh();
+          expect(dbUser.get('snaps_added')).toEqual(1);
         });
       });
 
@@ -154,6 +175,28 @@ describe('The Launchpad API endpoint', () => {
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasMessage('snap-created', snapUrl))
             .end(done);
+        });
+
+        it('should leave snaps_added unmodified if it is unset', async () => {
+          await supertest(app)
+            .post('/launchpad/snaps')
+            .send({ repository_url: 'https://github.com/anowner/aname' });
+          const dbUser = await db.model('GitHubUser')
+            .where({ github_id: session.user.id })
+            .fetch();
+          expect(dbUser.get('snaps_added')).toBeFalsy();
+        });
+
+        it('should increment snaps_added if it is set', async () => {
+          const dbUser = await db.model('GitHubUser')
+            .where({ github_id: session.user.id })
+            .fetch();
+          await dbUser.save({ snaps_added: 1 });
+          await supertest(app)
+            .post('/launchpad/snaps')
+            .send({ repository_url: 'https://github.com/anowner/aname' });
+          await dbUser.refresh();
+          expect(dbUser.get('snaps_added')).toEqual(2);
         });
       });
     });
@@ -295,10 +338,18 @@ describe('The Launchpad API endpoint', () => {
   describe('list snaps route', () => {
     let apiResponse;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       apiResponse = supertest(app)
         .get('/launchpad/snaps/list')
         .query({ owner: 'anowner' });
+      await db.model('GitHubUser').query('truncate').fetch();
+      await db.model('GitHubUser')
+        .forge({
+          github_id: session.user.id,
+          login: session.user.login,
+          last_login_at: new Date()
+        })
+        .save();
     });
 
     context('when snaps exist', () => {
@@ -322,18 +373,23 @@ describe('The Launchpad API endpoint', () => {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~another-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~another-user`,
-            git_repository_url: 'https://github.com/another-user/test-snap'
+            git_repository_url: 'https://github.com/another-user/test-snap',
+            builds_collection_link: `${lp_api_base}/~another-user/+snap/` +
+                                    'test-snap/builds',
+            store_name: 'snap1'
           },
           {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~test-user`,
-            git_repository_url: 'https://github.com/test-user/test-snap'
+            git_repository_url: 'https://github.com/test-user/test-snap',
+            builds_collection_link: `${lp_api_base}/~test-user/+snap/` +
+                                    'test-snap/builds'
           }
         ];
 
-        lpApi = nock(lp_api_url)
-          .get('/devel/+snaps')
+        lpApi = nock(lp_api_url);
+        lpApi.get('/devel/+snaps')
           .query({
             'ws.op': 'findByURLPrefix',
             url_prefix: 'https://github.com/anowner/',
@@ -352,6 +408,22 @@ describe('The Launchpad API endpoint', () => {
           ghApi = nock(gh_api_url)
             .get(`/repos/${fullName}/contents/snap/snapcraft.yaml`)
             .reply(200, repoContents);
+          const builds_link = snap.builds_collection_link;
+          lpApi.get(builds_link.replace(lp_api_url, ''))
+            .optionally()
+            .reply(200, {
+              total_size: 2,
+              entries: [
+                {
+                  resource_type_link: `${lp_api_url}/devel/#snap_build`,
+                  self_link: `${builds_link.replace(/builds$/, '')}/+build/1`
+                },
+                {
+                  resource_type_link: `${lp_api_url}/devel/#snap_build`,
+                  self_link: `${builds_link.replace(/builds$/, '')}/+build/2`
+                }
+              ]
+            });
         });
 
       });
@@ -388,6 +460,39 @@ describe('The Launchpad API endpoint', () => {
         });
         expect(snap).toContain({
           snapcraft_data: { path: 'snap/snapcraft.yaml' }
+        });
+      });
+
+      it('should leave metrics unmodified if already set', async () => {
+        const dbUser = await db.model('GitHubUser')
+          .where({ github_id: session.user.id })
+          .fetch();
+        await dbUser.save({
+          snaps_added: 4,
+          snaps_removed: 2,
+          names_registered: 2,
+          builds_requested: 8
+        });
+        await apiResponse;
+        await dbUser.refresh();
+        expect(dbUser.serialize()).toMatch({
+          snaps_added: 4,
+          snaps_removed: 2,
+          names_registered: 2,
+          builds_requested: 8
+        });
+      });
+
+      it('should initialize metrics if unset', async () => {
+        await apiResponse;
+        const dbUser = await db.model('GitHubUser')
+          .where({ github_id: session.user.id })
+          .fetch();
+        expect(dbUser.serialize()).toMatch({
+          snaps_added: 2,
+          snaps_removed: 0,
+          names_registered: 1,
+          builds_requested: 4
         });
       });
 
@@ -494,6 +599,7 @@ describe('The Launchpad API endpoint', () => {
     context('when snaps are memcached', () => {
       const urlPrefix = 'https://github.com/anowner/';
       let testSnaps;
+      let lpApi;
 
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
@@ -504,13 +610,18 @@ describe('The Launchpad API endpoint', () => {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~another-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~another-user`,
-            git_repository_url: 'https://github.com/another-user/test-snap'
+            git_repository_url: 'https://github.com/another-user/test-snap',
+            builds_collection_link: `${lp_api_base}/~another-user/+snap/` +
+                                    'test-snap/builds',
+            store_name: 'snap1'
           },
           {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~test-user`,
-            git_repository_url: 'https://github.com/test-user/test-snap'
+            git_repository_url: 'https://github.com/test-user/test-snap',
+            builds_collection_link: `${lp_api_base}/~test-user/+snap/` +
+                                    'test-snap/builds'
           }
         ];
 
@@ -523,13 +634,32 @@ describe('The Launchpad API endpoint', () => {
           [getUrlPrefixCacheId(urlPrefix)]: testSnaps
         });
 
+        lpApi = nock(lp_api_url);
         testSnaps.map((snap) => {
           const cacheId = getSnapcraftYamlCacheId(snap.git_repository_url);
           getMemcached().cache[cacheId] = contents[snap.git_repository_url];
+          const builds_link = snap.builds_collection_link;
+          lpApi.get(builds_link.replace(lp_api_url, ''))
+            .optionally()
+            .reply(200, {
+              total_size: 2,
+              entries: [
+                {
+                  resource_type_link: `${lp_api_url}/devel/#snap_build`,
+                  self_link: `${builds_link.replace(/builds$/, '')}/+build/1`
+                },
+                {
+                  resource_type_link: `${lp_api_url}/devel/#snap_build`,
+                  self_link: `${builds_link.replace(/builds$/, '')}/+build/2`
+                }
+              ]
+            });
         });
       });
 
       afterEach(() => {
+        lpApi.done();
+        nock.cleanAll();
         resetMemcached();
       });
 
@@ -548,6 +678,39 @@ describe('The Launchpad API endpoint', () => {
         expect(responseSnaps.length).toEqual(testSnaps.length);
         expect(responseSnaps[0]).toContain(testSnaps[0]);
         expect(responseSnaps[1]).toContain(testSnaps[1]);
+      });
+
+      it('should leave metrics unmodified if already set', async () => {
+        const dbUser = await db.model('GitHubUser')
+          .where({ github_id: session.user.id })
+          .fetch();
+        await dbUser.save({
+          snaps_added: 4,
+          snaps_removed: 2,
+          names_registered: 2,
+          builds_requested: 8
+        });
+        await apiResponse;
+        await dbUser.refresh();
+        expect(dbUser.serialize()).toMatch({
+          snaps_added: 4,
+          snaps_removed: 2,
+          names_registered: 2,
+          builds_requested: 8
+        });
+      });
+
+      it('should initialize metrics if unset', async () => {
+        await apiResponse;
+        const dbUser = await db.model('GitHubUser')
+          .where({ github_id: session.user.id })
+          .fetch();
+        expect(dbUser.serialize()).toMatch({
+          snaps_added: 2,
+          snaps_removed: 0,
+          names_registered: 1,
+          builds_requested: 4
+        });
       });
 
     });
@@ -1252,7 +1415,7 @@ describe('The Launchpad API endpoint', () => {
     let api;
 
     context('when snap exists', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         nock(conf.get('GITHUB_API_ENDPOINT'))
           .get('/repos/anowner/aname')
           .reply(200, { permissions: { admin: true } });
@@ -1270,6 +1433,14 @@ describe('The Launchpad API endpoint', () => {
               self_link: `${lp_api_base}${lp_snap_path}/+build/2`
             }
           ]);
+        await db.model('GitHubUser').query('truncate').fetch();
+        await db.model('GitHubUser')
+          .forge({
+            github_id: session.user.id,
+            login: session.user.login,
+            last_login_at: new Date()
+          })
+          .save();
       });
 
       afterEach(() => {
@@ -1354,6 +1525,28 @@ describe('The Launchpad API endpoint', () => {
               done(err);
             });
         });
+
+        it('leaves builds_requested unmodified if it is unset', async () => {
+          await supertest(app)
+            .post('/launchpad/snaps/request-builds')
+            .send({ repository_url: 'https://github.com/anowner/aname' });
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          expect(dbUser.get('builds_requested')).toBeFalsy();
+        });
+
+        it('increments builds_requested if it is set', async () => {
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          await dbUser.save({ builds_requested: 2 });
+          await supertest(app)
+            .post('/launchpad/snaps/request-builds')
+            .send({ repository_url: 'https://github.com/anowner/aname' });
+          await dbUser.refresh();
+          expect(dbUser.get('builds_requested')).toEqual(4);
+        });
       });
 
       context('when auto_build is true', () => {
@@ -1427,6 +1620,28 @@ describe('The Launchpad API endpoint', () => {
               api.done();
               done(err);
             });
+        });
+
+        it('leaves builds_requested unmodified if it is unset', async () => {
+          await supertest(app)
+            .post('/launchpad/snaps/request-builds')
+            .send({ repository_url: 'https://github.com/anowner/aname' });
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          expect(dbUser.get('builds_requested')).toBeFalsy();
+        });
+
+        it('increments builds_requested if it is set', async () => {
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          await dbUser.save({ builds_requested: 2 });
+          await supertest(app)
+            .post('/launchpad/snaps/request-builds')
+            .send({ repository_url: 'https://github.com/anowner/aname' });
+          await dbUser.refresh();
+          expect(dbUser.get('builds_requested')).toEqual(4);
         });
       });
     });
@@ -1556,8 +1771,16 @@ describe('The Launchpad API endpoint', () => {
     const lp_snap_path = `/~${lp_snap_user}/+snap/test-snap`;
     const repositoryUrl = 'https://github.com/anowner/aname';
 
-    beforeEach(() => {
+    beforeEach(async () => {
       setupInMemoryMemcached();
+      await db.model('GitHubUser').query('truncate').fetch();
+      await db.model('GitHubUser')
+        .forge({
+          github_id: session.user.id,
+          login: session.user.login,
+          last_login_at: new Date()
+        })
+        .save();
     });
 
     afterEach(() => {
@@ -1639,6 +1862,28 @@ describe('The Launchpad API endpoint', () => {
             expect(getMemcached().cache).toExcludeKey(repoCacheId);
             done();
           });
+      });
+
+      it('leaves snaps_removed unmodified if it is unset', async () => {
+        await supertest(app)
+          .post('/launchpad/snaps/delete')
+          .send({ repository_url: repositoryUrl });
+        const dbUser = await db.model('GitHubUser')
+          .where({ github_id: session.user.id })
+          .fetch();
+        expect(dbUser.get('snaps_removed')).toBeFalsy();
+      });
+
+      it('increments snaps_removed if it is set', async () => {
+        const dbUser = await db.model('GitHubUser')
+          .where({ github_id: session.user.id })
+          .fetch();
+        await dbUser.save({ snaps_removed: 1 });
+        await supertest(app)
+          .post('/launchpad/snaps/delete')
+          .send({ repository_url: repositoryUrl });
+        await dbUser.refresh();
+        expect(dbUser.get('snaps_removed')).toEqual(2);
       });
     });
 
@@ -1828,6 +2073,18 @@ describe('The Launchpad API endpoint', () => {
           .send({ repository_url: repositoryUrl })
           .expect(hasMessage('snap-not-found'))
           .end(done);
+      });
+
+      it('leaves snaps_removed unmodified', async () => {
+        const dbUser = await db.model('GitHubUser')
+          .where({ github_id: session.user.id })
+          .fetch();
+        await dbUser.save({ snaps_removed: 1 });
+        await supertest(app)
+          .post('/launchpad/snaps/delete')
+          .send({ repository_url: repositoryUrl });
+        await dbUser.refresh();
+        expect(dbUser.get('snaps_removed')).toEqual(1);
       });
     });
   });

--- a/test/unit/src/server/metrics/t_developer-uptake.js
+++ b/test/unit/src/server/metrics/t_developer-uptake.js
@@ -1,0 +1,73 @@
+import expect from 'expect';
+import promClient from 'prom-client';
+
+import db from '../../../../../src/server/db';
+
+describe('The developer uptake metric', () => {
+  let updateDeveloperUptake;
+
+  const testUsers = {
+    0: {},
+    1: {
+      snaps_added: 1,
+      snaps_removed: 1
+    },
+    2: {
+      snaps_added: 2,
+      snaps_removed: 1,
+      names_registered: 1
+    },
+    3: {
+      snaps_added: 1,
+      names_registered: 1,
+      builds_requested: 1
+    }
+  };
+
+  beforeEach(async () => {
+    // Must be required here rather than imported, to make sure that it
+    // registers metrics when tests are run and clears them immediately
+    // afterwards.
+    updateDeveloperUptake = require('../../../../../src/server/metrics/developer-uptake').default;
+
+    await db.model('GitHubUser').query('truncate').fetch();
+  });
+
+  afterEach(() => {
+    promClient.register.clear();
+  });
+
+  it('returns reasonable developer uptake values', () => {
+    return db.transaction(async (trx) => {
+      for (let i = 0; i < 4; i++) {
+        await db.model('GitHubUser').forge({
+          github_id: i,
+          name: null,
+          login: `person-${i}`,
+          last_login_at: new Date()
+        }).save(testUsers[i], { transacting: trx });
+      }
+      await updateDeveloperUptake(trx);
+      const metricName = 'bsi_developer_uptake';
+      expect(promClient.register.getSingleMetric(metricName).get()).toEqual({
+        type: 'gauge',
+        name: metricName,
+        help: 'Number of developers who have reached various steps.',
+        values: [
+          {
+            labels: { metric_type: 'kpi', step: 'enabled_repository' },
+            value: 3
+          },
+          {
+            labels: { metric_type: 'kpi', step: 'registered_name' },
+            value: 2
+          },
+          {
+            labels: { metric_type: 'kpi', step: 'requested_build' },
+            value: 1
+          }
+        ]
+      });
+    });
+  });
+});


### PR DESCRIPTION
We now track developers adding/removing snaps, registering snap names,
and requesting builds, and emit aggregate metrics indicating how many
developers have reached various stages in the process.

Fixes #446.