### PR TITLE
Add the environment name as a metric label

### DIFF
--- a/charm/templates/snap-build_systemd.j2
+++ b/charm/templates/snap-build_systemd.j2
@@ -9,6 +9,7 @@ Type=simple
 {%- if base_url %}
 Environment='BASE_URL={{ base_url }}'
 {%- endif %}
+Environment='ENVIRONMENT={{ environment }}'
 Environment='SESSION_SECRET={{ session_secret }}'
 Environment='LOGS_PATH={{ logs_path }}'
 Environment='MEMCACHED_HOST={{ cache_hosts | join(",") }}'

--- a/environments/test.env
+++ b/environments/test.env
@@ -1,4 +1,5 @@
 NODE_ENV=test
+ENVIRONMENT=test
 
 BASE_URL=http://localhost:8000
 

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -4,6 +4,7 @@ export default {
   BASE_URL: 'http://localhost:8000',
   WEBPACK_DEV_URL: 'http://localhost:8001',
   NODE_ENV: 'development',
+  ENVIRONMENT: 'development',
   UBUNTU_SSO_URL: 'https://login.ubuntu.com',
   OPENID_VERIFY_URL: 'http://localhost:8000/login/verify',
   LP_API_URL: 'https://api.launchpad.net',

--- a/src/server/metrics/github-users.js
+++ b/src/server/metrics/github-users.js
@@ -1,16 +1,17 @@
 import promClient from 'prom-client';
 
 import db from '../db';
+import getDefaultLabels from './labels';
 
+const labels = getDefaultLabels();
 const gitHubUsersTotal = new promClient.Gauge(
   'bsi_github_users_total',
   'Total number of GitHub users who have ever logged in.',
-  ['metric_type']
+  Object.keys(labels)
 );
 
 export default async function updateGitHubUsersTotal(trx) {
   gitHubUsersTotal.set(
-    { metric_type: 'kpi' },
-    await db.model('GitHubUser').count('*', { transacting: trx })
+    labels, await db.model('GitHubUser').count('*', { transacting: trx })
   );
 }

--- a/src/server/metrics/labels.js
+++ b/src/server/metrics/labels.js
@@ -1,0 +1,5 @@
+import { conf } from '../helpers/config';
+
+export default function getDefaultLabels() {
+  return { environment: conf.get('ENVIRONMENT'), metric_type: 'kpi' };
+}

--- a/test/unit/src/server/metrics/t_github-users.js
+++ b/test/unit/src/server/metrics/t_github-users.js
@@ -36,7 +36,7 @@ describe('The GitHub users metric', () => {
         name: metricName,
         help: 'Total number of GitHub users who have ever logged in.',
         values: [{
-          labels: { metric_type: 'kpi' },
+          labels: { environment: 'test', metric_type: 'kpi' },
           value: 5
         }]
       });


### PR DESCRIPTION
This lets us select between staging and production in Grafana.
(Technically we can do this already due to automatically-applied labels,
but `instance="build.snapcraft.io:80"` is a terribly ugly way to go
about it; `environment="production"` is much nicer.)