### PR TITLE
Bump layer-ols-http to r9

### DIFF
--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -11,7 +11,7 @@ layer/layer-apt                     git+ssh://git.launchpad.net/layer-apt;revno=
 layer/layer-basic                   lp:~ubuntuone-hackers/ols-charm-deps/layer-basic;revno=62
 layer/layer-leadership              git+ssh://git.launchpad.net/layer-leadership;revno=8846afc
 layer/layer-ols                     lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols;revno=17
-layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=3
+layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=9
 layer/layer-ols-pg                  lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-pg;revno=4
 layer/layer-promreg-client          git+ssh://git.launchpad.net/~timkuhlman/prometheus-registration/+git/layer-promreg-client;revno=0f9f74b
 


### PR DESCRIPTION
The only effective difference here is to remove invalid characters from
the Nagios service description.  For the full diff, see:

  https://bazaar.launchpad.net/~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http/revision/9?compare_revid=3

I'm avoiding newer revisions for the time being since those will require
either a code change (to implement `/_status/check`) or a Mojo spec
change (to suppress the `httpchk` option).