### PR TITLE
Removes 'My repos' link from the header

### DIFF
--- a/src/common/components/header/index.js
+++ b/src/common/components/header/index.js
@@ -24,7 +24,6 @@ export default class Header extends Component {
                     Hi, {user.name || user.login}
                   </span>
                 }
-                <Link to={`/user/${user.login}`} className={ styles.link }>My repos</Link>
                 <a
                   className={ styles.link }
                   onClick={ this.onLogoutClick.bind(this) }

--- a/test/unit/src/common/components/header/t_header.js
+++ b/test/unit/src/common/components/header/t_header.js
@@ -17,10 +17,6 @@ describe('<Header />', function() {
       expect(element.findWhere(isLinkTo('/')).length).toBe(1);
     });
 
-    it('should not render my repos link', () => {
-      expect(element.findWhere(isLinkTo('/user/jdoe')).length).toBe(0);
-    });
-
     it('should render sign in link', () => {
       expect(element.find({ href: '/auth/authenticate' }).length).toBe(1);
     });
@@ -42,10 +38,6 @@ describe('<Header />', function() {
 
     it('should render user name', () => {
       expect(element.html().indexOf('Hi, Joe Doe')).toBeGreaterThan(0);
-    });
-
-    it('should render my repos link', () => {
-      expect(element.findWhere(isLinkTo('/user/jdoe')).length).toBe(1);
     });
 
     it('should render sign out link', () => {


### PR DESCRIPTION
A _partial_ fix for #318. The link in the header should no longer be necessary, because (thanks to #310) it is now present in the breadcrumbs on every other page.