### PR TITLE
Added spinner on 'Add' repository button

### DIFF
--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -14,7 +14,7 @@ import PageLinks from '../page-links';
 import Button, { LinkButton } from '../vanilla/button';
 import { HeadingThree } from '../vanilla/heading';
 import { fetchUserRepositories } from '../../actions/repositories';
-import { hasRepository } from '../../helpers/repositories';
+import { hasRepository, hasSnapForRepository } from '../../helpers/repositories';
 import { isAddingSnaps } from '../../selectors';
 
 import styles from './styles.css';
@@ -65,11 +65,12 @@ export class SelectRepositoryListComponent extends Component {
   }
 
   renderRepository(repo) {
+    const { repositoriesStatus, selectRepositoriesForm, snaps } = this.props;
     const { fullName } = repo;
-    const status = this.props.repositoriesStatus[fullName] || {};
+    const status = repositoriesStatus[fullName] || {};
 
-    const selected = this.props.isRepoSelected(repo);
-    const enabled = this.props.isRepoEnabled(repo);
+    const selected = hasRepository(selectRepositoriesForm.selectedRepos, repo);
+    const enabled = snaps.success && hasSnapForRepository(snaps.snaps, repo);
 
     return (
       <SelectRepositoryRow
@@ -169,8 +170,6 @@ SelectRepositoryListComponent.propTypes = {
   repositoriesStatus: PropTypes.object,
   selectRepositoriesForm: PropTypes.object,
   isAddingSnaps: PropTypes.bool,
-  isRepoSelected: PropTypes.func,
-  isRepoEnabled: PropTypes.func,
   onSelectRepository: PropTypes.func,
   router: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
@@ -191,15 +190,7 @@ function mapStateToProps(state) {
     repositories,
     repositoriesStatus,
     selectRepositoriesForm,
-    isAddingSnaps: isAddingSnaps(state),
-    isRepoSelected: (repo) => hasRepository(selectRepositoriesForm.selectedRepos, repo),
-    isRepoEnabled: (repo) => {
-      const { success, snaps } = state.snaps;
-      if (success && snaps.length) {
-        return snaps.some((snap) => snap.git_repository_url === repo.url);
-      }
-      return false;
-    }
+    isAddingSnaps: isAddingSnaps(state)
   };
 }
 

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -15,6 +15,8 @@ import Button, { LinkButton } from '../vanilla/button';
 import { HeadingThree } from '../vanilla/heading';
 import { fetchUserRepositories } from '../../actions/repositories';
 import { hasRepository } from '../../helpers/repositories';
+import { isAddingSnaps } from '../../selectors';
+
 import styles from './styles.css';
 
 // loading container styles not to duplicate .spinner class
@@ -63,20 +65,22 @@ export class SelectRepositoryListComponent extends Component {
   }
 
   renderRepository(repo) {
-    const { fullName, enabled } = repo;
+    const { fullName } = repo;
     const status = this.props.repositoriesStatus[fullName] || {};
-    const { selectedRepos } = this.props.selectRepositoriesForm;
+
+    const selected = this.props.isRepoSelected(repo);
+    const enabled = this.props.isRepoEnabled(repo);
 
     return (
       <SelectRepositoryRow
         key={ `repo_${repo.fullName}` }
         repository={ repo }
-        buttonLabel={ status.isFetching ? 'Creating...' : 'Create' }
-        buttonDisabled={ status.isFetching }
         onChange={ this.onSelectRepository.bind(this, repo) }
         errorMsg= { this.getErrorMessage(status.error) }
-        checked={ hasRepository(selectedRepos, repo) }
-        isEnabled={ enabled }
+        // row is checked if repo is already enabled or selected by user
+        checked={ selected || enabled }
+        // input is disabled when repo is already enabled or snaps are being added
+        disabled={ enabled || this.props.isAddingSnaps }
       />
     );
   }
@@ -96,40 +100,20 @@ export class SelectRepositoryListComponent extends Component {
     this.props.dispatch(fetchUserRepositories(pageNumber));
   }
 
-  filterEnabledRepos(repositories) {
-    const { success, snaps } = this.props.snaps;
-
-    if (success && snaps.length) {
-      for (let i = repositories.length; i--;) {
-        for (let j = snaps.length; j--;) {
-          const enabledRepo = snaps[j].git_repository_url;
-
-          if (enabledRepo === repositories[i].url) {
-            repositories[i].enabled = true;
-            break;
-          } else {
-            repositories[i].enabled = false;
-          }
-        }
-      }
-    }
-
-    return repositories;
-  }
-
   render() {
-    const { user } = this.props;
+    const { user, isAddingSnaps } = this.props;
     const isLoading = this.props.repositories.isFetching;
     const { selectedRepos } = this.props.selectRepositoriesForm;
     const { repos, success } = this.props.repositories;
     const pageLinks = this.renderPageLinks.call(this);
 
-    this.filterEnabledRepos(repos);
     let renderedRepos = null;
 
     if (success) {
       renderedRepos = this.props.repositories.repos.map(this.renderRepository.bind(this));
     }
+
+    const buttonSpinner = isLoading || isAddingSnaps;
 
     return (
       <div>
@@ -153,8 +137,9 @@ export class SelectRepositoryListComponent extends Component {
             <div className={ styles['button-wrapper'] }>
               <Button
                 appearance={ 'positive' }
-                disabled={ !selectedRepos.length }
+                disabled={ !selectedRepos.length || buttonSpinner }
                 onClick={ this.onSubmit.bind(this) }
+                isSpinner={buttonSpinner}
               >
                 Add
               </Button>
@@ -183,6 +168,9 @@ SelectRepositoryListComponent.propTypes = {
   repositories: PropTypes.object,
   repositoriesStatus: PropTypes.object,
   selectRepositoriesForm: PropTypes.object,
+  isAddingSnaps: PropTypes.bool,
+  isRepoSelected: PropTypes.func,
+  isRepoEnabled: PropTypes.func,
   onSelectRepository: PropTypes.func,
   router: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
@@ -202,7 +190,16 @@ function mapStateToProps(state) {
     snaps,
     repositories,
     repositoriesStatus,
-    selectRepositoriesForm
+    selectRepositoriesForm,
+    isAddingSnaps: isAddingSnaps(state),
+    isRepoSelected: (repo) => hasRepository(selectRepositoriesForm.selectedRepos, repo),
+    isRepoEnabled: (repo) => {
+      const { success, snaps } = state.snaps;
+      if (success && snaps.length) {
+        return snaps.some((snap) => snap.git_repository_url === repo.url);
+      }
+      return false;
+    }
   };
 }
 

--- a/src/common/components/select-repository-row/index.js
+++ b/src/common/components/select-repository-row/index.js
@@ -10,13 +10,13 @@ class SelectRepositoryRow extends Component {
       repository,
       onChange,
       checked,
-      isEnabled
+      disabled
     } = this.props;
 
     const rowClass = classNames({
       [styles.repositoryRow]: true,
       [styles.error]: errorMsg,
-      [styles.repositoryEnabled]: isEnabled
+      [styles.disabled]: disabled
     });
 
     return (
@@ -26,8 +26,8 @@ class SelectRepositoryRow extends Component {
             id={ repository.fullName }
             type="checkbox"
             onChange={ this.onChange.bind(this) }
-            checked={ checked || isEnabled }
-            disabled={ isEnabled }
+            checked={ checked }
+            disabled={ disabled }
           />
         }
         <div>
@@ -48,8 +48,7 @@ class SelectRepositoryRow extends Component {
 }
 
 SelectRepositoryRow.defaultProps = {
-  checked: false,
-  isEnabled: false
+  checked: false
 };
 
 SelectRepositoryRow.propTypes = {
@@ -58,7 +57,7 @@ SelectRepositoryRow.propTypes = {
     fullName: PropTypes.string.isRequired
   }).isRequired,
   checked: PropTypes.bool,
-  isEnabled: PropTypes.bool,
+  disabled: PropTypes.bool,
   onChange: PropTypes.func
 };
 

--- a/src/common/components/select-repository-row/selectRepositoryRow.css
+++ b/src/common/components/select-repository-row/selectRepositoryRow.css
@@ -32,7 +32,7 @@ $error-color: $error;
   background-color: $error-color;
 }
 
-.repositoryEnabled {
+.disabled {
   opacity: 0.5;
 }
 

--- a/src/common/helpers/repositories.js
+++ b/src/common/helpers/repositories.js
@@ -1,5 +1,7 @@
 export function hasRepository(arr, repository) {
-  return arr.filter((item) => {
-    return (item.fullName === repository.fullName);
-  }).length > 0;
+  return arr.some((item) => item.fullName === repository.fullName);
+}
+
+export function hasSnapForRepository(snaps, repository) {
+  return snaps.some((snap) => snap.git_repository_url === repository.url);
 }

--- a/src/common/selectors/index.js
+++ b/src/common/selectors/index.js
@@ -4,6 +4,7 @@ import { parseGitHubRepoUrl } from '../helpers/github-url';
 
 const getSnaps = state => state.snaps;
 const getSnapBuilds = state => state.snapBuilds;
+const getRepositoriesStatus = state => state.repositoriesStatus;
 
 /**
  * @returns {Boolean} true if there are any snaps in state
@@ -85,5 +86,16 @@ export const snapsWithNoBuilds = createSelector(
       }
       return false;
     });
+  }
+);
+
+/**
+ * @returns {Boolean} true if any snap create request is still fetching
+ */
+export const isAddingSnaps = createSelector(
+  [getRepositoriesStatus],
+  (repositoriesStatus) => {
+    const ids = Object.keys(repositoriesStatus);
+    return !!(ids.length && ids.some((id) => repositoriesStatus[id].isFetching));
   }
 );

--- a/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
+++ b/test/unit/src/common/components/select-repository-list/t_select-repository-list.js
@@ -69,42 +69,13 @@ describe('<SelectRepositoryListComponent /> instance', function() {
       wrapper = shallow(<SelectRepositoryListComponent { ...props } />);
     });
 
-    it('should disable Add button', function() {
-      expect(wrapper.find('Button').prop('disabled')).toBe(false);
+    it('should not disable Add button', function() {
+      expect(wrapper.find('Button').prop('disabled')).toNotBe(true);
     });
 
-    it('should show message about 0 selected repos', function() {
+    it('should show message about 1 selected repo', function() {
       expect(wrapper.html()).toInclude('1 selected');
     });
   });
 
-  context('when user has some snaps', function() {});
-
-  context('filterEnabledRepos', function() {
-    let instance;
-
-    beforeEach(function() {
-      props.snaps = {
-        success: true,
-        snaps: [{
-          git_repository_url: 'foo/bar'
-        }]
-      };
-
-      instance = shallow(<SelectRepositoryListComponent { ...props } />).instance();
-    });
-
-    it('should flag matching repos as enabled', function() {
-      expect(instance.filterEnabledRepos(props.repositories.repos)[0].enabled).toBe(true);
-    });
-
-    it('should flag non matching repos as not enabled', function() {
-      expect(instance.filterEnabledRepos(props.repositories.repos)[1].enabled).toBe(false);
-    });
-
-    it('should reset the enabled flags if we change the snaps list', function() {
-      props.snaps.snaps[0].git_repository_url = 'bar/baz';
-      expect(instance.filterEnabledRepos(props.repositories.repos)[0].enabled).toBe(false);
-    });
-  });
 });

--- a/test/unit/src/common/components/select-repository-row/t_select-repository-row.js
+++ b/test/unit/src/common/components/select-repository-row/t_select-repository-row.js
@@ -77,19 +77,14 @@ describe('The SelectRepositoryRow component', () => {
         });
       });
 
-      context('and the isEnabled prop is "true"', () => {
+      context('and the disabled prop is "true"', () => {
         beforeEach(() => {
-          props.isEnabled = true;
+          props.disabled = true;
         });
 
         it('should contain a disabled checkbox', () => {
           const component = shallow(<SelectRepositoryRow { ...props } />);
           expect(component.find('input[disabled=true]').length).toBe(1);
-        });
-
-        it('should contain a checked checkbox', () => {
-          const component = shallow(<SelectRepositoryRow { ...props } />);
-          expect(component.find('input[checked=true]').length).toBe(1);
         });
       });
     });

--- a/test/unit/src/common/selectors/t_selectors.js
+++ b/test/unit/src/common/selectors/t_selectors.js
@@ -6,7 +6,8 @@ import {
   hasNoRegisteredNames,
   snapsWithRegisteredNameAndSnapcraftData,
   snapsWithRegisteredNameAndNoSnapcraftData,
-  snapsWithNoBuilds
+  snapsWithNoBuilds,
+  isAddingSnaps
 } from '../../../../../src/common/selectors';
 
 describe('selectors', function() {
@@ -178,6 +179,46 @@ describe('selectors', function() {
         snapcraft_data: { name: 'bsi-test-iii' }
       });
     });
+  });
+
+  context('isAddingSnaps', function() {
+    const stateNoRepos = {
+      repositoriesStatus: {}
+    };
+
+    const stateNotFetching = {
+      repositoriesStatus: {
+        'foo/bar': {
+          isFetching: false,
+          error: null,
+          success: false
+        }
+      }
+    };
+
+    const stateFetching = {
+      repositoriesStatus: {
+        'foo/bar': {
+          isFetching: true,
+          error: null,
+          success: false
+        }
+      }
+    };
+
+    it('should be false when no repo have status', function() {
+      expect(isAddingSnaps(stateNoRepos)).toBe(false);
+    });
+
+    it('should be false when no snaps are being created', function() {
+      expect(isAddingSnaps(stateNotFetching)).toBe(false);
+    });
+
+    it('should be true if any snap is currently fetching', function() {
+      expect(isAddingSnaps(stateFetching)).toBe(true);
+    });
+
+
   });
 
 });


### PR DESCRIPTION
Fixes #313 

Adding spinner to 'Add' repository button and disabling whole repositories form while waiting for response.

> https://docs.google.com/document/d/1koTwI3cRr2S2vj5zHKKbR7aWxLRfShDVq2gHQ29cDyU/edit#heading=h.43owh6tjv12q: “When you choose ‘Add’, everything in the dialog should become disabled, and the text of the ‘Add’ button should change to a spinner.”