### PR TITLE
Add instance option for LP credentials

### DIFF
--- a/scripts/create-launchpad-credentials
+++ b/scripts/create-launchpad-credentials
@@ -43,7 +43,10 @@ class AuthorizeRequestTokenRemotely(RequestTokenAuthorizationEngine):
 def main():
     parser = ArgumentParser()
     parser.add_argument(
-        "-l", "--launchpad", dest="launchpad_instance", default="production")
+        "-l", "--launchpad", dest="launchpad_instance", default="production",
+        help=(
+            "Launchpad instance (production, staging, qastaging, dogfood, "
+            "dev, or a URI); defaults to production"))
     args = parser.parse_args()
 
     service_root = lookup_service_root(args.launchpad_instance)

--- a/scripts/create-launchpad-credentials
+++ b/scripts/create-launchpad-credentials
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+from argparse import ArgumentParser
 import sys
 
 from launchpadlib.credentials import (
@@ -9,6 +10,7 @@ from launchpadlib.credentials import (
     RequestTokenAuthorizationEngine,
     )
 from launchpadlib.launchpad import Launchpad
+from launchpadlib.uris import lookup_service_root
 
 
 class MemoryCredentialStore(CredentialStore):
@@ -39,19 +41,25 @@ class AuthorizeRequestTokenRemotely(RequestTokenAuthorizationEngine):
 
 
 def main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-l", "--launchpad", dest="launchpad_instance", default="production")
+    args = parser.parse_args()
+
+    service_root = lookup_service_root(args.launchpad_instance)
     store = MemoryCredentialStore()
     authorization_engine = AuthorizeRequestTokenRemotely(
-        "production", consumer_name="build.snapcraft.io development",
+        service_root, consumer_name="build.snapcraft.io development",
         allow_access_levels=["WRITE_PRIVATE"])
     lp = Launchpad.login_with(
-        service_root="production",
-        authorization_engine=authorization_engine,
+        service_root=service_root, authorization_engine=authorization_engine,
         credential_store=store)
     creds = store.store.values()[0]
     print("Now set the following values in environments/development.env, and "
           "make sure to keep them private (including 'chmod 600') as they "
           "allow full access to your Launchpad account:")
     print()
+    print("LP_API_URL={}".format(service_root.rstrip("/")))
     print("LP_API_USERNAME={}".format(lp.me.name))
     print("LP_API_CONSUMER_KEY='{}'".format(creds.consumer.key))
     print("LP_API_TOKEN={}".format(creds.access_token.key))


### PR DESCRIPTION
BSI can be usefully configured locally to point to Launchpad instances
other than production for the purpose of testing various things: staging
mostly works (modulo a snap-proxy problem that'll be fixed soon),
dogfood works, and it's even possible to use a local development
instance.  To make such things easier, add a `--launchpad` option to
`scripts/create-launchpad-credentials`.

Production is still the right choice for BSI staging for the moment,
since Launchpad staging is reset weekly and would require some
reconfiguration to preserve BSI credentials across the reset, but it may
be worth looking into that in future.