### PR TITLE
495: CSRF tokens

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -832,6 +832,9 @@
     "node-fetch": {
       "version": "1.6.3"
     },
+    "node-uuid": {
+      "version": "1.4.8"
+    },
     "normalize-package-data": {
       "version": "2.3.5"
     },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "macaroons.js": "^0.3.6",
     "memcached": "^2.2.2",
     "moment": "^2.17.1",
+    "node-uuid": "^1.4.8",
     "normalize.css": "^5.0.0",
     "oauth": "^0.9.14",
     "openid": "^2.0.6",

--- a/src/common/actions/snaps.js
+++ b/src/common/actions/snaps.js
@@ -1,9 +1,6 @@
 import 'isomorphic-fetch';
 
-import { checkStatus, getError } from '../helpers/api';
-import { conf } from '../helpers/config';
-
-const BASE_URL = conf.get('BASE_URL');
+import { CALL_API } from '../middleware/call-api';
 
 export const FETCH_SNAPS = 'FETCH_SNAP_REPOSITORIES';
 export const FETCH_SNAPS_SUCCESS = 'FETCH_SNAPS_SUCCESS';
@@ -14,42 +11,19 @@ export const REMOVE_SNAP_ERROR = 'REMOVE_SNAP_ERROR';
 
 export function fetchUserSnaps(owner) {
   return async (dispatch) => {
-    const url = `${BASE_URL}/api/launchpad/snaps/list`;
     const query = `owner=${encodeURIComponent(owner)}`;
 
     dispatch({
-      type: FETCH_SNAPS
-    });
-
-    try {
-      const response = await fetch(`${url}?${query}`, {
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin'
-      });
-      await checkStatus(response);
-      const result = await response.json();
-      if (result.status !== 'success') {
-        throw getError(response, result);
+      type: FETCH_SNAPS,
+      [CALL_API]: {
+        types: [ FETCH_SNAPS_SUCCESS, FETCH_SNAPS_ERROR ],
+        path: `/api/launchpad/snaps/list?${query}`,
+        options: {
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin'
+        }
       }
-      dispatch(fetchSnapsSuccess(result.payload.snaps));
-    } catch (error) {
-      dispatch(fetchSnapsError(error));
-    }
-  };
-}
-
-export function fetchSnapsSuccess(snaps) {
-  return {
-    type: FETCH_SNAPS_SUCCESS,
-    payload: snaps
-  };
-}
-
-export function fetchSnapsError(error) {
-  return {
-    type: FETCH_SNAPS_ERROR,
-    payload: error,
-    error: true
+    });
   };
 }
 
@@ -57,42 +31,17 @@ export function removeSnap(repositoryUrl) {
   return async (dispatch) => {
     dispatch({
       type: REMOVE_SNAP,
-      payload: { repository_url: repositoryUrl }
-    });
-
-    try {
-      const response = await fetch(`${BASE_URL}/api/launchpad/snaps/delete`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ repository_url: repositoryUrl }),
-        credentials: 'same-origin'
-      });
-      await checkStatus(response);
-      const result = await response.json();
-      if (result.status !== 'success') {
-        throw getError(response, result);
+      payload: { repository_url: repositoryUrl },
+      [ CALL_API ]: {
+        types: [ REMOVE_SNAP_SUCCESS, REMOVE_SNAP_ERROR ],
+        path: '/api/launchpad/snaps/delete',
+        options: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ repository_url: repositoryUrl }),
+          credentials: 'same-origin'
+        }
       }
-      dispatch(removeSnapSuccess(repositoryUrl));
-    } catch (error) {
-      dispatch(removeSnapError(repositoryUrl, error));
-    }
-  };
-}
-
-export function removeSnapSuccess(repositoryUrl) {
-  return {
-    type: REMOVE_SNAP_SUCCESS,
-    payload: { repository_url: repositoryUrl }
-  };
-}
-
-export function removeSnapError(repositoryUrl, error) {
-  return {
-    type: REMOVE_SNAP_ERROR,
-    payload: {
-      repository_url: repositoryUrl,
-      error
-    },
-    error: true
+    });
   };
 }

--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -1,0 +1,96 @@
+import { checkStatus, getError } from '../helpers/api';
+
+// Action key that carries API call info interpreted by this Redux middleware.
+export const CALL_API = 'CALL_API';
+
+// A Redux middleware that interprets actions with CALL_API info specified.
+// Performs the call and promises when such actions are dispatched.
+export default defaults => () => next => async action => {
+  // If action does not invoke CALL_API,
+  // ignore it
+  const settings = action[CALL_API];
+  if (typeof settings === 'undefined') {
+    return next(action);
+  }
+
+  // Validate action settings
+  validateDefaults(defaults);
+  validateSettings(settings);
+
+  const [ successType, failureType ] = settings.types;
+  const resource = defaults.endpoint + settings.path;
+  const optionsWithCsrfToken = withCsrfToken(defaults.csrfToken, settings.options);
+  const createAction = createActionWith.bind({}, action);
+
+  try {
+    const response = await fetch(resource, optionsWithCsrfToken);
+    await checkStatus(response);
+    const result = await response.json();
+
+    if (result.status !== 'success') {
+      throw getError(response, result);
+    }
+
+    return next(createAction({
+      type: successType,
+      payload: result.payload
+    }));
+  }
+  catch(error) {
+    return next(createAction({
+      type: failureType,
+      payload: error,
+      error: true
+    }));
+  }
+};
+
+// Creates new action with request, success or
+// failure types, corresponding with the stages
+// of the request cycle.
+function createActionWith(action, data) {
+  const finalAction = Object.assign({}, action, data);
+  // Remove properties invoke CALL_API
+  delete finalAction[CALL_API];
+
+  return finalAction;
+}
+
+function validateDefaults({ endpoint, csrfToken }) {
+  if (typeof endpoint !== 'string') {
+    throw new Error('Specify a string endpoint URL.');
+  }
+  if (csrfToken && typeof csrfToken !== 'string') {
+    throw new Error('Expected csrfToken to be a string');
+  }
+}
+
+function validateSettings(settings) {
+  const { path, options, types } = settings;
+  if (typeof path !== 'string') {
+    throw new Error('Specify a string path.');
+  }
+  if (!options) {
+    throw new Error('Specify settings for API request');
+  }
+  if (!Array.isArray(types) || types.length !== 2) {
+    throw new Error('Expected an array of three action types.');
+  }
+  if (!types.every(type => typeof type === 'string')) {
+    throw new Error('Expected action types to be strings.');
+  }
+}
+
+function withCsrfToken(csrfToken, options) {
+  if (csrfToken) {
+    if (!options.headers) {
+      options.headers = {};
+    }
+
+    options.headers = Object.assign({}, options.headers, {
+      'X-CSRF-Token': csrfToken
+    });
+  }
+
+  return options;
+}

--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -45,7 +45,7 @@ export function snaps(state = {
         isFetching: false,
         success: true,
         snaps: [
-          ...action.payload
+          ...action.payload.snaps
         ],
         error: null
       };
@@ -64,7 +64,17 @@ export function snaps(state = {
     case ActionTypes.REMOVE_SNAP:
       return {
         ...state,
-        isFetching: true
+        isFetching: true,
+        snaps: (
+          state.snaps !== null ?
+          state.snaps.map((snap) => {
+            if (snap.git_repository_url === action.payload.repository_url) {
+              snap.__FOR_REMOVAL__ = true;
+            }
+
+            return snap;
+          }) : null
+        )
       };
     case ActionTypes.REMOVE_SNAP_SUCCESS:
       return {
@@ -74,7 +84,7 @@ export function snaps(state = {
         snaps: (
           state.snaps !== null ?
           state.snaps.filter((snap) => {
-            return snap.git_repository_url !== action.payload.repository_url;
+            return !snap.__FOR_REMOVAL__;
           }) : null
         ),
         error: null
@@ -84,7 +94,17 @@ export function snaps(state = {
         ...state,
         isFetching: false,
         success: false,
-        error: action.payload.error
+        error: action.payload,
+        snaps: (
+          state.snaps !== null ?
+          state.snaps.map((snap) => {
+            if (snap.__FOR_REMOVAL__) {
+              delete snap.__FOR_REMOVAL__;
+            }
+
+            return snap;
+          }) : null
+        )
       };
     default:
       return state;

--- a/src/common/store/configureStore.js
+++ b/src/common/store/configureStore.js
@@ -2,10 +2,13 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import { routerMiddleware } from 'react-router-redux';
 import { browserHistory } from 'react-router';
 import thunk from 'redux-thunk';
+
 import rootReducer from '../reducers';
 import { analytics } from '../middleware';
+import callApi from '../middleware/call-api';
+import { conf } from '../helpers/config';
 
-export default function configureStore(preloadedState) {
+export default function configureStore(preloadedState, csrfToken) {
   const store = createStore(
     rootReducer,
     preloadedState,
@@ -13,7 +16,11 @@ export default function configureStore(preloadedState) {
       applyMiddleware(
         analytics,
         thunk,
-        routerMiddleware(browserHistory)
+        routerMiddleware(browserHistory),
+        callApi({
+          endpoint: conf.get('BASE_URL'),
+          csrfToken: csrfToken
+        })
       ),
       typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f
     )

--- a/src/common/store/index.js
+++ b/src/common/store/index.js
@@ -1,6 +1,7 @@
 import configureStore from './configureStore';
 
 const preloadedState = window.__PRELOADED_STATE__;
-const store = configureStore(preloadedState);
+const csrfToken = window.__CSRF_TOKEN__;
+const store = configureStore(preloadedState, csrfToken);
 
 export default store;

--- a/src/server/handlers/universal.js
+++ b/src/server/handlers/universal.js
@@ -44,6 +44,10 @@ export const handleMatch = (req, res, error, redirectLocation, renderProps) => {
       initialState.user = req.session.user;
     }
 
+    const csrfToken = req.session.csrfTokens
+      ? req.session.csrfTokens[req.session.csrfTokens.length - 1]
+      : null;
+
     if (req.session.error) {
       initialState['authError'] = { message: req.session.error };
       delete req.session.error;
@@ -82,6 +86,7 @@ export const handleMatch = (req, res, error, redirectLocation, renderProps) => {
           component={ component }
           config={ getClientConfig(conf) }
           assets={ assets }
+          csrfToken={ csrfToken }
         />
       ));
   } else {

--- a/src/server/helpers/html.js
+++ b/src/server/helpers/html.js
@@ -32,7 +32,7 @@ const googleTagManagerNoScript = GAID ?
 
 export default class Html extends Component {
   render() {
-    const { assets, store, component, config } = this.props;
+    const { assets, store, component, config, csrfToken } = this.props;
     const preloadedState = store.getState();
     const content = component ? this.renderComponent(component, store) : '';
 
@@ -65,6 +65,9 @@ export default class Html extends Component {
             dangerouslySetInnerHTML={{ __html: `window.__CONFIG__ = ${JSON.stringify(config)}` }}
           />
           <script
+            dangerouslySetInnerHTML={{ __html: `window.__CSRF_TOKEN__ = ${JSON.stringify(csrfToken)}` }}
+          />
+          <script
             dangerouslySetInnerHTML={{ __html: `window.__PRELOADED_STATE__ = ${JSON.stringify(preloadedState)}` }}
           />
           <script src={ assets.main.js } />
@@ -86,6 +89,7 @@ Html.propTypes = {
   config: PropTypes.object,
   component: PropTypes.node,
   store: PropTypes.object,
+  csrfToken: PropTypes.string,
   assets: PropTypes.shape({
     main: PropTypes.shape({
       js: PropTypes.string,

--- a/src/server/middleware/csrf-token.js
+++ b/src/server/middleware/csrf-token.js
@@ -1,0 +1,67 @@
+import uuid from 'node-uuid';
+
+export const generateToken = (req, res, next) => {
+  // Don't generate new tokens for API calls
+  if (req.path.match(/^\/api/)) {
+    return next();
+  }
+
+  // TODO: Remove debug
+  const csrfToken = uuid.v4();
+  if (typeof req.session.csrfTokens === 'undefined') {
+    req.session.csrfTokens = [];
+  }
+
+  req.session.csrfTokens.push(csrfToken);
+
+  // Only 5 valid CSRF tokens at a time. Safe to increase number.
+  while (req.session.csrfTokens.length > 5) {
+    req.session.csrfTokens.shift();
+  }
+
+  next();
+};
+
+export const verifyToken = (req, res, next) => {
+  const csrfToken = req.get('X-CSRF-Token');
+
+  if (!csrfToken) {
+    return res.status(401).json(RESPONSE_MISSING_TOKEN);
+  }
+
+  if (!req.session.csrfTokens) {
+    req.session.csrfTokens = [];
+
+    return res.status(401).json(RESPONSE_SESSION_HAS_NO_TOKENS);
+  }
+
+  if (req.session.csrfTokens.indexOf(csrfToken) == -1) {
+    return res.status(401).json(RESPONSE_INVALID_TOKEN);
+  }
+
+  next();
+};
+
+const RESPONSE_SESSION_HAS_NO_TOKENS = {
+  status: 'error',
+  body: {
+    code: 'session-has-no-tokens',
+    message: 'No valid CSRF tokens found in session'
+  }
+};
+
+const RESPONSE_MISSING_TOKEN = {
+  status: 'error',
+  body: {
+    code: 'request-missing-token',
+    message: 'No CSRF token header sent'
+  }
+};
+
+const RESPONSE_INVALID_TOKEN = {
+  status: 'error',
+  body: {
+    code: 'token-not-valid',
+    message: 'CSRF token not valid'
+  }
+};

--- a/src/server/routes/launchpad.js
+++ b/src/server/routes/launchpad.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { json } from 'body-parser';
+import { verifyToken } from '../middleware/csrf-token';
 
 import {
   authorizeSnap,
@@ -20,6 +21,7 @@ router.get('/launchpad/snaps', findSnap);
 router.use('/launchpad/snaps/list', json());
 router.get('/launchpad/snaps/list', findSnaps);
 
+
 router.use('/launchpad/snaps/authorize', json());
 router.post('/launchpad/snaps/authorize', authorizeSnap);
 
@@ -31,6 +33,7 @@ router.post('/launchpad/snaps/request-builds', requestSnapBuilds);
 
 // XXX cjwatson 2017-02-28: This would be more RESTful if we defined an API
 // URL for each snap and then just made this a DELETE.
+router.use('/launchpad/snaps/delete', verifyToken);
 router.use('/launchpad/snaps/delete', json());
 router.post('/launchpad/snaps/delete', deleteSnap);
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -15,6 +15,7 @@ import sessionConfig from './helpers/session';
 import logging from './logging';
 import setRevisionHeader from './middleware/set-revision-header';
 import trustedNetworks from './middleware/trusted-networks';
+import { generateToken } from './middleware/csrf-token';
 
 const appUrl = url.parse(conf.get('BASE_URL'));
 const app = Express();
@@ -57,6 +58,7 @@ app.use(metricsBundle);
 // routes
 app.use('/metrics', trustedNetworks, metricsBundle.metricsMiddleware);
 app.use('/', routes.login);
+app.use(generateToken);
 app.use('/api', routes.github);
 app.use('/api', routes.launchpad);
 app.use('/api', routes.store);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,8 @@
 import expect from 'expect';
 import proxyquire from 'proxyquire';
 import { Map } from 'immutable';
+import { EOL } from 'os';
+import { inspect } from 'util';
 
 // Custom assertions
 expect.extend({
@@ -25,6 +27,18 @@ expect.extend({
       }).length === 0,
       'Expected dispatched actions not to have action %s',
       expected
+    );
+
+    return this;
+  }
+});
+
+expect.extend({
+  toHaveActionsMatching(predicate) {
+    expect.assert(
+      this.actual.filter(predicate).length > 0,
+      `Expected dispatched actions to have action matching supplied predicate.${EOL}
+       Actual: ${inspect(this.actual, { depth: 3 })}`
     );
 
     return this;

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -19,7 +19,7 @@ import { conf } from '../../../../../src/server/helpers/config.js';
 
 describe('The Launchpad API endpoint', () => {
   const app = Express();
-  const session = { token: 'secret', user: { id: 123, login: 'anowner' } };
+  const session = { token: 'secret', user: { id: 123, login: 'anowner' }, 'csrfTokens': ['blah'] };
   app.use((req, res, next) => {
     req.session = session;
     next();
@@ -1904,6 +1904,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns a 200 response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(200, done);
       });
@@ -1911,6 +1912,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns a "success" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasStatus('success'))
           .end(done);
@@ -1919,6 +1921,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns body with a "snap-deleted" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasMessage('snap-deleted'))
           .end(done);
@@ -1927,6 +1930,7 @@ describe('The Launchpad API endpoint', () => {
       it('removes stale entries from memcached', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .end((err) => {
             if (err) {
@@ -1957,6 +1961,7 @@ describe('The Launchpad API endpoint', () => {
         await dbUser.save({ snaps_removed: 1 });
         await supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl });
         await dbUser.refresh();
         expect(dbUser.get('snaps_removed')).toEqual(2);
@@ -1996,6 +2001,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns a 200 response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(200, done);
       });
@@ -2003,6 +2009,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns a "success" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasStatus('success'))
           .end(done);
@@ -2011,6 +2018,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns body with a "snap-deleted" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasMessage('snap-deleted'))
           .end(done);
@@ -2019,6 +2027,7 @@ describe('The Launchpad API endpoint', () => {
       it('removes stale entries from memcached', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .end((err) => {
             if (err) {
@@ -2063,6 +2072,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasMessage('github-no-admin-permissions'))
           .end(done);
@@ -2083,6 +2093,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 Not Found response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(404, done);
       });
@@ -2099,6 +2110,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasMessage('github-snapcraft-yaml-not-found'))
           .end(done);
@@ -2131,6 +2143,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns a 404 response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(404, done);
       });
@@ -2138,6 +2151,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns an "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasStatus('error'))
           .end(done);
@@ -2146,6 +2160,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns body with a "snap-not-found" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/delete')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: repositoryUrl })
           .expect(hasMessage('snap-not-found'))
           .end(done);

--- a/test/unit/src/common/actions/t_snaps.js
+++ b/test/unit/src/common/actions/t_snaps.js
@@ -1,20 +1,13 @@
 import expect from 'expect';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import nock from 'nock';
-import { isFSA } from 'flux-standard-action';
-
-import { conf } from '../../../../../src/server/helpers/config';
 
 import {
   fetchUserSnaps,
-  fetchSnapsSuccess,
-  fetchSnapsError,
-  removeSnap,
-  removeSnapSuccess,
-  removeSnapError
+  removeSnap
 } from '../../../../../src/common/actions/snaps';
 import * as ActionTypes from '../../../../../src/common/actions/snaps';
+import { CALL_API } from '../../../../../src/common/middleware/call-api';
 
 const middlewares = [ thunk ];
 const mockStore = configureMockStore(middlewares);
@@ -28,203 +21,42 @@ describe('repositories actions', () => {
   };
 
   let store;
-  let action;
 
   beforeEach(() => {
     store = mockStore(initialState);
   });
 
-  context('fetchSnapsSuccess', () => {
-    let payload = [ { full_name: 'test1' }, { full_name: 'test2' }];
-
-    beforeEach(() => {
-      action = fetchSnapsSuccess(payload);
-    });
-
-    it('should create an action to store snaps', () => {
-      const expectedAction = {
-        type: ActionTypes.FETCH_SNAPS_SUCCESS,
-        payload
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('should create a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
-  });
-
-  context('fetchSnapsError', () => {
-    let payload = 'Something went wrong!';
-
-    beforeEach(() => {
-      action = fetchSnapsError(payload);
-    });
-
-    it('should create an action to store request error on failure', () => {
-      const expectedAction = {
-        type: ActionTypes.FETCH_SNAPS_ERROR,
-        error: true,
-        payload
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('should create a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
-  });
-
   context('fetchUserSnaps', () => {
-    let api;
-
-    beforeEach(() => {
-      api = nock(conf.get('BASE_URL'));
-    });
-
-    afterEach(() => {
-      api.done();
-      nock.cleanAll();
-    });
-
-    context('when snaps data successfully retrieved', () => {
-      beforeEach(() => {
-        api.get('/api/launchpad/snaps/list')
-          .query({ owner: 'anowner' })
-          .reply(200, {
-            status: 'success',
-            payload: {
-              code: 'snaps-found',
-              repos: []
-            }
-          });
-      });
-
-      it('should store repositories on fetch success', async () => {
-        await store.dispatch(fetchUserSnaps('anowner'));
-        expect(store.getActions()).toHaveActionOfType(
-          ActionTypes.FETCH_SNAPS_SUCCESS
-        );
-      });
-
-    });
-
-    it('should store error on Launchpad request failure', async () => {
-      api.get('/api/launchpad/snaps/list')
-        .query({ owner: 'anowner' })
-        .reply(404, {
-          status: 'error',
-          payload: {
-            code: 'lp-error',
-            message: 'Something went wrong'
-          }
-        });
-
+    it('should invoke CALL_API', async () => {
       await store.dispatch(fetchUserSnaps('anowner'));
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.FETCH_SNAPS_ERROR
-      );
+      expect(store.getActions()).toHaveActionsMatching((action) => {
+        return !!action[CALL_API];
+      });
     });
 
+    it('should invoke supply success and failure actions when invoking CALL_API', async () => {
+      await store.dispatch(fetchUserSnaps('anowner'));
+      expect(store.getActions()).toHaveActionsMatching((action) => {
+        return action[CALL_API].types[0] == ActionTypes.FETCH_SNAPS_SUCCESS
+          && action[CALL_API].types[1] == ActionTypes.FETCH_SNAPS_ERROR;
+      });
+    });
   });
 
   context('removeSnap', () => {
-    const repositoryUrl = 'https://github.com/anowner/aname';
-    let api;
-
-    beforeEach(() => {
-      api = nock(conf.get('BASE_URL'));
+    it('should invoke CALL_API', async () => {
+      await store.dispatch(removeSnap('anowner'));
+      expect(store.getActions()).toHaveActionsMatching((action) => {
+        return !!action[CALL_API];
+      });
     });
 
-    afterEach(() => {
-      api.done();
-      nock.cleanAll();
-    });
-
-    it('stores success action on successful removal', async () => {
-      api
-        .post('/api/launchpad/snaps/delete', { repository_url: repositoryUrl })
-        .reply(200, {
-          status: 'success',
-          payload: {
-            code: 'snap-deleted',
-            message: 'Snap deleted'
-          }
-        });
-
-      await store.dispatch(removeSnap(repositoryUrl));
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.REMOVE_SNAP_SUCCESS
-      );
-    });
-
-    it('stores error action on failed removal', async () => {
-      api
-        .post('/api/launchpad/snaps/delete', { repository_url: repositoryUrl })
-        .reply(404, {
-          status: 'error',
-          payload: {
-            code: 'lp-error',
-            message: 'Something went wrong'
-          }
-        });
-
-      await store.dispatch(removeSnap(repositoryUrl));
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.REMOVE_SNAP_ERROR
-      );
-    });
-  });
-
-  context('removeSnapSuccess', () => {
-    const repositoryUrl = 'https://github.com/anowner/aname';
-
-    beforeEach(() => {
-      action = removeSnapSuccess(repositoryUrl);
-    });
-
-    it('creates an action to indicate successful removal', () => {
-      const expectedAction = {
-        type: ActionTypes.REMOVE_SNAP_SUCCESS,
-        payload: { repository_url: repositoryUrl }
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('creates a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
-  });
-
-  context('removeSnapError', () => {
-    const repositoryUrl = 'https://github.com/anowner/aname';
-
-    beforeEach(() => {
-      action = removeSnapError(repositoryUrl, 'Something went wrong!');
-    });
-
-    it('creates an action to store request error on failure', () => {
-      const expectedAction = {
-        type: ActionTypes.REMOVE_SNAP_ERROR,
-        payload: {
-          repository_url: repositoryUrl,
-          error: 'Something went wrong!',
-        },
-        error: true,
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('creates a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
+    it('should invoke supply success and failure actions when invoking CALL_API', async () => {
+      await store.dispatch(removeSnap('anowner'));
+      expect(store.getActions()).toHaveActionsMatching((action) => {
+        return action[CALL_API].types[0] == ActionTypes.REMOVE_SNAP_SUCCESS
+          && action[CALL_API].types[1] == ActionTypes.REMOVE_SNAP_ERROR;
+      });
     });
   });
 });

--- a/test/unit/src/common/reducers/t_snaps.js
+++ b/test/unit/src/common/reducers/t_snaps.js
@@ -58,7 +58,7 @@ describe('snaps reducers', () => {
 
     const action = {
       type: ActionTypes.FETCH_SNAPS_SUCCESS,
-      payload: SNAPS
+      payload: { snaps: SNAPS }
     };
 
     it('should stop fetching', () => {
@@ -127,10 +127,28 @@ describe('snaps reducers', () => {
   });
 
   context('REMOVE_SNAP', () => {
-    const action = { type: ActionTypes.REMOVE_SNAP };
+    const state = {
+      ...initialState,
+      isFetching: true,
+      snaps: SNAPS,
+      error: 'Previous error'
+    };
+
+    const action = {
+      type: ActionTypes.REMOVE_SNAP,
+      payload: {
+        repository_url: 'https://github.com/anowner/aname'
+      }
+    };
 
     it('stores fetching status', () => {
-      expect(snaps(initialState, action).isFetching).toBe(true);
+      expect(snaps(state, action).isFetching).toBe(true);
+    });
+
+    it('marks a snap for deletion', () => {
+      expect(snaps(state, action).snaps.filter((snap) => {
+        return snap.__FOR_REMOVAL__;
+      }).length).toEqual(1);
     });
   });
 
@@ -142,25 +160,29 @@ describe('snaps reducers', () => {
       error: 'Previous error'
     };
 
-    const action = {
+    const removeAction = {
       type: ActionTypes.REMOVE_SNAP_SUCCESS,
       payload: { repository_url: 'https://github.com/anowner/aname' }
     };
 
+    const successAction = {
+      type: ActionTypes.REMOVE_SNAP_SUCCESS
+    };
+
     it('clears fetching status', () => {
-      expect(snaps(state, action).isFetching).toBe(false);
+      expect(snaps(state, successAction).isFetching).toBe(false);
     });
 
     it('stores success status', () => {
-      expect(snaps(state, action).success).toBe(true);
+      expect(snaps(state, successAction).success).toBe(true);
     });
 
     it('clears error', () => {
-      expect(snaps(state, action).error).toBe(null);
+      expect(snaps(state, successAction).error).toBe(null);
     });
 
     it('removes snap from state', () => {
-      expect(snaps(state, action).snaps.map((snap) => {
+      expect(snaps(snaps(state, removeAction), successAction).snaps.map((snap) => {
         return snap.git_repository_url;
       })).toEqual(['https://github.com/anowner/anothername']);
     });
@@ -176,10 +198,7 @@ describe('snaps reducers', () => {
 
     const action = {
       type: ActionTypes.REMOVE_SNAP_ERROR,
-      payload: {
-        repository_url: 'https://github.com/anowner/aname',
-        error: 'Something went wrong!'
-      },
+      payload: 'Something went wrong!',
       error: true
     };
 


### PR DESCRIPTION
- Added new Express middleware to generate and verify CSRF tokens
- Added global window.__CSRF_TOKEN__ variable for application to consume
  token from server
- Added new API_CALL redux middleware to encapsulate API requests and pass tokens
- Migrated FETCH_SNAPS and REMOVE_SNAPS chain of events to API_CALL
- Fixed snaps reducer to work with API_CALL middleware
- Added unit tests