### PR TITLE
Remove Prometheus registration layer

### DIFF
--- a/charm/charm-deps
+++ b/charm/charm-deps
@@ -14,6 +14,5 @@ layer/layer-leadership              git+ssh://git.launchpad.net/layer-leadership
 layer/layer-ols                     lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols;revno=17
 layer/layer-ols-http                lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-http;revno=9
 layer/layer-ols-pg                  lp:~ubuntuone-pqm-team/ols-charm-deps/layer-ols-pg;revno=4
-layer/layer-promreg-client          git+ssh://git.launchpad.net/~timkuhlman/prometheus-registration/+git/layer-promreg-client;revno=0f9f74b
 
 wheels                              git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/wheels

--- a/charm/layer.yaml
+++ b/charm/layer.yaml
@@ -3,7 +3,6 @@ includes:
     - layer:leadership
     - layer:ols-http
     - layer:ols-pg
-    - layer:promreg-client
     - interface:memcache
 options:
     basic:


### PR DESCRIPTION
It turns out that auto-registering with IS Prometheus doesn't meet our
needs since it doesn't federate with snappy.kpi.canonical.com, and we
had to just have snappy.kpi.canonical.com manually configured to fetch
metrics from us instead.  As such, we no longer need the Prometheus
registration layer.