### PR TITLE
Add metric for builds released to edge

### DIFF
--- a/docs/memcached.md
+++ b/docs/memcached.md
@@ -13,3 +13,8 @@ Caches snap data for given repository URL.
 Caches JSON subset of data from `snapcraft.yaml` found in given repository.
 Currently it contains only a snap `name` from `snapcraft.yaml` file and a `path`
 to snapcraft.yaml file in given repository.
+
+## `lp:has_webhook:https://api.launchpad.net/devel/:owner/+snap/:name`
+
+Caches whether a snap in Launchpad is known to have a webhook pointing back
+to us.

--- a/environments/test.env
+++ b/environments/test.env
@@ -11,6 +11,7 @@ LP_API_USERNAME=test-user
 LP_API_CONSUMER_KEY=consumer key
 LP_API_TOKEN=token key
 LP_API_TOKEN_SECRET=token secret
+LP_WEBHOOK_SECRET=dummy-lp-webhook-secret
 
 STORE_API_URL=https://myapps.developer.ubuntu.com/dev/api
 STORE_DEVPORTAL_URL=https://myapps.developer.ubuntu.com/dev
@@ -22,4 +23,4 @@ GITHUB_AUTH_REDIRECT_URL=http://localhost:8000/auth/verify
 
 GITHUB_AUTH_CLIENT_ID=test-gh-client-id
 GITHUB_AUTH_CLIENT_SECRET=test-gh-client-secret
-GITHUB_WEBHOOK_SECRET=dummy-webhook-secret
+GITHUB_WEBHOOK_SECRET=dummy-gh-webhook-secret

--- a/migrations/20170320131245_builds-released-metric.js
+++ b/migrations/20170320131245_builds-released-metric.js
@@ -1,0 +1,15 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('github_user', function(table) {
+      table.integer('builds_released');
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.table('github_user', function(table) {
+      table.dropColumn('builds_released');
+    })
+  ]);
+};

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -8,6 +8,7 @@ export default {
   UBUNTU_SSO_URL: 'https://login.ubuntu.com',
   OPENID_VERIFY_URL: 'http://localhost:8000/login/verify',
   LP_API_URL: 'https://api.launchpad.net',
+  LP_WEBHOOK_SECRET: 'dummy-lp-webhook-secret',
   STORE_API_URL: 'https://myapps.developer.ubuntu.com/dev/api',
   STORE_DEVPORTAL_URL: 'https://myapps.developer.ubuntu.com/dev',
   STORE_ALLOWED_CHANNELS: ['edge'],
@@ -18,6 +19,6 @@ export default {
   GITHUB_AUTH_REDIRECT_URL: 'http://localhost:8000/auth/verify',
   GITHUB_AUTH_CLIENT_ID: '389a7b4c2ade662c0bf4',
   GITHUB_AUTH_CLIENT_SECRET: 'ea482b47a4830d38a838f48be43ab28002c33187',
-  GITHUB_WEBHOOK_SECRET: 'dummy-webhook-secret',
+  GITHUB_WEBHOOK_SECRET: 'dummy-gh-webhook-secret',
   KNEX_CONFIG_PATH: 'knexfile.js'
 };

--- a/src/server/db/models/github-user.js
+++ b/src/server/db/models/github-user.js
@@ -11,6 +11,7 @@ export default function register(db) {
    *   snaps_removed: number of snaps removed
    *   names_registered: number of snap names registered
    *   builds_requested: number of snap builds requested
+   *   builds_released: number of snap builds released to a store channel
    */
   db.model('GitHubUser', {
     tableName: 'github_user',

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -7,7 +7,7 @@ import requestGitHub from '../helpers/github';
 import { getMemcached } from '../helpers/memcached';
 import logging from '../logging';
 import { internalGetSnapcraftYaml } from './launchpad';
-import { makeWebhookSecret } from './webhook';
+import { getGitHubRootSecret, makeWebhookSecret } from './webhook';
 
 const logger = logging.getLogger('express');
 const REPOSITORY_ENDPOINT = '/user/repos';
@@ -168,7 +168,7 @@ export const createWebhook = async (req, res) => {
 
   let secret;
   try {
-    secret = makeWebhookSecret(owner, name);
+    secret = makeWebhookSecret(getGitHubRootSecret(), owner, name);
   } catch (e) {
     return res.status(500).send({
       status: 'error',

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -1,15 +1,16 @@
 import { createHash } from 'crypto';
 
 import yaml from 'js-yaml';
-import parseGitHubUrl from 'parse-github-url';
 
+import { parseGitHubRepoUrl } from '../../common/helpers/github-url';
 import db from '../db';
 import { conf } from '../helpers/config';
 import { getMemcached } from '../helpers/memcached';
 import requestGitHub from '../helpers/github';
 import getLaunchpad from '../launchpad';
-import { getSnapcraftData } from './github';
 import logging from '../logging';
+import { getSnapcraftData } from './github';
+import { getLaunchpadRootSecret, makeWebhookSecret } from './webhook';
 
 const logger = logging.getLogger('express');
 
@@ -99,6 +100,7 @@ export const getRepoUrlPrefix = (owner) => `https://github.com/${owner}/`;
 // memcached cache id helpers
 export const getUrlPrefixCacheId = (urlPrefix) => `url_prefix:${urlPrefix}`;
 export const getRepositoryUrlCacheId = (repositoryUrl) => `url:${repositoryUrl}`;
+export const getHasWebhookCacheId = (snapUrl) => `has_webhook:${snapUrl}`;
 
 // Wrap errors in a promise chain so that they always end up as a
 // PreparedError.
@@ -167,8 +169,8 @@ const checkAdminPermissions = async (session, repositoryUrl) => {
   }
   const token = session.token;
 
-  const parsed = parseGitHubUrl(repositoryUrl);
-  if (parsed === null || parsed.owner === null || parsed.name === null) {
+  const parsed = parseGitHubRepoUrl(repositoryUrl);
+  if (parsed === null) {
     logger.info(`Cannot parse "${repositoryUrl}"`);
     throw new PreparedError(400, RESPONSE_GITHUB_BAD_URL);
   }
@@ -276,6 +278,57 @@ const requestNewSnap = (repositoryUrl) => {
   });
 };
 
+const ensureWebhook = async (snap) => {
+  const cacheId = getHasWebhookCacheId(snap.self_link);
+  const { owner, name } = parseGitHubRepoUrl(snap.git_repository_url);
+  const notifyUrl = `${conf.get('BASE_URL')}/${owner}/${name}/webhook/notify`;
+  const lpClient = getLaunchpad();
+
+  try {
+    const result = await getMemcached().get(cacheId);
+    if (result !== undefined) {
+      return;
+    }
+  } catch (error) {
+    logger.error(`Error getting ${cacheId} from memcached: ${error}`);
+  }
+
+  try {
+    const webhooks = await lpClient.get(snap.webhooks_collection_link);
+    if (webhooks.entries.some(
+          (webhook) => webhook.delivery_url === notifyUrl)) {
+      return;
+    }
+
+    let secret;
+    try {
+      secret = makeWebhookSecret(getLaunchpadRootSecret(), owner, name);
+    } catch (error) {
+      throw new PreparedError(500, {
+        status: 'error',
+        payload: {
+          code: 'lp-unconfigured',
+          message: error.message
+        }
+      });
+    }
+    await lpClient.named_post(snap.self_link, 'newWebhook', {
+      parameters: {
+        delivery_url: notifyUrl,
+        event_types: ['snap:build:0.1'],
+        active: true,
+        secret
+      }
+    });
+    await getMemcached().set(cacheId, true, 3600);
+    logger.info(`Created webhook on ${snap.self_link}`);
+  } catch (error) {
+    // This is unfortunate, but it can be non-fatal at the moment as we only
+    // use this for metrics.  We'll try again later.
+    logger.error(`Error creating webhook on ${snap.self_link}: ${error}`);
+  }
+};
+
 export const newSnap = async (req, res) => {
   const repositoryUrl = req.body.repository_url;
 
@@ -298,6 +351,7 @@ export const newSnap = async (req, res) => {
       await getMemcached().del(cacheId);
       const snapUrl = result.self_link;
       logger.info(`Created ${snapUrl}`);
+      await ensureWebhook(result);
       return res.status(201).send({
         status: 'success',
         payload: {
@@ -379,6 +433,9 @@ const internalFindSnapsByPrefix = async (urlPrefix) => {
       }
     });
     await getMemcached().set(cacheId, result.entries, 3600);
+    for (const snap of result.entries) {
+      await ensureWebhook(snap);
+    }
     return result.entries;
   } catch (error) {
     // At least for the moment, we just wrap the error we get from
@@ -485,7 +542,7 @@ export const findSnap = async (req, res) => {
 };
 
 const clearSnapCache = (repositoryUrl) => {
-  const repository = parseGitHubUrl(repositoryUrl);
+  const repository = parseGitHubRepoUrl(repositoryUrl);
   const enabledReposCacheId = getUrlPrefixCacheId(getRepoUrlPrefix(repository.owner));
   const snapCacheId = getRepositoryUrlCacheId(repositoryUrl);
   const snapNameCacheId = getSnapcraftYamlCacheId(repositoryUrl);

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -417,7 +417,7 @@ describe('The WebHook API endpoint', () => {
           .save();
       });
 
-      describe('if store_upload_status is not Uploaded', () => {
+      context('if store_upload_status is not Uploaded', () => {
         const body = JSON.stringify({ store_upload_status: 'Pending' });
         let signature;
 
@@ -456,7 +456,7 @@ describe('The WebHook API endpoint', () => {
         });
       });
 
-      describe('if store_upload_status is Uploaded', () => {
+      context('if store_upload_status is Uploaded', () => {
         const body = JSON.stringify({ store_upload_status: 'Uploaded' });
         let signature;
 

--- a/test/routes/src/server/routes/t_webhook.js
+++ b/test/routes/src/server/routes/t_webhook.js
@@ -4,6 +4,7 @@ import Express from 'express';
 import nock from 'nock';
 import supertest from 'supertest';
 
+import db from '../../../../../src/server/db';
 import { getSnapcraftYamlCacheId } from '../../../../../src/server/handlers/github';
 import { conf } from '../../../../../src/server/helpers/config';
 import {
@@ -43,6 +44,16 @@ describe('The WebHook API endpoint', () => {
         .expect(400, done);
     });
 
+    it('rejects requests containing malformed JSON data', (done) => {
+      supertest(app)
+        .post('/anowner/aname/webhook/notify')
+        .type('application/json')
+        .set('X-GitHub-Event', 'push')
+        .set('X-Hub-Signature', 'dummy')
+        .send('{"bad"')
+        .expect(400, done);
+    });
+
     it('rejects requests with a bad signature', (done) => {
       const body = JSON.stringify({ ref: 'refs/heads/master' });
       let hmac = createHmac('sha1', conf.get('GITHUB_WEBHOOK_SECRET'));
@@ -59,7 +70,7 @@ describe('The WebHook API endpoint', () => {
         .expect(400, done);
     });
 
-    describe('with a good signature', () => {
+    describe('with a good signature from GitHub', () => {
       const lp_api_url = conf.get('LP_API_URL');
       const lp_api_base = `${lp_api_url}/devel`;
       const body = JSON.stringify({ ref: 'refs/heads/master' });
@@ -391,6 +402,149 @@ describe('The WebHook API endpoint', () => {
             expect(requestAutoBuilds.isDone()).toBe(false);
             done(err);
           });
+      });
+    });
+
+    describe('with a good signature from Launchpad', () => {
+      beforeEach(async () => {
+        await db.model('GitHubUser').query('truncate').fetch();
+        await db.model('GitHubUser')
+          .forge({
+            github_id: 1,
+            login: 'anowner',
+            last_login_at: new Date()
+          })
+          .save();
+      });
+
+      describe('if store_upload_status is not Uploaded', () => {
+        const body = JSON.stringify({ store_upload_status: 'Pending' });
+        let signature;
+
+        before(() => {
+          let hmac = createHmac('sha1', conf.get('LP_WEBHOOK_SECRET'));
+          hmac.update('anowner');
+          hmac.update('aname');
+          hmac = createHmac('sha1', hmac.digest('hex'));
+          hmac.update(body);
+          signature = hmac.digest('hex');
+        });
+
+        it('returns 200 OK', (done) => {
+          supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-Launchpad-Event-Type', 'snap:build:0.1')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body)
+            .expect(200, done);
+        });
+
+        it('leaves builds_released unmodified', async () => {
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          await dbUser.save({ builds_released: 1 });
+          await supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-Launchpad-Event-Type', 'snap:build:0.1')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body);
+          await dbUser.refresh();
+          expect(dbUser.get('builds_released')).toEqual(1);
+        });
+      });
+
+      describe('if store_upload_status is Uploaded', () => {
+        const body = JSON.stringify({ store_upload_status: 'Uploaded' });
+        let signature;
+
+        before(() => {
+          let hmac = createHmac('sha1', conf.get('LP_WEBHOOK_SECRET'));
+          hmac.update('anowner');
+          hmac.update('aname');
+          hmac = createHmac('sha1', hmac.digest('hex'));
+          hmac.update(body);
+          signature = hmac.digest('hex');
+        });
+
+        it('returns 200 OK', (done) => {
+          supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-Launchpad-Event-Type', 'snap:build:0.1')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body)
+            .expect(200, done);
+        });
+
+        it('leaves builds_released unmodified if it is unset', async () => {
+          await supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-Launchpad-Event-Type', 'snap:build:0.1')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body);
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          expect(dbUser.get('builds_released')).toBeFalsy();
+        });
+
+        it('increments builds_released if it is set', async () => {
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          await dbUser.save({ builds_released: 1 });
+          await supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-Launchpad-Event-Type', 'snap:build:0.1')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body);
+          await dbUser.refresh();
+          expect(dbUser.get('builds_released')).toEqual(2);
+        });
+      });
+
+      context('for a ping event', () => {
+        const body = JSON.stringify({ ping: true });
+        let signature;
+
+        before(() => {
+          let hmac = createHmac('sha1', conf.get('LP_WEBHOOK_SECRET'));
+          hmac.update('anowner');
+          hmac.update('aname');
+          hmac = createHmac('sha1', hmac.digest('hex'));
+          hmac.update(body);
+          signature = hmac.digest('hex');
+        });
+
+        it('returns 200 OK', (done) => {
+          supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-Launchpad-Event-Type', 'ping')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body)
+            .expect(200, done);
+        });
+
+        it('leaves builds_released unmodified', async () => {
+          const dbUser = await db.model('GitHubUser')
+            .where({ login: 'anowner' })
+            .fetch();
+          await dbUser.save({ builds_released: 1 });
+          await supertest(app)
+            .post('/anowner/aname/webhook/notify')
+            .type('application/json')
+            .set('X-Launchpad-Event-Type', 'ping')
+            .set('X-Hub-Signature', `sha1=${signature}`)
+            .send(body);
+          await dbUser.refresh();
+          expect(dbUser.get('builds_released')).toEqual(1);
+        });
       });
     });
   });


### PR DESCRIPTION
We do this by configuring a webhook on Launchpad snaps and counting
events where `store_upload_status` is "Uploaded".  (We could use the
information provided by this webhook for some more things in future to
reduce polling, although that would also require putting some more
thought into ordering guarantees; since "Uploaded" is a terminal status
we don't need to think about that too hard in this case.)

Of course there are lots of existing snaps that need to have the webhook
added, and it's also possible that we might create the snap and then
fail to create the webhook.  We don't currently have any infrastructure
for running scripts or periodic jobs, which would be a better way to
handle this; but as a reasonably lightweight workaround for these
problems, `/api/launchpad/snaps/list` also ensures that the necessary
webhook exists for each of the snaps it returns, and we make a note in
memcached that we've done so to avoid hitting the Launchpad API too
often.

Fixes #517.