### PR TITLE
Adjust the alignment of the beta flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "vsicons.presets.angular": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "vsicons.presets.angular": false
+}

--- a/src/common/components/header/header.css
+++ b/src/common/components/header/header.css
@@ -79,6 +79,6 @@ $text-color: $cool-grey;
   height: 16px;
   width: 32px;
   position: absolute;
-  top: 11px;
+  top: 18px;
   right: -40px;
 }


### PR DESCRIPTION
The beta flag needs to align with the baseline of the word mark and not
been in a superscript position as it is now.