### PR TITLE
Drop next-route fallthrough from universal handler

### DIFF
--- a/src/server/handlers/universal.js
+++ b/src/server/handlers/universal.js
@@ -9,7 +9,7 @@ import assets from '../../../webpack-assets.json';
 
 let routes = require('../../common/routes').default;
 
-export const universal = (req, res, next) => {
+export const universal = (req, res) => {
   if (process.env.NODE_ENV === 'development') {
     // Hot-reload application files when changes
     // made when running as a development site
@@ -19,8 +19,6 @@ export const universal = (req, res, next) => {
   match({ routes, location: req.url }, (error, redirectLocation, renderProps) => {
     handleMatch(req, res, error, redirectLocation, renderProps);
   });
-
-  next();
 };
 
 export const handleMatch = (req, res, error, redirectLocation, renderProps) => {


### PR DESCRIPTION
This has recently started causing `HEAD /` requests to fail on staging.
I'm not clear on why this has only started happening recently, but I
think this code has been wrong for some time: `handleMatch` is always
called and emits a response in all cases, so there's no reason to fall
through to other routes here (except for error-handling middleware,
which will still be called on unhandled exceptions).

Fixes #583.