### PR TITLE
fix select-repository-row tests

### DIFF
--- a/test/unit/src/common/components/select-repository-row/t_select-repository-row.js
+++ b/test/unit/src/common/components/select-repository-row/t_select-repository-row.js
@@ -47,20 +47,20 @@ describe('The SelectRepositoryRow component', () => {
 
         beforeEach(() => {
           component = shallow(<SelectRepositoryRow { ...props } />);
-          component.instance().onChange();
         });
 
-        xit('should call the onChange callback', () => {
+        it('should call the onChange callback', () => {
+          component.find('input').simulate('change');
           expect(onChange).toHaveBeenCalled();
         });
       });
 
       context('and the checked prop is "true"', () => {
         beforeEach(() => {
-          props.checked = true;
+          props.repository.__isSelected = true;
         });
 
-        xit('should contain a checked checkbox', () => {
+        it('should contain a checked checkbox', () => {
           const component = shallow(<SelectRepositoryRow { ...props } />);
           expect(component.find('input[checked=true]').length).toBe(1);
         });
@@ -68,7 +68,7 @@ describe('The SelectRepositoryRow component', () => {
 
       context('and the checked prop is "false"', () => {
         beforeEach(() => {
-          props.checked = false;
+          props.repository.__isSelected = false;
         });
 
         it('should contain an unchecked checkbox', () => {
@@ -79,10 +79,21 @@ describe('The SelectRepositoryRow component', () => {
 
       context('and the disabled prop is "true"', () => {
         beforeEach(() => {
-          props.disabled = true;
+          props.isEnabled = true;
         });
 
-        xit('should contain a disabled checkbox', () => {
+        it('should contain a disabled checkbox', () => {
+          const component = shallow(<SelectRepositoryRow { ...props } />);
+          expect(component.find('input[disabled=true]').length).toBe(1);
+        });
+      });
+
+      context('and the reposistory is fetching', () => {
+        beforeEach(() => {
+          props.repository.__isFetching = true;
+        });
+
+        it('should contain a disabled checkbox', () => {
           const component = shallow(<SelectRepositoryRow { ...props } />);
           expect(component.find('input[disabled=true]').length).toBe(1);
         });


### PR DESCRIPTION
select-repository-row has the repository as a prop and can figure out if it should be selected or not from that, it can't know if it's enabled, so that has to be passed from the parent where the comparison of snap and repo list (selector) works that out.

Use simulate('change') to trigger the onChange handler.

FWIW I find the verbose naming of these tests a little hard to parse on a test by test basis.