### PR TITLE
30 seconds beta notification delay

### DIFF
--- a/src/common/components/beta-notification/trigger.js
+++ b/src/common/components/beta-notification/trigger.js
@@ -5,7 +5,7 @@ import localforage from 'localforage';
 import { BETA_NOTIFICATION_TOGGLE } from '../../reducers/beta-notification';
 import { BETA_NOTIFICATION_DISMISSED_KEY } from './index';
 
-const BETA_NOTIFICATION_DELAY = 2 * 60 * 1000; // 2 minutes
+const BETA_NOTIFICATION_DELAY = 30 * 1000; // 30 seconds
 
 export class BetaNotificationTriggerView extends Component {
   notificationTimeout = null;


### PR DESCRIPTION
Fix #563

There is a potential issue of notification being in flow moving the users content reported in #558.
We can address it separately if needed.