### PR TITLE
Show store-assigned revisions of builds

### DIFF
--- a/src/common/components/help/install-snap/index.js
+++ b/src/common/components/help/install-snap/index.js
@@ -19,6 +19,11 @@ export default class HelpInstallSnap extends Component {
             {command}
           </code>
         </pre>
+        { revision &&
+          <p className={ styles.p }>
+            The installed snap will not be auto-updated.
+          </p>
+        }
         <p className={ styles.p }>
           Don’t have snapd installed?  {' '}
           <a

--- a/src/common/containers/build-details.js
+++ b/src/common/containers/build-details.js
@@ -38,12 +38,13 @@ class BuildDetails extends Component {
           snapcraft cleanbuild --debug
         </HelpInstallSnap>
       );
-    } else if (snap && snap.store_name) {
-      // otherwise if we have snap name show install instructions
+    } else if (snap && snap.store_name && build.storeRevision) {
+      // otherwise if we have snap name and revision show install instructions
       helpBox = (
         <HelpInstallSnap
-          headline='To test the latest successful build on your PC or cloud instance:'
+          headline='To test this build on your PC or cloud instance:'
           name={ snap.store_name }
+          revision={ build.storeRevision }
         />
       );
     }

--- a/src/common/helpers/snap-builds.js
+++ b/src/common/helpers/snap-builds.js
@@ -66,6 +66,8 @@ export function snapBuildFromAPI(entry) {
     dateCreated: entry.datecreated,
     dateStarted: entry.date_started,
     dateBuilt: entry.datebuilt,
-    duration: entry.duration
+    duration: entry.duration,
+
+    storeRevision: entry.store_upload_revision
   } : null;
 }

--- a/test/unit/src/common/components/help/t_install_snap.js
+++ b/test/unit/src/common/components/help/t_install_snap.js
@@ -28,6 +28,11 @@ describe('<HelpInstallSnap />', function() {
     it('should include help link', function() {
       expect(wrapper.text()).toInclude('Don’t have snapd installed?');
     });
+
+    it('should include no-auto-update warning', function() {
+      expect(wrapper.text()).toInclude(
+        'The installed snap will not be auto-updated.');
+    });
   });
 
   context('when rendered with children', () => {
@@ -45,6 +50,11 @@ describe('<HelpInstallSnap />', function() {
 
     it('should include help link', function() {
       expect(wrapper.text()).toInclude('Don’t have snapd installed?');
+    });
+
+    it('should not include no-auto-update warning', function() {
+      expect(wrapper.text()).toNotInclude(
+        'The installed snap will not be auto-updated.');
     });
   });
 });

--- a/test/unit/src/common/helpers/t_snap-builds.js
+++ b/test/unit/src/common/helpers/t_snap-builds.js
@@ -33,7 +33,8 @@ describe('snapBuildFromAPI helper', () => {
     'datecreated': '2016-11-09T17:05:52.436792+00:00',
     'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
     'arch_tag': 'amd64',
-    'upload_log_url': null
+    'upload_log_url': null,
+    'store_upload_revision': 15
   };
 
   let snapBuild;
@@ -58,6 +59,8 @@ describe('snapBuildFromAPI helper', () => {
         'dateStarted',
         'dateBuilt',
         'duration',
+
+        'storeRevision'
       ]);
     });
 
@@ -92,6 +95,11 @@ describe('snapBuildFromAPI helper', () => {
 
     it('should take duration from duration field', () => {
       expect(snapBuild.duration).toEqual(SNAP_BUILD_ENTRY.duration);
+    });
+
+    it('should take storeRevision from store_upload_revision field', () => {
+      expect(snapBuild.storeRevision).toEqual(
+        SNAP_BUILD_ENTRY.store_upload_revision);
     });
 
   });


### PR DESCRIPTION
Launchpad exports this information now, so we can restore the
`--revision=` part of `snap install` instructions.