### PR TITLE
Do all time manipulations in UTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "eslint -c .eslintrc.js '**/*.js'",
     "test": "npm run test:setup-db && nyc npm run test:unit && npm run test:routes && npm run lint",
     "test:setup-db": "rm -f test.sqlite3 && NODE_ENV=test npm run migrate:latest",
-    "test:unit": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*",
-    "test:routes": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/routes/**/*",
+    "test:unit": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*",
+    "test:routes": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/routes/**/*",
     "migrate:latest": "knex migrate:latest",
     "migrate:rollback": "knex migrate:rollback"
   },

--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -33,7 +33,7 @@ export function extractExpiresCaveat(macaroon) {
     if (caveat.verificationKeyId === '') {
       const parts = caveat.caveatId.split('|');
       if (parts[0] === storeLocation && parts[1] === 'expires') {
-        return moment(parts[2]);
+        return moment.utc(parts[2]);
       }
     }
   }
@@ -67,7 +67,7 @@ async function getPackageUploadRequestPermission() {
     body: JSON.stringify({
       permissions: ['package_upload_request', 'edit_account'],
       channels: conf.get('STORE_ALLOWED_CHANNELS'),
-      expires: moment()
+      expires: moment.utc()
         .add(lifetime, 'seconds')
         .format('YYYY-MM-DD[T]HH:mm:ss.SSS')
     })
@@ -114,7 +114,7 @@ export function checkPackageUploadRequest(rootRaw, dischargeRaw) {
   // caveat ID matches.
   const root = MacaroonsBuilder.deserialize(rootRaw);
   const expires = extractExpiresCaveat(root);
-  if (expires && expires <= moment()) {
+  if (expires && expires <= moment.utc()) {
     throw new Error('Store root macaroon has expired.');
   }
   const caveatId = extractSSOCaveat(root);

--- a/src/common/components/build-status/index.js
+++ b/src/common/components/build-status/index.js
@@ -16,7 +16,7 @@ const BuildStatus = (props) => {
   let humanDateStarted;
 
   if (dateStarted) {
-    const momentStarted = moment(dateStarted);
+    const momentStarted = moment.utc(dateStarted);
     humanDateStarted = (
       <span className={ styles.buildDate } title={momentStarted.format('YYYY-MM-DD HH:mm:ss UTC')}>
         {momentStarted.fromNow()}

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -61,7 +61,7 @@ describe('store authentication actions', () => {
       const macaroon = new MacaroonsBuilder('location', 'key', 'id')
         .add_first_party_caveat(`${storeLocation}|expires|${expires}`)
         .getMacaroon();
-      expect(extractExpiresCaveat(macaroon)).toEqual(moment(expires));
+      expect(extractExpiresCaveat(macaroon)).toEqual(moment.utc(expires));
     });
 
     it('skips expires caveats from wrong host', () => {
@@ -169,7 +169,7 @@ describe('store authentication actions', () => {
       let discharge;
 
       beforeEach(() => {
-        const expires = moment()
+        const expires = moment.utc()
           .subtract(1, 'seconds')
           .format('YYYY-MM-DD[T]HH:mm:ss.SSS');
         root = new MacaroonsBuilder(storeLocation, 'key', 'id')
@@ -319,8 +319,8 @@ describe('store authentication actions', () => {
           const expectedLifetime = conf.get(
             'STORE_PACKAGE_UPLOAD_REQUEST_LIFETIME'
           );
-          const now = moment();
-          const expires = moment(body.expires);
+          const now = moment.utc();
+          const expires = moment.utc(body.expires);
           return expires.isBetween(
             // Allow a bit of slack for slow tests.
             now.clone().add(expectedLifetime - 5, 'seconds'),


### PR DESCRIPTION
Without this, people in a timezone sufficiently far west of UTC will get
macaroons that expire before the start of their validity period.

I experimented with some timezone mocking libraries, but couldn't get
anything to work very well.  The easiest approach seems to be to just
run the whole test suite in `TZ=US/Pacific`, which should be enough to
shake out most timezone handling bugs.

Fixes #527.