### PR TITLE
Refactor snaps redux store

### DIFF
--- a/src/common/components/first-time-heading/index.js
+++ b/src/common/components/first-time-heading/index.js
@@ -5,6 +5,7 @@ import { HeadingThree } from '../vanilla/heading';
 import TrafficLights, { SIGNALS } from '../traffic-lights';
 
 import {
+  hasLoadedSnaps,
   hasNoRegisteredNames,
   snapsWithRegisteredNameAndSnapcraftData,
   snapsWithRegisteredNameAndNoSnapcraftData,
@@ -91,9 +92,7 @@ FirstTimeHeading.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    // TODO: bartaz refactor
-    // use snaps from entities
-    snapsLoaded: !!state.snaps,
+    snapsLoaded: hasLoadedSnaps(state),
     hasNoRegisteredNames: hasNoRegisteredNames(state),
     hasNoSnapsWithRegisteredNameAndSnapcraftData: snapsWithRegisteredNameAndSnapcraftData(state).length === 0,
     hasSnapsWithRegisteredNameAndNoSnapcraftData: snapsWithRegisteredNameAndNoSnapcraftData(state).length > 0,

--- a/src/common/components/first-time-heading/index.js
+++ b/src/common/components/first-time-heading/index.js
@@ -91,6 +91,8 @@ FirstTimeHeading.propTypes = {
 
 function mapStateToProps(state) {
   return {
+    // TODO: bartaz refactor
+    // use snaps from entities
     snapsLoaded: !!state.snaps,
     hasNoRegisteredNames: hasNoRegisteredNames(state),
     hasNoSnapsWithRegisteredNameAndSnapcraftData: snapsWithRegisteredNameAndSnapcraftData(state).length === 0,

--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -64,6 +64,8 @@ class RepositoriesHome extends Component {
   }
 
   renderRepositoriesList() {
+    // TODO: bartaz refactor
+    // does it need snaps (ids) or entities?
     const { snaps, snapBuilds } = this.props;
 
     return (

--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
+import { hasSnaps } from '../../selectors';
 import { fetchUserSnaps } from '../../actions/snaps';
 import { fetchBuilds } from '../../actions/snap-builds';
 import { LinkButton } from '../vanilla/button';
@@ -19,18 +20,19 @@ const SNAP_POLL_PERIOD = (15 * 1000);
 
 class RepositoriesHome extends Component {
   fetchData(props) {
-    const { snaps } = props;
+    const { hasSnaps, snaps, entities } = props;
 
-    if (snaps.success) {
+    // check both success and fetching to avoid redirecting
+    // based on previous success
+    if (snaps.success && !snaps.isFetching) {
       // if user doesn't have enabled repos open add repositories view
-      // TODO: bartaz refactor
-      if (snaps.snaps.length === 0) {
+      if (!hasSnaps) {
         this.props.router.replace('/select-repositories');
         return;
       }
 
-      // TODO: bartaz refactor
-      snaps.snaps.forEach((snap) => {
+      snaps.ids.forEach((id) => {
+        const snap = entities.snaps[id];
         this.props.fetchBuilds(snap.git_repository_url, snap.self_link);
       });
     }
@@ -57,7 +59,7 @@ class RepositoriesHome extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const snapsLength = nextProps.snaps.snaps && nextProps.snaps.snaps.length;
+    const snapsLength = nextProps.snaps.ids.length;
 
     if ((this.props.snaps.success !== nextProps.snaps.success)
         || (snapsLength === 0)) {
@@ -95,16 +97,12 @@ class RepositoriesHome extends Component {
   }
 
   render() {
-    // TODO: bartaz refactor
-    const { snaps } = this.props;
-    const hasSnaps = (snaps.snaps && snaps.snaps.length > 0);
-
     // show spinner if snaps data was not yet fetched (snaps list is empty)
     // (to avoid spinner during polling we are not checking `success` or `isFetching`
     //
     // when snaps are loaded and user doesn't have any, they will be redirected
     // to select repositories (so spinner won't be showing endlessly)
-    return !hasSnaps
+    return !this.props.hasSnaps
       ? this.renderSpinner()
       : this.renderRepositoriesList();
   }
@@ -113,8 +111,10 @@ class RepositoriesHome extends Component {
 RepositoriesHome.propTypes = {
   auth: PropTypes.object.isRequired,
   user: PropTypes.object,
+  entities: PropTypes.object,
   snaps: PropTypes.object.isRequired,
   snapBuilds: PropTypes.object.isRequired,
+  hasSnaps: PropTypes.bool,
   router: PropTypes.object.isRequired,
   updateSnaps: PropTypes.func.isRequired,
   fetchBuilds: PropTypes.func.isRequired
@@ -124,6 +124,7 @@ function mapStateToProps(state) {
   const {
     auth,
     user,
+    entities,
     snaps,
     snapBuilds
   } = state;
@@ -131,8 +132,10 @@ function mapStateToProps(state) {
   return {
     auth,
     user,
+    entities,
     snaps,
-    snapBuilds
+    snapBuilds,
+    hasSnaps: hasSnaps(state)
   };
 }
 

--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -23,11 +23,13 @@ class RepositoriesHome extends Component {
 
     if (snaps.success) {
       // if user doesn't have enabled repos open add repositories view
+      // TODO: bartaz refactor
       if (snaps.snaps.length === 0) {
         this.props.router.replace('/select-repositories');
         return;
       }
 
+      // TODO: bartaz refactor
       snaps.snaps.forEach((snap) => {
         this.props.fetchBuilds(snap.git_repository_url, snap.self_link);
       });
@@ -93,6 +95,7 @@ class RepositoriesHome extends Component {
   }
 
   render() {
+    // TODO: bartaz refactor
     const { snaps } = this.props;
     const hasSnaps = (snaps.snaps && snaps.snaps.length > 0);
 

--- a/src/common/components/repositories-home/index.js
+++ b/src/common/components/repositories-home/index.js
@@ -65,12 +65,12 @@ class RepositoriesHome extends Component {
 
   renderRepositoriesList() {
     // TODO: bartaz refactor
-    // does it need snaps (ids) or entities?
-    const { snaps, snapBuilds } = this.props;
+    // should it fetch data for first time heading (it already does need it anyway probably)
+    // move it to HOC?
 
     return (
       <div>
-        <FirstTimeHeading snaps={snaps} snapBuilds={snapBuilds} isOnMyRepos={true} />
+        <FirstTimeHeading isOnMyRepos={true} />
         <div className={ styles['button-container'] }>
           <HeadingThree>Repos to build and publish</HeadingThree>
           <div>

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -104,6 +104,9 @@ export class RepositoriesListView extends Component {
   }
 
   render() {
+    // TODO bartaz refactor
+    // selector to as has snaps?
+    // selector to get snaps for listing
     const { snaps } = this.props.snaps;
     const hasSnaps = (snaps && Object.keys(snaps).length > 0);
 

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -1,7 +1,11 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { hasNoRegisteredNames, hasNoConfiguredSnaps } from '../../selectors';
+import {
+  hasSnaps,
+  hasNoRegisteredNames,
+  hasNoConfiguredSnaps
+} from '../../selectors';
 import { conf } from '../../helpers/config';
 import {
   checkSignedIntoStore,
@@ -67,7 +71,8 @@ export class RepositoriesListView extends Component {
     }
   }
 
-  renderRow(snap, index) {
+  renderRow(id, index) {
+    const snap = this.props.entities.snaps[id];
     const { hasNoConfiguredSnaps, hasNoRegisteredNames, registerName, snapBuilds, authStore } = this.props;
     const { fullName } = parseGitHubRepoUrl(snap.git_repository_url);
     const isFirstInList = index === 0;
@@ -104,11 +109,7 @@ export class RepositoriesListView extends Component {
   }
 
   render() {
-    // TODO bartaz refactor
-    // selector to as has snaps?
-    // selector to get snaps for listing
-    const { snaps } = this.props.snaps;
-    const hasSnaps = (snaps && Object.keys(snaps).length > 0);
+    const { ids } = this.props.snaps;
 
     return (
       <div className={styles.repositoriesList}>
@@ -122,8 +123,8 @@ export class RepositoriesListView extends Component {
             </Row>
           </Head>
           <Body>
-            { hasSnaps &&
-              snaps.map(this.renderRow.bind(this))
+            { this.props.hasSnaps &&
+              ids.map(this.renderRow.bind(this))
             }
           </Body>
         </Table>
@@ -135,6 +136,7 @@ export class RepositoriesListView extends Component {
 RepositoriesListView.defaultProps = {
   auth: {},
   authStore: {},
+  entities: {},
   hasNoConfiguredSnaps: true,
   hasNoRegisteredNames: true,
   registerName: {},
@@ -145,7 +147,11 @@ RepositoriesListView.defaultProps = {
 RepositoriesListView.propTypes = {
   auth: PropTypes.object.isRequired,
   authStore: PropTypes.object.isRequired,
+  entities: PropTypes.shape({
+    snaps: PropTypes.object
+  }),
   dispatch: PropTypes.func,
+  hasSnaps: PropTypes.bool,
   hasNoConfiguredSnaps: PropTypes.bool,
   hasNoRegisteredNames: PropTypes.bool,
   registerName: PropTypes.object,
@@ -157,6 +163,7 @@ function mapStateToProps(state) {
   const {
     auth,
     authStore,
+    entities,
     registerName,
     snaps,
     snapBuilds
@@ -165,9 +172,11 @@ function mapStateToProps(state) {
   return {
     auth,
     authStore,
+    entities,
     registerName,
     snaps,
     snapBuilds,
+    hasSnaps: hasSnaps(state),
     hasNoRegisteredNames: hasNoRegisteredNames(state),
     hasNoConfiguredSnaps: hasNoConfiguredSnaps(state)
   };

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -53,8 +53,8 @@ class SelectRepositoriesPage extends Component {
     const { snaps } = props;
 
     if (snaps.success) {
-      // TODO: bartaz refactor
-      snaps.snaps.forEach((snap) => {
+      snaps.ids.forEach((id) => {
+        const snap = props.entities.snaps[id];
         this.props.dispatch(fetchBuilds(snap.git_repository_url, snap.self_link));
       });
     }
@@ -63,6 +63,7 @@ class SelectRepositoriesPage extends Component {
 
 SelectRepositoriesPage.propTypes = {
   auth: PropTypes.object.isRequired,
+  entities: PropTypes.object.isRequired,
   user: PropTypes.object,
   snaps: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
@@ -71,12 +72,14 @@ SelectRepositoriesPage.propTypes = {
 function mapStateToProps(state) {
   const {
     auth,
+    entities,
     user,
     snaps
   } = state;
 
   return {
     auth,
+    entities,
     user,
     snaps
   };

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -31,12 +31,13 @@ class SelectRepositoriesPage extends Component {
 
   render() {
     // TODO: bartaz refactor
-    // does it need snaps (ids) or entities?
     // XXX this should fetch snaps and repos and pass to children ?
-    const { snaps, snapBuilds } = this.props;
+    // should it fetch data for first time heading (or others?)
+    // move it to HOC?
+
     return (
       <div>
-        <FirstTimeHeading snaps={snaps} snapBuilds={snapBuilds} />
+        <FirstTimeHeading />
         <CardHighlighted>
           <HeadingThree className={ styles.heading }>
             Choose repos to add
@@ -63,7 +64,6 @@ SelectRepositoriesPage.propTypes = {
   auth: PropTypes.object.isRequired,
   user: PropTypes.object,
   snaps: PropTypes.object.isRequired,
-  snapBuilds: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
 };
 
@@ -71,15 +71,13 @@ function mapStateToProps(state) {
   const {
     auth,
     user,
-    snaps,
-    snapBuilds
+    snaps
   } = state;
 
   return {
     auth,
     user,
-    snaps,
-    snapBuilds
+    snaps
   };
 }
 

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -53,6 +53,7 @@ class SelectRepositoriesPage extends Component {
     const { snaps } = props;
 
     if (snaps.success) {
+      // TODO: bartaz refactor
       snaps.snaps.forEach((snap) => {
         this.props.dispatch(fetchBuilds(snap.git_repository_url, snap.self_link));
       });

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -30,6 +30,8 @@ class SelectRepositoriesPage extends Component {
   }
 
   render() {
+    // TODO: bartaz refactor
+    // does it need snaps (ids) or entities?
     // XXX this should fetch snaps and repos and pass to children ?
     const { snaps, snapBuilds } = this.props;
     return (

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -192,6 +192,8 @@ SelectRepositoryListComponent.propTypes = {
   user: PropTypes.object,
   repositoriesStatus: PropTypes.object,
   router: PropTypes.object.isRequired,
+  // TODO: bartaz refactor
+  // are snaps used at all in here?
   snaps: PropTypes.object,
   selectedRepositories: PropTypes.array,
   reposToAdd: PropTypes.array,

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -192,9 +192,6 @@ SelectRepositoryListComponent.propTypes = {
   user: PropTypes.object,
   repositoriesStatus: PropTypes.object,
   router: PropTypes.object.isRequired,
-  // TODO: bartaz refactor
-  // are snaps used at all in here?
-  snaps: PropTypes.object,
   selectedRepositories: PropTypes.array,
   reposToAdd: PropTypes.array,
   enabledRepositories: PropTypes.object,
@@ -205,14 +202,12 @@ SelectRepositoryListComponent.propTypes = {
 function mapStateToProps(state) {
   const {
     user,
-    snaps,
     entities,
     repositories,
   } = state;
 
   return {
     user,
-    snaps,
     entities,
     repositories, // ?repository-pagination
     isAddingSnaps: isAddingSnaps(state),

--- a/src/common/helpers/repositories.js
+++ b/src/common/helpers/repositories.js
@@ -1,9 +1,3 @@
 export function hasRepository(arr, repository) {
   return arr.some((item) => item.fullName === repository.fullName);
 }
-
-// TODO bartaz refactor
-// not needed when we can get snap by id from entities?
-export function hasSnapForRepository(snaps, repository) {
-  return snaps.some((snap) => snap.git_repository_url === repository.url);
-}

--- a/src/common/helpers/repositories.js
+++ b/src/common/helpers/repositories.js
@@ -2,6 +2,8 @@ export function hasRepository(arr, repository) {
   return arr.some((item) => item.fullName === repository.fullName);
 }
 
+// TODO bartaz refactor
+// not needed when we can get snap by id from entities?
 export function hasSnapForRepository(snaps, repository) {
   return snaps.some((snap) => snap.git_repository_url === repository.url);
 }

--- a/src/common/reducers/entities/index.js
+++ b/src/common/reducers/entities/index.js
@@ -1,9 +1,11 @@
 import merge from 'lodash/merge';
 
 import * as RepoActionTypes from '../../actions/repository';
+import * as RegisterNameActionTypes from '../../actions/register-name';
 import repository from './repository';
+import snap from './snap';
 
-// TODO snaps
+import { getGitHubRepoUrl } from '../../helpers/github-url';
 
 export function entities(state = {
   snaps: {},
@@ -26,7 +28,26 @@ export function entities(state = {
     return reduceRepoEntity(state, action);
   }
 
+  // update snaps on register name actions
+  if (RegisterNameActionTypes[action.type]) {
+    // TODO refactor
+    // register name actions use fullName as id instead of repo url
+    const snapAction = {
+      ...action,
+      payload: {
+        ...action.payload,
+        id: getGitHubRepoUrl(action.payload.id)
+      }
+    };
+
+    return reduceSnapEntity(state, snapAction);
+  }
+
   return state;
+}
+
+function reduceSnapEntity(state, action) {
+  return reduceEntityHelper(state, action, snap, 'snaps');
 }
 
 function reduceRepoEntity(state, action) {

--- a/src/common/reducers/entities/snap.js
+++ b/src/common/reducers/entities/snap.js
@@ -1,0 +1,13 @@
+import * as RegisterNameActionTypes from '../../actions/register-name';
+
+export default function snap(state={}, action) {
+  switch(action.type) {
+    case RegisterNameActionTypes.REGISTER_NAME_SUCCESS:
+      return {
+        ...state,
+        store_name: action.payload.snapName
+      };
+    default:
+      return state;
+  }
+}

--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -49,6 +49,8 @@ export function snaps(state = {
         ...state,
         isFetching: false,
         success: true,
+        // TODO bartaz refactor
+        // snaps object should only be in entities
         snaps: [
           ...action.payload.response.payload.snaps
         ],
@@ -62,6 +64,8 @@ export function snaps(state = {
         success: false,
         error: action.payload.error
       };
+    // TODO bartaz refactor
+    // make sure registered name is updated in entities
     case RegisterNameActionTypes.REGISTER_NAME_SUCCESS:
       return {
         ...state,
@@ -77,6 +81,8 @@ export function snaps(state = {
         ...state,
         isFetching: false,
         success: true,
+        // TODO bartaz refactor
+        // make sure ids are up to date after remove, also remove from entities?
         snaps: (
           state.snaps !== null ?
           state.snaps.filter((snap) => {

--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -1,37 +1,11 @@
 import * as ActionTypes from '../actions/snaps';
-import * as RegisterNameActionTypes from '../actions/register-name';
-import { getGitHubRepoUrl } from '../helpers/github-url';
+
 import union from 'lodash/union';
-
-// TODO move to selector
-function findSnapByFullName(snaps, fullName) {
-  return snaps.find((snap) => {
-    return snap.git_repository_url === getGitHubRepoUrl(fullName);
-  });
-}
-
-function updateRegisteredName(snaps, fullName, snapName) {
-  if (!snaps) {
-    return snaps;
-  }
-
-  const updatedSnaps = [ ...snaps ]; // copy snaps array
-  const snap = findSnapByFullName(updatedSnaps, fullName);
-  const index = updatedSnaps.indexOf(snap);
-
-  if (snap && index !== -1) {
-    // change snap at correct index with new updated snap object
-    updatedSnaps[index] = { ...snap, store_name: snapName };
-  }
-
-  return updatedSnaps;
-}
 
 export function snaps(state = {
   isFetching: false,
   success: false,
   error: null,
-  snaps: null,
   ids: []
 }, action) {
   switch(action.type) {
@@ -40,18 +14,11 @@ export function snaps(state = {
         ...state,
         isFetching: true
       };
-      // XXX a little confusing because we're not refactoring this yet, just
-      // making do for the repositories refactor
     case ActionTypes.FETCH_SNAPS_SUCCESS:
       return {
         ...state,
         isFetching: false,
         success: true,
-        // TODO bartaz refactor
-        // snaps object should only be in entities
-        snaps: [
-          ...action.payload.response.payload.snaps
-        ],
         ids: union(state.ids, action.payload.response.result),
         error: null
       };
@@ -61,13 +28,6 @@ export function snaps(state = {
         isFetching: false,
         success: false,
         error: action.payload.error
-      };
-    // TODO bartaz refactor
-    // make sure registered name is updated in entities
-    case RegisterNameActionTypes.REGISTER_NAME_SUCCESS:
-      return {
-        ...state,
-        snaps: updateRegisteredName(state.snaps, action.payload.id, action.payload.snapName)
       };
     case ActionTypes.REMOVE_SNAP:
       return {
@@ -79,14 +39,6 @@ export function snaps(state = {
         ...state,
         isFetching: false,
         success: true,
-        // TODO bartaz refactor
-        // make sure ids are up to date after remove, also remove from entities?
-        snaps: (
-          state.snaps !== null ?
-          state.snaps.filter((snap) => {
-            return snap.git_repository_url !== action.payload.repository_url;
-          }) : null
-        ),
         ids: state.ids.filter((id) => {
           return id !== action.payload.repository_url;
         }),

--- a/src/common/reducers/snaps.js
+++ b/src/common/reducers/snaps.js
@@ -38,9 +38,7 @@ export function snaps(state = {
     case ActionTypes.FETCH_SNAPS:
       return {
         ...state,
-        isFetching: true,
-        success: false,
-        error: null
+        isFetching: true
       };
       // XXX a little confusing because we're not refactoring this yet, just
       // making do for the repositories refactor

--- a/src/common/selectors/index.js
+++ b/src/common/selectors/index.js
@@ -6,6 +6,8 @@ import { parseGitHubRepoUrl } from '../helpers/github-url';
 const getRepositoriesIndex = state => state.repositories.ids;
 const getRepositories = state => state.entities.repos;
 const getRepositoryOwners = state => state.entities.owners;
+// TODO: bartaz refactor
+// replace old selectors with new ones
 const getSnaps = state => state.snaps;
 const _getSnapsIndex = state => state.snaps.ids;
 const _getSnaps = state => state.entities.snaps;

--- a/src/common/selectors/index.js
+++ b/src/common/selectors/index.js
@@ -6,38 +6,33 @@ import { parseGitHubRepoUrl } from '../helpers/github-url';
 const getRepositoriesIndex = state => state.repositories.ids;
 const getRepositories = state => state.entities.repos;
 const getRepositoryOwners = state => state.entities.owners;
-// TODO: bartaz refactor
-// replace old selectors with new ones
-const getSnaps = state => state.snaps;
-const _getSnapsIndex = state => state.snaps.ids;
-const _getSnaps = state => state.entities.snaps;
+const getSnapsIndex = state => state.snaps.ids;
+const getSnaps = state => state.entities.snaps;
 const getSnapBuilds = state => state.snapBuilds;
 
 /**
  * @returns {Boolean} true if there are any snaps in state
  */
 export const hasSnaps = createSelector(
-  [getSnaps],
-  (snaps) => snaps.snaps ? snaps.snaps.length > 0 : false
+  [getSnapsIndex],
+  (ids) => ids.length > 0
 );
 
 /**
  * @returns {Boolean} true if there are no snaps in state
  */
 export const hasNoSnaps = createSelector(
-  [getSnaps],
-  (snaps) => snaps.snaps ? snaps.snaps.length === 0 : true
+  [getSnapsIndex],
+  (ids) => ids.length === 0
 );
 
 /**
  * @returns {Boolean} true if there are no snaps with registered names in state
  */
 export const hasNoRegisteredNames = createSelector(
-  [getSnaps],
-  (snaps) => {
-    return snaps.snaps ? !snaps.snaps.some((snap) => {
-      return snap.store_name;
-    }) : true;
+  [getSnapsIndex, getSnaps],
+  (ids, snaps) => {
+    return !ids.some((id) => snaps[id].store_name);
   }
 );
 
@@ -45,24 +40,18 @@ export const hasNoRegisteredNames = createSelector(
  * @returns {Boolean} true if there are no configured snaps
  */
 export const hasNoConfiguredSnaps = createSelector(
-  [getSnaps],
-  (snaps) => {
-    return snaps.snaps ? !snaps.snaps.some((snap) => {
-      return snap.snapcraft_data;
-    }) : true;
+  [getSnapsIndex, getSnaps],
+  (ids, snaps) => {
+    return !ids.some((id) => snaps[id].snapcraft_data);
   }
 );
 
 /**
  * @returns {Boolean} true if snaps were successfully fetched
+ *
+ * TODO: don't rely on success? but if not on that then on what?
  */
-export const hasLoadedSnaps = createSelector(
-  [getSnaps],
-  // TODO bartaz refactor
-  // don't rely on success? but if not on that then on what?
-  // TODO add tests
-  (snaps) => snaps.success
-);
+export const hasLoadedSnaps = (state) => state.snaps.success;
 
 /**
  * TODO merge with reposToAdd?
@@ -115,7 +104,7 @@ export const hasFailedRepositories = createSelector(
  * @todo consider case for multiple snapcraft.yaml's per git_repository_url
  */
 export const getEnabledRepositories = createSelector(
-  [getRepositories, getRepositoriesIndex, _getSnaps, _getSnapsIndex],
+  [getRepositories, getRepositoriesIndex, getSnaps, getSnapsIndex],
   (repositories, repositoriesIndex, snaps, snapIndex) => {
     return pick(repositories, repositoriesIndex.filter((repositoryId) => {
       return snapIndex.some((snapId) => {
@@ -129,11 +118,11 @@ export const getEnabledRepositories = createSelector(
  * @returns {Array} snaps that have both registered name and snapcraft data
  */
 export const snapsWithRegisteredNameAndSnapcraftData = createSelector(
-  [getSnaps],
-  (snaps) => {
-    return snaps.snaps ? snaps.snaps.filter((snap) => {
+  [getSnapsIndex, getSnaps],
+  (ids, snaps) => {
+    return ids.map((id) => snaps[id]).filter((snap) => {
       return snap.store_name && snap.snapcraft_data;
-    }) : [];
+    });
   }
 );
 
@@ -141,11 +130,11 @@ export const snapsWithRegisteredNameAndSnapcraftData = createSelector(
  * @returns {Array} snaps that have registered name but no snapcraft data
  */
 export const snapsWithRegisteredNameAndNoSnapcraftData = createSelector(
-  [getSnaps],
-  (snaps) => {
-    return snaps.snaps ? snaps.snaps.filter((snap) => {
+  [getSnapsIndex, getSnaps],
+  (ids, snaps) => {
+    return ids.map((id) => snaps[id]).filter((snap) => {
       return snap.store_name && !snap.snapcraft_data;
-    }) : [];
+    });
   }
 );
 

--- a/src/common/selectors/index.js
+++ b/src/common/selectors/index.js
@@ -54,6 +54,17 @@ export const hasNoConfiguredSnaps = createSelector(
 );
 
 /**
+ * @returns {Boolean} true if snaps were successfully fetched
+ */
+export const hasLoadedSnaps = createSelector(
+  [getSnaps],
+  // TODO bartaz refactor
+  // don't rely on success? but if not on that then on what?
+  // TODO add tests
+  (snaps) => snaps.success
+);
+
+/**
  * TODO merge with reposToAdd?
  * @returns {Array} get selected repositories
  */

--- a/test/unit/src/common/components/repositories-home/t_repositories-home.js
+++ b/test/unit/src/common/components/repositories-home/t_repositories-home.js
@@ -27,6 +27,9 @@ describe('The RepositoriesHome component', () => {
           authenticated: true
         },
         user: {},
+        entities: {
+          snaps: {}
+        },
         snaps: {},
         snapBuilds: {},
         fetchBuilds: () => {},
@@ -51,9 +54,13 @@ describe('The RepositoriesHome component', () => {
           authenticated: true
         },
         user: {},
+        entities: {
+          snaps: {}
+        },
         snaps: {
           success: true,
-          snaps: []
+          snaps: [],
+          ids: []
         },
         snapBuilds: {},
         fetchBuilds: () => {},
@@ -95,6 +102,9 @@ describe('The RepositoriesHome component', () => {
           authenticated: true
         },
         user: {},
+        entities: {
+          snaps: {}
+        },
         snaps: {},
         snapBuilds: {},
         updateSnaps: expect.createSpy(),

--- a/test/unit/src/common/components/repositories-list/t_repositories-list.js
+++ b/test/unit/src/common/components/repositories-list/t_repositories-list.js
@@ -7,23 +7,39 @@ import { Table, Body } from '../../../../../../src/common/components/vanilla/tab
 
 // state fixtures
 const initialState = {
+  hasSnaps: true,
   hasNoRegisteredNames: true,
   hasNoConfiguredSnaps: true,
   snaps: {
     isFetching: false,
     success: false,
     error: {},
-    snaps: [{
-      git_repository_url: 'https://github.com/earnubs/bsi-test-v'
-    }, {
-      git_repository_url: 'https://github.com/earnubs/bsi-test-ii'
-    }, {
-      git_repository_url: 'https://github.com/earnubs/bsi-test-iii'
-    }, {
-      git_repository_url: 'https://github.com/earnubs/bsi-test-iv'
-    }, {
-      git_repository_url: 'https://github.com/earnubs/bsi-test-i'
-    }]
+    ids: [
+      'https://github.com/earnubs/bsi-test-v',
+      'https://github.com/earnubs/bsi-test-ii',
+      'https://github.com/earnubs/bsi-test-iii',
+      'https://github.com/earnubs/bsi-test-iv',
+      'https://github.com/earnubs/bsi-test-i'
+    ]
+  },
+  entities: {
+    snaps: {
+      'https://github.com/earnubs/bsi-test-v': {
+        git_repository_url: 'https://github.com/earnubs/bsi-test-v'
+      },
+      'https://github.com/earnubs/bsi-test-ii': {
+        git_repository_url: 'https://github.com/earnubs/bsi-test-ii'
+      },
+      'https://github.com/earnubs/bsi-test-iii': {
+        git_repository_url: 'https://github.com/earnubs/bsi-test-iii'
+      },
+      'https://github.com/earnubs/bsi-test-iv': {
+        git_repository_url: 'https://github.com/earnubs/bsi-test-iv'
+      },
+      'https://github.com/earnubs/bsi-test-i': {
+        git_repository_url: 'https://github.com/earnubs/bsi-test-i'
+      }
+    }
   }
 };
 
@@ -33,8 +49,15 @@ describe('<RepositoriesList />', function() {
     let wrapper;
 
     beforeEach(function() {
-      initialState.snaps.snaps = null;
-      wrapper = shallow(<RepositoriesListView { ...initialState } />);
+      const state = {
+        ...initialState,
+        snaps: {
+          ...initialState.snaps,
+          ids: []
+        }
+      };
+
+      wrapper = shallow(<RepositoriesListView { ...state } />);
     });
 
     xit('should display \'No repos\' message', function() {

--- a/test/unit/src/common/reducers/entities/t_entities.js
+++ b/test/unit/src/common/reducers/entities/t_entities.js
@@ -3,11 +3,17 @@ import proxyquire from 'proxyquire';
 
 import * as fixtures from './fixtures.js';
 import * as RepoActionTypes from '../../../../../../src/common/actions/repository';
+import * as RegisterNameActionTypes from '../../../../../../src/common/actions/register-name';
 
 const repoSpy = expect.createSpy();
+const snapSpy = expect.createSpy();
+
 const entities = proxyquire('../../../../../../src/common/reducers/entities', {
   './repository': {
     default: repoSpy
+  },
+  './snap': {
+    default: snapSpy
   }
 }).entities;
 
@@ -39,7 +45,7 @@ describe('entities', function() {
   context('repository helper', function() {
 
     for (let type in RepoActionTypes) {
-      it(`should call the repository spy for ${type}`, function() {
+      it(`should call the repository reducer for ${type}`, function() {
         entities(fixtures.initialState, {
           type: type,
           payload: {
@@ -49,5 +55,16 @@ describe('entities', function() {
         expect(repoSpy).toHaveBeenCalled();
       });
     }
+
+    it('should call the snap reducer for REGISTER_NAME_SUCCESS', function() {
+      entities(fixtures.initialState, {
+        type: RegisterNameActionTypes.REGISTER_NAME_SUCCESS,
+        payload: {
+          id: 'http://github.com/anowner/aname'
+        }
+      });
+      expect(repoSpy).toHaveBeenCalled();
+    });
+
   });
 });

--- a/test/unit/src/common/reducers/entities/t_snap.js
+++ b/test/unit/src/common/reducers/entities/t_snap.js
@@ -1,0 +1,20 @@
+import expect from 'expect';
+
+import snap from '../../../../../../src/common/reducers/entities/snap.js';
+
+describe('snaps entities', function() {
+
+  let state = {
+    store_name: 'test-name'
+  };
+
+  it('should update registered name on REGISTER_NAME_SUCCESS', function() {
+    expect(snap(state, {
+      type: 'REGISTER_NAME_SUCCESS',
+      payload: {
+        snapName: 'test-name-changed'
+      }
+    }).store_name).toEqual('test-name-changed');
+  });
+
+});

--- a/test/unit/src/common/reducers/t_snaps.js
+++ b/test/unit/src/common/reducers/t_snaps.js
@@ -2,7 +2,6 @@ import expect from 'expect';
 
 import { snaps } from '../../../../../src/common/reducers/snaps';
 import * as ActionTypes from '../../../../../src/common/actions/snaps';
-import * as RegisterNameActionTypes from '../../../../../src/common/actions/register-name';
 
 describe('snaps reducers', () => {
   const initialState = {
@@ -119,30 +118,6 @@ describe('snaps reducers', () => {
         success: false,
         error: action.payload.error
       });
-    });
-  });
-
-  // TODO bartaz refactor
-  // move to entities
-  xcontext('REGISTER_NAME_SUCCESS', () => {
-    const state = {
-      ...initialState,
-      success: true,
-      snaps: SNAPS,
-      isFetching: true
-    };
-
-    const action = {
-      type: RegisterNameActionTypes.REGISTER_NAME_SUCCESS,
-      payload: {
-        id: 'anowner/anothername',
-        snapName: 'new-test-snap-name'
-      }
-    };
-
-    it('should update store_name of given snap', () => {
-      expect(snaps(state, action).snaps[0].store_name).toBe('test-snap-store-name');
-      expect(snaps(state, action).snaps[1].store_name).toBe('new-test-snap-name');
     });
   });
 

--- a/test/unit/src/common/reducers/t_snaps.js
+++ b/test/unit/src/common/reducers/t_snaps.js
@@ -9,7 +9,6 @@ describe('snaps reducers', () => {
     isFetching: false,
     success: false,
     error: null,
-    snaps: null,
     ids: []
   };
 
@@ -27,6 +26,8 @@ describe('snaps reducers', () => {
     self_link: 'https://api.launchpad.net/devel/~anowner/+snap/blahblahtest-xenial',
     store_name: 'test-snap-store-another-name'
   }];
+
+  const IDS = SNAPS.map((snap) => snap.git_repository_url);
 
   it('should return the initial state', () => {
     expect(snaps(undefined, {})).toEqual(initialState);
@@ -88,12 +89,6 @@ describe('snaps reducers', () => {
       expect(snaps(state, action).error).toBe(null);
     });
 
-    it('should store full snap info', () => {
-      snaps(state, action).snaps.forEach((snap, i) => {
-        expect(snap).toEqual(SNAPS[i]);
-      });
-    });
-
     it('should store result snap ids', () => {
       snaps(state, action).ids.forEach((id, i) => {
         expect(id).toEqual(SNAPS[i]['git_repository_url']);
@@ -105,7 +100,7 @@ describe('snaps reducers', () => {
     const state = {
       ...initialState,
       success: true,
-      snaps: SNAPS,
+      ids: IDS,
       isFetching: true
     };
 
@@ -127,7 +122,9 @@ describe('snaps reducers', () => {
     });
   });
 
-  context('REGISTER_NAME_SUCCESS', () => {
+  // TODO bartaz refactor
+  // move to entities
+  xcontext('REGISTER_NAME_SUCCESS', () => {
     const state = {
       ...initialState,
       success: true,
@@ -161,7 +158,7 @@ describe('snaps reducers', () => {
     const state = {
       ...initialState,
       isFetching: true,
-      snaps: SNAPS,
+      ids: IDS,
       error: 'Previous error'
     };
 
@@ -182,11 +179,11 @@ describe('snaps reducers', () => {
       expect(snaps(state, action).error).toBe(null);
     });
 
-    it('removes snap from state', () => {
-      expect(snaps(state, action).snaps.map((snap) => {
-        return snap.git_repository_url;
-      })).toEqual(['https://github.com/anowner/anothername']);
+    it('removes snap id from state', () => {
+      expect(snaps(state, action).ids).toExclude('https://github.com/anowner/aname');
     });
+
+
   });
 
   context('REMOVE_SNAP_ERROR', () => {

--- a/test/unit/src/common/selectors/t_selectors.js
+++ b/test/unit/src/common/selectors/t_selectors.js
@@ -4,6 +4,8 @@ import {
   hasSnaps,
   hasNoSnaps,
   hasNoRegisteredNames,
+  hasNoConfiguredSnaps,
+  hasLoadedSnaps,
   snapsWithRegisteredNameAndSnapcraftData,
   snapsWithRegisteredNameAndNoSnapcraftData,
   snapsWithNoBuilds,
@@ -12,37 +14,61 @@ import {
 
 describe('selectors', function() {
 
-  const stateWithNullSnaps = {
-    snaps: {
-      snaps: null
-    }
-  };
-
   const stateWithNoSnaps = {
     snaps: {
-      snaps: []
+      ids: []
+    },
+    entities: {
+      snaps: {}
     }
   };
 
   const stateWithNoName = {
     snaps: {
-      snaps: [{}, {}]
+      ids: ['https:github.com/anowner/aname', 'https:github.com/anowner/aname-i']
+    },
+    entities: {
+      snaps: {
+        'https:github.com/anowner/aname': {
+          git_repository_url: 'https:github.com/anowner/aname'
+        },
+        'https:github.com/anowner/aname-i': {
+          git_repository_url: 'https:github.com/anowner/aname-i'
+        }
+      }
     }
   };
 
   const stateWithName = {
     snaps: {
-      snaps: [{
-        store_name: 'bsi-test-ii'
-      }, {}]
+      ids: ['https:github.com/anowner/aname']
+    },
+    entities: {
+      snaps: {
+        'https:github.com/anowner/aname': {
+          store_name: 'bsi-test-ii',
+          git_repository_url: 'https:github.com/anowner/aname'
+        }
+      }
+    }
+  };
+
+  const stateWithSnapcraftData = {
+    snaps: {
+      ids: ['https:github.com/anowner/aname']
+    },
+    entities: {
+      snaps: {
+        'https:github.com/anowner/aname': {
+          store_name: 'bsi-test-ii',
+          snapcraft_data: { name: 'bsi-test-ii' },
+          git_repository_url: 'https:github.com/anowner/aname'
+        }
+      }
     }
   };
 
   context('hasSnaps', function() {
-    it('should be false when snaps are null in state', function() {
-      expect(hasSnaps(stateWithNullSnaps)).toBe(false);
-    });
-
     it('should be false when no snaps in state', function() {
       expect(hasSnaps(stateWithNoSnaps)).toBe(false);
     });
@@ -53,10 +79,6 @@ describe('selectors', function() {
   });
 
   context('hasNoSnaps', function() {
-    it('should be true when snaps are null in state', function() {
-      expect(hasNoSnaps(stateWithNullSnaps)).toBe(true);
-    });
-
     it('should be true when no snaps in state', function() {
       expect(hasNoSnaps(stateWithNoSnaps)).toBe(true);
     });
@@ -67,8 +89,8 @@ describe('selectors', function() {
   });
 
   context('hasNoRegisteredNames', function() {
-    it('should be true when snaps are null in state', function() {
-      expect(hasNoRegisteredNames(stateWithNullSnaps)).toBe(true);
+    it('should be true when no snaps in state', function() {
+      expect(hasNoRegisteredNames(stateWithNoSnaps)).toBe(true);
     });
 
     it('should be true when no names in state', function() {
@@ -80,19 +102,63 @@ describe('selectors', function() {
     });
   });
 
-  context('snapsWithRegisteredNameAndSnapcraftData', function() {
-    const stateWithNameAndSnapcraftData = {
+  context('hasNoConfiguredSnaps', function() {
+    it('should be true when no snaps in state', function() {
+      expect(hasNoConfiguredSnaps(stateWithNoSnaps)).toBe(true);
+    });
+
+    it('should be true when no snapcraft data in state', function() {
+      expect(hasNoConfiguredSnaps(stateWithNoName)).toBe(true);
+    });
+
+    it('should be false when snapcraft data is in state', function() {
+      expect(hasNoConfiguredSnaps(stateWithSnapcraftData)).toBe(false);
+    });
+  });
+
+  context('hasLoadedSnaps', function() {
+    const stateWithSnapsNotLoaded = {
       snaps: {
-        snaps: [{
-          store_name: 'bsi-test-ii',
-          snapcraft_data: { name: 'bsi-test-ii' }
-        }, {}]
+        success: false,
+        ids: []
       }
     };
 
-    it('should be empty when snaps are null in state', function() {
-      expect(snapsWithRegisteredNameAndSnapcraftData(stateWithNullSnaps)).toEqual([]);
+    const stateWithSnapsLoaded = {
+      snaps: {
+        success: true,
+        ids: []
+      }
+    };
+
+    it('should be false when snaps not yet loaded', function() {
+      expect(hasLoadedSnaps(stateWithSnapsNotLoaded)).toBe(false);
     });
+
+    it('should be true when snaps were already loaded', function() {
+      expect(hasLoadedSnaps(stateWithSnapsLoaded)).toBe(true);
+    });
+
+  });
+
+  context('snapsWithRegisteredNameAndSnapcraftData', function() {
+    const stateWithNameAndSnapcraftData = {
+      snaps: {
+        ids: [
+          'https:github.com/anowner/aname',
+          'https:github.com/anowner/aname-i'
+        ]
+      },
+      entities: {
+        snaps: {
+          'https:github.com/anowner/aname': {
+            store_name: 'bsi-test-ii',
+            snapcraft_data: { name: 'bsi-test-ii' }
+          },
+          'https:github.com/anowner/aname-i': {}
+        }
+      }
+    };
 
     it('should be empty when no snaps in state', function() {
       expect(snapsWithRegisteredNameAndSnapcraftData(stateWithNoSnaps)).toEqual([]);
@@ -111,18 +177,23 @@ describe('selectors', function() {
   context('snapsWithRegisteredNameAndNoSnapcraftData', function() {
     const stateWithNameAndNoSnapcraftData = {
       snaps: {
-        snaps: [{
-          store_name: 'bsi-test-ii',
-          snapcraft_data: { name: 'bsi-test-ii' }
-        }, {
-          store_name: 'bsi-test-iii'
-        }]
+        ids: [
+          'https:github.com/anowner/aname',
+          'https:github.com/anowner/aname-i'
+        ]
+      },
+      entities: {
+        snaps: {
+          'https:github.com/anowner/aname': {
+            store_name: 'bsi-test-ii',
+            snapcraft_data: { name: 'bsi-test-ii' }
+          },
+          'https:github.com/anowner/aname-i': {
+            store_name: 'bsi-test-iii'
+          }
+        }
       }
     };
-
-    it('should be empty when snaps are null in state', function() {
-      expect(snapsWithRegisteredNameAndNoSnapcraftData(stateWithNullSnaps)).toEqual([]);
-    });
 
     it('should be empty when no snaps in state', function() {
       expect(snapsWithRegisteredNameAndNoSnapcraftData(stateWithNoSnaps)).toEqual([]);
@@ -140,15 +211,24 @@ describe('selectors', function() {
   context('snapsWithNoBuilds', function() {
     const stateWithBuilds = {
       snaps: {
-        snaps: [{
-          store_name: 'bsi-test-ii',
-          git_repository_url: 'https://github.com/test/bsi-test',
-          snapcraft_data: { name: 'bsi-test-ii' }
-        }, {
-          store_name: 'bsi-test-iii',
-          git_repository_url: 'https://github.com/test/bsi-test-iii',
-          snapcraft_data: { name: 'bsi-test-iii' }
-        }]
+        ids: [
+          'https://github.com/test/bsi-test',
+          'https://github.com/test/bsi-test-iii'
+        ]
+      },
+      entities: {
+        snaps: {
+          'https://github.com/test/bsi-test': {
+            store_name: 'bsi-test-ii',
+            git_repository_url: 'https://github.com/test/bsi-test',
+            snapcraft_data: { name: 'bsi-test-ii' }
+          },
+          'https://github.com/test/bsi-test-iii': {
+            store_name: 'bsi-test-iii',
+            git_repository_url: 'https://github.com/test/bsi-test-iii',
+            snapcraft_data: { name: 'bsi-test-iii' }
+          }
+        }
       },
       snapBuilds: {
         'test/bsi-test': {
@@ -161,10 +241,6 @@ describe('selectors', function() {
         },
       }
     };
-
-    it('should be empty when snaps are null in state', function() {
-      expect(snapsWithNoBuilds(stateWithNullSnaps)).toEqual([]);
-    });
 
     it('should be empty when no snaps in state', function() {
       expect(snapsWithNoBuilds(stateWithNoSnaps)).toEqual([]);


### PR DESCRIPTION
First part of #465

- removes snaps objects from `snaps` reducer and only keeps list of `ids` there
- snaps data is now fully kept in `entities`
- updated relevant components, selectors, etc to accommodate the change

This should be a good first step refactoring, further work is needed around actions, API calls etc.
As described in TODO items in code and in description of #465