### PR TITLE
Rewrite subscribe handler using request

### DIFF
--- a/src/server/handlers/subscribe.js
+++ b/src/server/handlers/subscribe.js
@@ -1,5 +1,4 @@
-import 'isomorphic-fetch';
-import url from 'url';
+import request from 'request';
 import sanitizeHtml from 'sanitize-html';
 
 import { conf } from '../helpers/config';
@@ -10,45 +9,38 @@ export const MAILCHIMP_FORM_ID = '381f5c55f1';
 const HTTP_PROXY = conf.get('HTTP_PROXY');
 
 export const privateRepos = async (req, res) => {
-  const formUrl = url.parse(MAILCHIMP_FORM_URL);
-  const submitUrl = url.format({
-    ...formUrl,
-    query: {
+  const options = {
+    uri: MAILCHIMP_FORM_URL,
+    headers: { 'Accept': 'application/json' },
+    qs: {
       u: MAILCHIMP_FORM_U,
       id: MAILCHIMP_FORM_ID,
       EMAIL: req.query.email
-    }
-  });
-
-  const response = await fetch(submitUrl, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
     },
+    json: true,
     proxy: HTTP_PROXY
-  });
-  const json = await response.json();
+  };
 
-  json.msg = sanitizeHtml(json.msg, {
-    transformTags: {
-      'a': (tagName, attribs) => {
-        return {
-          tagName: 'a',
-          attribs: {
-            href: attribs.href,
-            target: '_blank',
-            rel: 'noreferrer noopener'
-          }
-        };
+  request.get(options, (error, response, body) => {
+    body.msg = sanitizeHtml(body.msg, {
+      transformTags: {
+        'a': (tagName, attribs) => {
+          return {
+            tagName: 'a',
+            attribs: {
+              href: attribs.href,
+              target: '_blank',
+              rel: 'noreferrer noopener'
+            }
+          };
+        }
+      },
+      allowedTags: [ 'b', 'i', 'em', 'strong', 'a' ],
+      allowedAttributes: {
+        'a': [ 'href', 'target', 'rel' ]
       }
-    },
-    allowedTags: [ 'b', 'i', 'em', 'strong', 'a' ],
-    allowedAttributes: {
-      'a': [ 'href', 'target', 'rel' ]
-    }
+    });
+
+    return res.status(response.statusCode).send(body);
   });
-
-
-  return res.status(response.status).send(json);
 };


### PR DESCRIPTION
`fetch` doesn't support proxies, so is no good in staging/production
where we need a proxy to talk to MailChimp.

Fixes #617.