### PR TITLE
614: Add CSRF tokens to single repo API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npm run test:setup-db && nyc npm run test:unit && npm run test:routes && npm run lint",
     "test:setup-db": "rm -f test.sqlite3 && NODE_ENV=test npm run migrate:latest",
     "test:unit": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*",
+    "test:unit:inspect": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --inspect --debug-brk --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*",
     "test:routes": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/routes/**/*",
     "migrate:latest": "knex migrate:latest",
     "migrate:rollback": "knex migrate:rollback"

--- a/src/common/components/select-repository-list/index.js
+++ b/src/common/components/select-repository-list/index.js
@@ -2,7 +2,6 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
-import { conf } from '../../helpers/config';
 import SelectRepositoryRow from '../select-repository-row';
 import Spinner from '../spinner';
 import PageLinks from '../page-links';
@@ -28,44 +27,12 @@ import styles from './styles.css';
 // loading container styles not to duplicate .spinner class
 import { spinner as spinnerStyles } from '../../containers/container.css';
 
-const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
-
 export class SelectRepositoryListComponent extends Component {
 
   componentDidMount() {
     this.props.selectedRepositories && this.props.selectedRepositories.map(id => {
       this.props.dispatch(resetRepository(id));
     });
-  }
-
-  // TODO this can be moved too select-repository-row as the error prop is on
-  // the repository object passed to it
-  getSnapNotRegisteredMessage(snapName) {
-    const devportalUrl = conf.get('STORE_DEVPORTAL_URL');
-    const registerNameUrl = `${devportalUrl}/click-apps/register-name/` +
-                            `?name=${encodeURIComponent(snapName)}`;
-
-    return <span>
-      The name provided in the snapcraft.yaml file ({snapName}) is not
-      registered in the store.
-      Please <a href={registerNameUrl}>register it</a> before trying
-      again.
-    </span>;
-  }
-
-  // TODO this can be moved too select-repository-row as the error prop is on
-  // the repository object passed to it
-  getErrorMessage(error) {
-
-    const { payload = undefined } = error;
-
-    if (payload) {
-      if (payload.code === SNAP_NAME_NOT_REGISTERED_ERROR_CODE) {
-        return this.getSnapNotRegisteredMessage(payload.snap_name);
-      } else {
-        return payload.message;
-      }
-    }
   }
 
   renderRepository(id) {
@@ -79,7 +46,7 @@ export class SelectRepositoryListComponent extends Component {
         key={ `repo_${fullName}` }
         repository={ repository }
         onChange={ this.onSelectRepository.bind(this, id) }
-        errorMsg={ repository.error && this.getErrorMessage(repository.error) }
+        errorMsg={ repository.error && repository.error.message }
         isEnabled={ isEnabled }
       />
     );

--- a/src/common/reducers/entities/repository.js
+++ b/src/common/reducers/entities/repository.js
@@ -6,7 +6,6 @@ export default function repository(state={
   isFetching: false,
   error: null
 }, action) {
-
   switch(action.type) {
     case ActionTypes.REPO_TOGGLE_SELECT: {
       const wasSelected = state.isSelected;
@@ -16,14 +15,14 @@ export default function repository(state={
         isSelected: !wasSelected
       };
     }
-    case ActionTypes.REPO_ADD: {
+    case ActionTypes.REPO_ADD_REQUEST: {
       return {
         ...state,
         isFetching: true,
         isSelected: true
       };
     }
-    case ActionTypes.REPO_SUCCESS: {
+    case ActionTypes.REPO_ADD_SUCCESS: {
       return {
         ...state,
         isFetching: false,
@@ -38,11 +37,11 @@ export default function repository(state={
         error: null
       };
     }
-    case ActionTypes.REPO_FAILURE: {
+    case ActionTypes.REPO_ADD_FAILURE: {
       return {
         ...state,
         isFetching: false,
-        error: action.payload.error.json
+        error: action.payload.error
       };
     }
     default:

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -39,19 +39,19 @@ const RESPONSE_OTHER = {
   }
 };
 
-const RESPONSE_ALREADY_CREATED = {
-  status: 'error',
-  payload: {
-    code: 'github-already-created',
-    message: 'A webhook already exists on the given repository'
-  }
-};
-
 const RESPONSE_CREATED = {
   status: 'success',
   payload: {
     code: 'github-webhook-created',
     message: 'GitHub webhook successfully created'
+  }
+};
+
+const RESPONSE_ALREADY_CREATED = {
+  status: 'success',
+  payload: {
+    code: 'github-already-created',
+    message: 'A webhook already exists on the given repository'
   }
 };
 
@@ -196,7 +196,7 @@ export const createWebhook = async (req, res) => {
           return res.status(401).send(RESPONSE_AUTHENTICATION_FAILED);
         case 'Validation Failed':
           // Webhook already created
-          return res.status(422).send(RESPONSE_ALREADY_CREATED);
+          return res.status(200).send(RESPONSE_ALREADY_CREATED);
         default:
           // Something else
           logger.error('GitHub API error', response.statusCode);

--- a/src/server/routes/github.js
+++ b/src/server/routes/github.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { json } from 'body-parser';
 
+import { verifyToken } from '../middleware/csrf-token';
 import {
   getUser,
   createWebhook,
@@ -11,6 +12,7 @@ import { getSnapcraftYaml } from '../handlers/launchpad';
 const router = Router();
 
 router.use('/github/webhook', json());
+router.post('/github/webhook', verifyToken);
 router.post('/github/webhook', createWebhook);
 
 router.use('/github/user', json());

--- a/src/server/routes/launchpad.js
+++ b/src/server/routes/launchpad.js
@@ -15,6 +15,7 @@ import {
 const router = Router();
 
 router.use('/launchpad/snaps', json());
+router.post('/launchpad/snaps', verifyToken);
 router.post('/launchpad/snaps', newSnap);
 router.get('/launchpad/snaps', findSnap);
 

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -9,7 +9,7 @@ import { conf } from '../../../../../src/server/helpers/config.js';
 
 describe('The GitHub API endpoint', () => {
   const app = Express();
-  const session = { 'token': 'secret' };
+  const session = { 'token': 'secret', 'csrfTokens': ['blah']  };
 
   let scope;
 
@@ -458,6 +458,7 @@ describe('The GitHub API endpoint', () => {
       it('should call GitHub API endpoint to create new webhook', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .end((err) => {
             scope.done();
@@ -469,6 +470,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a 201 created response', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(201, done);
       });
@@ -476,6 +478,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a "success" status', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('success'))
           .end(done);
@@ -484,6 +487,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a "github-webhook-created" message', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-webhook-created'))
           .end(done);
@@ -501,24 +505,27 @@ describe('The GitHub API endpoint', () => {
         nock.cleanAll();
       });
 
-      it('should return a 422 Unprocessable Entity response', (done) => {
+      it('should return a 200 OK', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
-          .expect(422, done);
+          .expect(200, done);
       });
 
-      it('should return a "error" status', (done) => {
+      it('should return a "success" status', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
-          .expect(hasStatus('error'))
+          .expect(hasStatus('success'))
           .end(done);
       });
 
       it('should return a body with a "github-already-created" message', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-already-created'))
           .end(done);
@@ -539,6 +546,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a 404 Not Found response', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(404, done);
       });
@@ -546,6 +554,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -554,6 +563,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a "github-repository-not-found" message', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-repository-not-found'))
           .end(done);
@@ -574,6 +584,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(401, done);
       });
@@ -581,6 +592,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -589,6 +601,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a github-authentication-failed message', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-authentication-failed'))
           .end(done);
@@ -609,6 +622,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a 500 Internal Server Error response', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(500, done);
       });
@@ -616,6 +630,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -624,6 +639,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a github-error-other message', (done) => {
         supertest(app)
           .post('/github/webhook')
+          .set('X-CSRF-Token', 'blah')
           .send({ owner: 'anowner', name: 'aname' })
           .expect(hasMessage('github-error-other'))
           .end(done);

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -42,6 +42,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
@@ -49,6 +50,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -57,6 +59,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a body with a "not-logged-in" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('not-logged-in'))
           .end(done);
@@ -98,6 +101,7 @@ describe('The Launchpad API endpoint', () => {
         it('should return a 400 Bad Request response', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(400, done);
         });
@@ -105,6 +109,7 @@ describe('The Launchpad API endpoint', () => {
         it('should return a "error" status', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasStatus('error'))
             .end(done);
@@ -113,6 +118,7 @@ describe('The Launchpad API endpoint', () => {
         it('should return a body with an "lp-error" message', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasMessage(
                 'lp-error',
@@ -127,6 +133,7 @@ describe('The Launchpad API endpoint', () => {
           await dbUser.save({ snaps_added: 1 });
           await supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' });
           await dbUser.refresh();
           expect(dbUser.get('snaps_added')).toEqual(1);
@@ -185,6 +192,7 @@ describe('The Launchpad API endpoint', () => {
         it('should return a 201 Created response', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(201, done);
         });
@@ -192,6 +200,7 @@ describe('The Launchpad API endpoint', () => {
         it('should return a "success" status', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasStatus('success'))
             .end(done);
@@ -200,6 +209,7 @@ describe('The Launchpad API endpoint', () => {
         it('should return a body with the new snap URL', (done) => {
           supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasMessage('snap-created', snapUrl))
             .end(done);
@@ -208,6 +218,7 @@ describe('The Launchpad API endpoint', () => {
         it('should leave snaps_added unmodified if it is unset', async () => {
           await supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' });
           const dbUser = await db.model('GitHubUser')
             .where({ github_id: session.user.id })
@@ -222,6 +233,7 @@ describe('The Launchpad API endpoint', () => {
           await dbUser.save({ snaps_added: 1 });
           await supertest(app)
             .post('/launchpad/snaps')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' });
           await dbUser.refresh();
           expect(dbUser.get('snaps_added')).toEqual(2);
@@ -233,6 +245,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 400 Bad Request response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'nonsense' })
           .expect(400, done);
       });
@@ -240,6 +253,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'nonsense' })
           .expect(hasStatus('error'))
           .end(done);
@@ -248,6 +262,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a body with a "github-bad-url" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'nonsense' })
           .expect(hasMessage('github-bad-url'))
           .end(done);
@@ -268,6 +283,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
@@ -275,6 +291,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -284,6 +301,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-no-admin-permissions'))
           .end(done);
@@ -304,6 +322,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 Not Found response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(404, done);
       });
@@ -311,6 +330,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -320,6 +340,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-snapcraft-yaml-not-found'))
           .end(done);
@@ -340,6 +361,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
@@ -347,6 +369,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -356,6 +379,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-authentication-failed'))
           .end(done);

--- a/test/unit/src/common/middleware/t_call-api.js
+++ b/test/unit/src/common/middleware/t_call-api.js
@@ -149,20 +149,27 @@ describe('The callApi middleware', () => {
         };
       });
 
-      it('should dispatch EXAMPLE_ACTION', async () => {
-        await store.dispatch(action);
-        expect(store.getActions()).toHaveActionOfType('EXAMPLE_ACTION');
+      it('should dispatch EXAMPLE_ACTION', (done) => {
+        store.dispatch(action).catch(() => {
+          expect(store.getActions()).toHaveActionOfType('EXAMPLE_ACTION');
+          done();
+        });
       });
 
-      it('should dispatch EXAMPLE_ACTION_ERROR', async () => {
-        await store.dispatch(action);
-        expect(store.getActions()).toHaveActionOfType('EXAMPLE_ACTION_ERROR');
+      it('should dispatch EXAMPLE_ACTION_ERROR', (done) => {
+        store.dispatch(action).catch(() => {
+          expect(store.getActions()).toHaveActionOfType('EXAMPLE_ACTION_ERROR');
+          done();
+        });
+
       });
 
-      it('should dispatch EXAMPLE_ACTION_SUCCESS with a payload containing fetched response', async () => {
-        await store.dispatch(action);
-        expect(store.getActions()).toHaveActionsMatching((action) => {
-          return action.payload.error && action.payload.error.message === RESPONSE.payload.message;
+      it('should dispatch EXAMPLE_ACTION_SUCCESS with a payload containing fetched response', (done) => {
+        store.dispatch(action).catch(() => {
+          expect(store.getActions()).toHaveActionsMatching((action) => {
+            return action.payload.error && action.payload.error.message === RESPONSE.payload.message;
+          });
+          done();
         });
       });
     });

--- a/test/unit/src/common/reducers/entities/t_repository.js
+++ b/test/unit/src/common/reducers/entities/t_repository.js
@@ -11,30 +11,28 @@ describe('repository entities', function() {
 
     beforeEach(function() {
       state = repository(undefined, {
-        type: 'REPO_ADD',
+        type: 'REPO_ADD_REQUEST',
         payload: fixtures.repoPayload
       });
     });
 
-    it('should update state on REPO_ADD', function() {
+    it('should update state on REPO_ADD_REQUEST', function() {
       expect(state).toEqual(fixtures.repoAddState);
     });
 
-    it('should update state on REPO_SUCCESS', function() {
+    it('should update state on REPO_ADD_SUCCESS', function() {
       expect(repository(state, {
-        type: 'REPO_SUCCESS',
+        type: 'REPO_ADD_SUCCESS',
         payload: fixtures.repoPayload
       })).toEqual(fixtures.repoSuccessState);
     });
 
-    it('should update state on REPO_FAILURE', function() {
+    it('should update state on REPO_ADD_FAILURE', function() {
       expect(repository(state, {
-        type: 'REPO_FAILURE',
+        type: 'REPO_ADD_FAILURE',
         payload: {
           ...fixtures.repoPayload,
-          error: {
-            json: fixtures.repoFailureState.error
-          }
+          error: fixtures.repoFailureState.error
         }
       })).toEqual(fixtures.repoFailureState);
     });


### PR DESCRIPTION
- Refactored actions to use CALL_API middleware
- Rewrote CALL_API middleware to use promises instead of async / await
- Renamed single repo action type identifiers
- Changed webhook-already-created response to return 200
- Added verify token middleware to add repo endpoint
- Added verify token middleware to webhook endpoint