### PR TITLE
Point browser to SCA for registerName

### DIFF
--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -8,6 +8,7 @@ import { checkPackageUploadRequest, getAccountInfo } from './auth-store';
 import { requestBuilds } from './snap-builds';
 
 const BASE_URL = conf.get('BASE_URL');
+const STORE_API_URL = conf.get('STORE_API_URL');
 
 // action types
 export const REGISTER_NAME = 'REGISTER_NAME';
@@ -86,7 +87,7 @@ async function signAgreement(root, discharge) {
 }
 
 async function requestRegisterName(root, discharge, snapName) {
-  return await fetch(`${conf.get('STORE_API_URL')}/register-name`, {
+  return await fetch(`${STORE_API_URL}/register-name`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -115,7 +116,7 @@ export async function internalRegisterName(root, discharge, snapName) {
 }
 
 async function getPackageUploadMacaroon(root, discharge, snapName) {
-  const response = await fetch(`${conf.get('STORE_API_URL')}/acl/`, {
+  const response = await fetch(`${STORE_API_URL}/acl/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -214,7 +215,7 @@ export function registerNameClear(id) {
 export async function internalNameOwnership(root, discharge, snapName) {
   // first request package_upload macaroon to see if name is registered
   // in the store
-  const url = `${conf.get('STORE_API_URL')}/acl/`;
+  const url = `${STORE_API_URL}/acl/`;
   const aclResponse = await fetch(url, {
     method: 'POST',
     headers: {

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -86,16 +86,15 @@ async function signAgreement(root, discharge) {
 }
 
 async function requestRegisterName(root, discharge, snapName) {
-  return await fetch(`${BASE_URL}/api/store/register-name`, {
+  return await fetch(`${conf.get('STORE_API_URL')}/register-name`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Accept': 'application/json'
+      'Accept': 'application/json',
+      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
     },
     body: JSON.stringify({
       snap_name: snapName,
-      root,
-      discharge
     })
   });
 }

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -20,33 +20,7 @@ const dumpCaveats = (rawMacaroon) => {
   return caveats;
 };
 
-export const registerName = async (req, res) => {
-  const snapName = req.body.snap_name;
-  const root = req.body.root;
-  const discharge = req.body.discharge;
-
-  const url = `${conf.get('STORE_API_URL')}/register-name/`;
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
-    },
-    body: JSON.stringify({ snap_name: snapName })
-  });
-  const json = await response.json();
-  if (response.status === 401) {
-    // Debug https://github.com/canonical-ols/build.snapcraft.io/issues/527
-    logger.info(`Failed to register name "${snapName}"`);
-    logger.info(`Root macaroon: ${dumpCaveats(root)}`);
-    logger.info(`Discharge macaroon: ${dumpCaveats(discharge)}`);
-    logger.info(
-      `WWW-Authenticate: ${response.headers.get('WWW-Authenticate')}`);
-  }
-  return res.status(response.status).send(json);
-};
-
+// XXX: Client can go straight to SCA for this now
 export const getAccount = async (req, res) => {
   const root = req.query.root;
   const discharge = req.query.discharge;

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -1,7 +1,6 @@
 import 'isomorphic-fetch';
 import { conf } from '../helpers/config';
 
-// XXX: Client can go straight to SCA for this now
 export const getAccount = async (req, res) => {
   const root = req.query.root;
   const discharge = req.query.discharge;

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -1,24 +1,5 @@
 import 'isomorphic-fetch';
-import { MacaroonsBuilder } from 'macaroons.js';
-
-import { getCaveats } from '../../common/helpers/macaroons';
 import { conf } from '../helpers/config';
-import logging from '../logging';
-
-const logger = logging.getLogger('express');
-
-const dumpCaveats = (rawMacaroon) => {
-  const macaroon = MacaroonsBuilder.deserialize(rawMacaroon);
-  const caveats = [];
-  for (const caveat of getCaveats(macaroon)) {
-    if (caveat.verificationKeyId === '') {
-      caveats.push(caveat.caveatId);
-    } else {
-      caveats.push(`Discharge required from ${caveat.location}`);
-    }
-  }
-  return caveats;
-};
 
 // XXX: Client can go straight to SCA for this now
 export const getAccount = async (req, res) => {

--- a/src/server/routes/store.js
+++ b/src/server/routes/store.js
@@ -4,14 +4,10 @@ import { json } from 'body-parser';
 import {
   getAccount,
   patchAccount,
-  registerName,
   signAgreement
 } from '../handlers/store';
 
 const router = Router();
-
-router.use('/store/register-name', json());
-router.post('/store/register-name', registerName);
 
 router.use('/store/account', json());
 router.get('/store/account', getAccount);

--- a/test/routes/src/server/routes/t_store.js
+++ b/test/routes/src/server/routes/t_store.js
@@ -3,81 +3,12 @@ import Express from 'express';
 import nock from 'nock';
 import supertest from 'supertest';
 
-import {
-  resetMemcached,
-  setupInMemoryMemcached
-} from '../../../../../src/server/helpers/memcached';
 import store from '../../../../../src/server/routes/store';
 import { conf } from '../../../../../src/server/helpers/config';
 
 describe('The store API endpoint', () => {
   const app = Express();
   app.use(store);
-
-  describe('register-name route', () => {
-    beforeEach(() => {
-      setupInMemoryMemcached();
-    });
-
-    afterEach(() => {
-      resetMemcached();
-      nock.cleanAll();
-    });
-
-    it('passes request through to store', (done) => {
-      const scope = nock(conf.get('STORE_API_URL'))
-        .post('/register-name/', { snap_name: 'test-snap' })
-        .matchHeader(
-          'Authorization',
-          'Macaroon root="dummy-root", discharge="dummy-discharge"'
-        )
-        .reply(201, { snap_id: 'test-snap-id' });
-
-      supertest(app)
-        .post('/store/register-name')
-        .send({
-          snap_name: 'test-snap',
-          repository_url: 'https://github.com/anowner/arepo',
-          root: 'dummy-root',
-          discharge: 'dummy-discharge'
-        })
-        .expect((res) => {
-          scope.done();
-          expect(res.status).toBe(201);
-          expect(res.body).toEqual({ snap_id: 'test-snap-id' });
-        })
-        .end(done);
-    });
-
-    it('handles error responses reasonably', (done) => {
-      const error = {
-        code: 'user-not-ready',
-        message: 'Developer has not signed agreement.'
-      };
-      const scope = nock(conf.get('STORE_API_URL'))
-        .post('/register-name/', { snap_name: 'test-snap' })
-        .matchHeader(
-          'Authorization',
-          'Macaroon root="dummy-root", discharge="dummy-discharge"'
-        )
-        .reply(403, { error_list: [error] });
-
-      supertest(app)
-        .post('/store/register-name')
-        .send({
-          snap_name: 'test-snap',
-          repository_url: 'https://github.com/anowner/arepo',
-          root: 'dummy-root',
-          discharge: 'dummy-discharge'
-        })
-        .expect((res) => {
-          scope.done();
-          expect(res.status).toBe(403);
-          expect(res.body).toEqual({ error_list: [error] });
-        })
-        .end(done);
-    });
-  });
 
   describe('GET account route', () => {
     afterEach(() => {

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -90,7 +90,8 @@ describe('register name actions', () => {
 
   context('internalRegisterName', () => {
     it('throws an error on failure to register snap name', async () => {
-      storeApi.post('/register-name', { snap_name: 'test-snap' })
+      storeApi
+        .post('/register-name', { snap_name: 'test-snap' })
         .reply(409, {
           status: 409,
           code: 'already_registered',
@@ -109,7 +110,8 @@ describe('register name actions', () => {
     });
 
     it('succeeds if registering snap name says already owned', async () => {
-      storeApi.post('/register-name', { snap_name: 'test-snap' })
+      storeApi
+        .post('/register-name', { snap_name: 'test-snap' })
         .reply(409, {
           status: 409,
           code: 'already_owned',
@@ -120,7 +122,8 @@ describe('register name actions', () => {
 
     it('succeeds if registering snap name succeeds', async () => {
       // XXX check Authorization header
-      storeApi.post('/register-name', { snap_name: 'test-snap' })
+      storeApi
+        .post('/register-name', { snap_name: 'test-snap' })
         .reply(201, { snap_id: 'test-snap-id' });
       await internalRegisterName(root, discharge, 'test-snap');
     });
@@ -174,7 +177,7 @@ describe('register name actions', () => {
       });
 
       it('stores an error on failure to register snap name', async () => {
-        storeApi = nock(conf.get('STORE_API_URL'))
+        storeApi
           .post('/register-name', { snap_name: 'test-snap' })
           .reply(409, {
             status: 409,

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -197,22 +197,20 @@ describe('register name actions', () => {
       });
 
       context('if registering snap name succeeds', () => {
-        let storeScope;
-
         beforeEach(() => {
           // XXX check Authorization header
-          storeScope = nock(conf.get('STORE_API_URL'))
+          storeApi = nock(conf.get('STORE_API_URL'))
             .post('/register-name', { snap_name: 'test-snap' })
             .reply(201, { snap_id: 'test-snap-id' });
         });
 
         afterEach(() => {
-          storeScope.done();
+          storeApi.done();
         });
 
         it('stores an error on failure to get package upload ' +
            'macaroon', async () => {
-          storeScope
+          storeApi
             .post('/acl/', {
               packages: [{ name: 'test-snap', series: '16' }],
               permissions: ['package_upload'],
@@ -238,7 +236,7 @@ describe('register name actions', () => {
         context('if getting package upload macaroon succeeds', () => {
           beforeEach(() => {
             // XXX check headers and body
-            storeScope.post('/acl/')
+            storeApi.post('/acl/')
               .reply(200, { macaroon: 'dummy-package-upload-macaroon' });
           });
 
@@ -498,8 +496,6 @@ describe('register name actions', () => {
     });
 
     context('when given snap name is registered by current user', () => {
-      let storeApi;
-
       const snapName = 'test-snap';
 
       beforeEach(() => {
@@ -526,8 +522,6 @@ describe('register name actions', () => {
     });
 
     context('when given snap name is registered by another user', () => {
-      let storeApi;
-
       const snapName = 'test-snap';
 
       beforeEach(() => {
@@ -554,8 +548,6 @@ describe('register name actions', () => {
     });
 
     context('when given snap name is registered by another user', () => {
-      let storeApi;
-
       const snapName = 'test-snap';
 
       beforeEach(() => {

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -90,8 +90,7 @@ describe('register name actions', () => {
 
   context('internalRegisterName', () => {
     it('throws an error on failure to register snap name', async () => {
-      storeApi = nock(conf.get('STORE_API_URL'))
-        .post('/register-name', { snap_name: 'test-snap' })
+      storeApi.post('/register-name', { snap_name: 'test-snap' })
         .reply(409, {
           status: 409,
           code: 'already_registered',
@@ -110,8 +109,7 @@ describe('register name actions', () => {
     });
 
     it('succeeds if registering snap name says already owned', async () => {
-      storeApi = nock(conf.get('STORE_API_URL'))
-        .post('/register-name', { snap_name: 'test-snap' })
+      storeApi.post('/register-name', { snap_name: 'test-snap' })
         .reply(409, {
           status: 409,
           code: 'already_owned',
@@ -122,8 +120,7 @@ describe('register name actions', () => {
 
     it('succeeds if registering snap name succeeds', async () => {
       // XXX check Authorization header
-      storeApi = nock(conf.get('STORE_API_URL'))
-        .post('/register-name', { snap_name: 'test-snap' })
+      storeApi.post('/register-name', { snap_name: 'test-snap' })
         .reply(201, { snap_id: 'test-snap-id' });
       await internalRegisterName(root, discharge, 'test-snap');
     });


### PR DESCRIPTION
Note this depends on [a SCA MP](https://code.launchpad.net/~adam-collard/software-center-agent/add-cors-headers/+merge/322856) before it can be deployed. I figure it's worth getting :eyes: on this first :man_shrugging: 

Instead of talking to the backend proxy for `registerName` POST directly to SCA. This removes one case of the security issue highlighted in #272