### PR TITLE
Suggest snap name based on repo name

### DIFF
--- a/src/common/components/repository-row/dropdowns/register-name-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/register-name-dropdown.js
@@ -112,6 +112,7 @@ const Caption = (props) => {
           <label>New name:
             {' ' /* force space between inline elements */}
             <input
+              autoFocus={true}
               className={ styles.snapNameInput }
               type='text'
               value={ snapName }

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -36,7 +36,10 @@ export class RepositoryRowView extends Component {
     if (props.snap.snapcraftData && props.snap.snapcraftData.name) {
       snapName = props.snap.snapcraftData.name;
     } else {
-      snapName = '';
+      // suggest name based on git repository name
+      snapName = parseGitHubRepoUrl(props.snap.gitRepoUrl).name.toLowerCase();
+      // replace invalid characters with dash are trim leading and trailing dashes
+      snapName = snapName.replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '');
     }
 
     this.state = {
@@ -407,6 +410,7 @@ export class RepositoryRowView extends Component {
       return (
         <form onSubmit={this.onRegisterSubmit.bind(this, snap.gitRepoUrl)}>
           <input
+            autoFocus={true}
             type='text'
             className={ styles.snapNameInput }
             value={ this.state.snapName }

--- a/test/unit/src/common/components/repository-row/t_repository-row.js
+++ b/test/unit/src/common/components/repository-row/t_repository-row.js
@@ -132,4 +132,28 @@ describe('<RepositoryRowView />', () => {
     });
   });
 
+  context('when snapcraft data with name is available', () => {
+    it('should set default snap name based on name from snapcraft.yaml', () => {
+      expect(view.instance().state.snapName).toEqual(props.snap.snapcraftData.name);
+    });
+  });
+
+  context('when snapcraft data is not available', () => {
+    beforeEach(() => {
+      const noNameProps = {
+        ...props,
+        snap: {
+          gitRepoUrl: 'http://github.com/anowner/_some-Crazy_123Name_'
+        }
+      };
+
+      view = shallow(<RepositoryRowView { ...noNameProps }/>);
+    });
+
+    it('should set default snap name based on repo name', () => {
+      // valid name should be lowercased with unvalid chars replaced with dashes
+      expect(view.instance().state.snapName).toEqual('some-crazy-123name');
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes #669 

If snapcraft.yaml is not available we are now suggesting snap name to register based on repo name.

