### PR TITLE
Add baseline support for organisation repositories

### DIFF
--- a/src/common/components/private-repos-info/index.js
+++ b/src/common/components/private-repos-info/index.js
@@ -110,7 +110,7 @@ export default class PrivateReposInfo extends Component {
   render() {
     return (
       <div className={ styles.info }>
-        <p>Organization and private repos not shown yet. (<a onClick={this.onHelpClick.bind(this)}>Why?</a>)</p>
+        <p>Private repos not shown yet. (<a onClick={this.onHelpClick.bind(this)}>Why?</a>)</p>
         { this.state.showPopover &&
           <Popover
             left={this.state.popoverOffsetLeft}

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -124,7 +124,7 @@ export class RepositoriesListView extends Component {
           </Head>
           <Body>
             { this.props.hasSnaps &&
-              ids.map(this.renderRow.bind(this))
+              Array.from(ids).sort().map(this.renderRow.bind(this))
             }
           </Body>
         </Table>

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -1,11 +1,13 @@
+import qs from 'qs';
 import request from 'request';
 import logging from '../logging';
 
 import db from '../db';
 import { conf } from '../helpers/config';
-import { requestUser } from './github';
+import { getMemcached } from '../helpers/memcached';
+import { listOrganizationsCacheId, requestUser } from './github';
 
-const AUTH_SCOPE = 'admin:repo_hook'; // another scope (like 'public_repo') may be needed to list organisations' repositories
+const AUTH_SCOPE = 'admin:repo_hook read:org';
 const GITHUB_AUTH_LOGIN_URL = conf.get('GITHUB_AUTH_LOGIN_URL');
 const GITHUB_AUTH_VERIFY_URL = conf.get('GITHUB_AUTH_VERIFY_URL');
 const GITHUB_AUTH_CLIENT_ID = conf.get('GITHUB_AUTH_CLIENT_ID');
@@ -24,13 +26,13 @@ export const authenticate = (req, res, next) => {
     req.session.sharedSecret = buffer.toString('hex');
 
     // Redirect user to GitHub login
-    res.redirect(`${GITHUB_AUTH_LOGIN_URL}?` + [
-      `client_id=${GITHUB_AUTH_CLIENT_ID}`,
-      `redirect_uri=${GITHUB_AUTH_REDIRECT_URL}`,
-      `scope=${AUTH_SCOPE}`,
-      `state=${req.session.sharedSecret}`,
-      'allow_signup=true'
-    ].join('&'));
+    res.redirect(`${GITHUB_AUTH_LOGIN_URL}?` + qs.stringify({
+      client_id: GITHUB_AUTH_CLIENT_ID,
+      redirect_uri: GITHUB_AUTH_REDIRECT_URL,
+      scope: AUTH_SCOPE,
+      state: req.session.sharedSecret,
+      allow_signup: true
+    }));
   });
 };
 
@@ -76,6 +78,11 @@ export const verify = (req, res, next) => {
     req.session.githubAuthenticated = true;
     req.session.token = body.access_token;
     req.session.user = userResponse.body;
+
+    // Make sure organization information is fetched again, since
+    // permissions may have changed
+    const orgsCacheID = listOrganizationsCacheId(userResponse.body.login);
+    await getMemcached().del(orgsCacheID);
 
     // Save user info to DB
     await db.transaction(async (trx) => {

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -337,7 +337,7 @@ export const newSnap = async (req, res) => {
 
   // We need admin permissions in order to be able to install a webhook later.
   try {
-    const { owner } = await checkAdminPermissions(req.session, repositoryUrl);
+    await checkAdminPermissions(req.session, repositoryUrl);
     await db.transaction(async (trx) => {
       if (req.session.user) {
         await db.model('GitHubUser').incrementMetric(
@@ -348,10 +348,8 @@ export const newSnap = async (req, res) => {
 
       const result = await requestNewSnap(repositoryUrl);
       // as new snap is created we need to clear list of snaps from cache
-      const urlPrefix = getRepoUrlPrefix(owner);
-      const cacheId = getUrlPrefixCacheId(urlPrefix);
+      await clearSnapCache(repositoryUrl);
 
-      await getMemcached().del(cacheId);
       const snapUrl = result.self_link;
       logger.info(`Created ${snapUrl}`);
       await ensureWebhook(result);

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 
 import yaml from 'js-yaml';
+import zip from 'lodash/zip';
 import { normalize } from 'normalizr';
 
 import { parseGitHubRepoUrl } from '../../common/helpers/github-url';
@@ -11,7 +12,7 @@ import requestGitHub from '../helpers/github';
 import getLaunchpad from '../launchpad';
 import logging from '../logging';
 import * as schema from './schema.js';
-import { getSnapcraftData } from './github';
+import { getSnapcraftData, internalListOrganizations } from './github';
 import { getLaunchpadRootSecret, makeWebhookSecret } from './webhook';
 
 const logger = logging.getLogger('express');
@@ -138,7 +139,7 @@ const sendError = async (res, error) => {
   res.status(preparedError.status).send(preparedError.body);
 };
 
-const checkGitHubStatus = (response) => {
+export const checkGitHubStatus = (response) => {
   if (response.statusCode !== 200) {
     let body = response.body;
     if (typeof body !== 'object') {
@@ -411,34 +412,60 @@ export const internalFindSnap = async (repositoryUrl) => {
   throw new PreparedError(404, RESPONSE_SNAP_NOT_FOUND);
 };
 
-const internalFindSnapsByPrefix = async (urlPrefix) => {
+const internalFindSnaps = async (owner, token) => {
+  const orgs = await internalListOrganizations(owner, token);
+  const owners = [owner].concat(orgs.map((org) => org.login));
+  const urlPrefixes = owners.map(getRepoUrlPrefix);
   const username = conf.get('LP_API_USERNAME');
-  const cacheId = getUrlPrefixCacheId(urlPrefix);
+  const cacheIds = urlPrefixes.map(getUrlPrefixCacheId);
+  const memcached = getMemcached();
   const lpClient = getLaunchpad();
+  let snaps;
+  let remainingPrefixes;
 
   try {
-    const result = await getMemcached().get(cacheId);
-    if (result !== undefined) {
-      return result.map((entry) => {
+    snaps = await Promise.all(
+      cacheIds.map((cacheId) => memcached.get(cacheId))
+    );
+    remainingPrefixes = zip(urlPrefixes, snaps)
+      .filter(([, snap]) => snap === undefined)
+      .map(([urlPrefix, ]) => urlPrefix);
+    if (!remainingPrefixes.length) {
+      return [].concat(...snaps).map((entry) => {
         return lpClient.wrap_resource(entry.self_link, entry);
       });
     }
+    snaps = snaps.filter((snap) => snap !== undefined);
   } catch (error) {
-    logger.error(`Error getting ${cacheId} from memcached: ${error}`);
+    logger.error(`Error getting one of ${cacheIds} from memcached: ${error}`);
+    snaps = [];
+    remainingPrefixes = urlPrefixes;
   }
 
   try {
-    const result = await lpClient.named_get('/+snaps', 'findByURLPrefix', {
+    const result = await lpClient.named_get('/+snaps', 'findByURLPrefixes', {
       parameters: {
-        url_prefix: urlPrefix,
+        url_prefixes: remainingPrefixes,
         owner: `/~${username}`
       }
     });
-    await getMemcached().set(cacheId, result.entries, 3600);
-    for (const snap of result.entries) {
+    // Split up results into separate cache entries so that they can help
+    // speed things up for other users.
+    const newSnaps = remainingPrefixes.map((urlPrefix) => {
+      return result.entries.filter(
+        (snap) => snap.git_repository_url.startsWith(urlPrefix)
+      );
+    });
+    await Promise.all(zip(remainingPrefixes, newSnaps).map(
+      ([urlPrefix, snap]) => memcached.set(
+        getUrlPrefixCacheId(urlPrefix), snap, 3600
+      )
+    ));
+    snaps = snaps.concat(...newSnaps);
+    for (const snap of snaps) {
       await ensureWebhook(snap);
     }
-    return result.entries;
+    return snaps;
   } catch (error) {
     // At least for the moment, we just wrap the error we get from
     // Launchpad.
@@ -504,9 +531,8 @@ const initializeMetrics = async (gitHubId, snaps) => {
 
 export const findSnaps = async (req, res) => {
   const owner = req.query.owner || req.session.user.login;
-  const urlPrefix = getRepoUrlPrefix(owner);
   try {
-    const rawSnaps = await internalFindSnapsByPrefix(urlPrefix);
+    const rawSnaps = await internalFindSnaps(owner, req.session.token);
     const snaps = await Promise.all(rawSnaps.map(async (snap) => {
       const snapcraftData = await getSnapcraftData(
         snap.git_repository_url, req.session.token

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -11,7 +11,10 @@ import {
 } from '../../../../../src/server/helpers/memcached';
 import launchpad from '../../../../../src/server/routes/launchpad';
 import db from '../../../../../src/server/db';
-import { getSnapcraftYamlCacheId } from '../../../../../src/server/handlers/github';
+import {
+  getSnapcraftYamlCacheId,
+  listOrganizationsCacheId
+} from '../../../../../src/server/handlers/github';
 import {
   getUrlPrefixCacheId,
   getRepositoryUrlCacheId
@@ -406,8 +409,8 @@ describe('The Launchpad API endpoint', () => {
 
     context('when snaps exist', () => {
       const contents = {
-        'https://github.com/another-user/test-snap': { name: 'snap1' },
-        'https://github.com/test-user/test-snap': { name: 'snap2' }
+        'https://github.com/anowner/test-snap': { name: 'snap1' },
+        'https://github.com/org1/test-snap': { name: 'snap2' }
       };
 
       let testSnaps;
@@ -425,7 +428,7 @@ describe('The Launchpad API endpoint', () => {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~another-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~another-user`,
-            git_repository_url: 'https://github.com/another-user/test-snap',
+            git_repository_url: 'https://github.com/anowner/test-snap',
             builds_collection_link: `${lp_api_base}/~another-user/+snap/` +
                                     'test-snap/builds',
             webhooks_collection_link: `${lp_api_base}/~another-user/+snap/` +
@@ -436,7 +439,7 @@ describe('The Launchpad API endpoint', () => {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~test-user`,
-            git_repository_url: 'https://github.com/test-user/test-snap',
+            git_repository_url: 'https://github.com/org1/test-snap',
             builds_collection_link: `${lp_api_base}/~test-user/+snap/` +
                                     'test-snap/builds',
             webhooks_collection_link: `${lp_api_base}/~test-user/+snap/` +
@@ -444,11 +447,19 @@ describe('The Launchpad API endpoint', () => {
           }
         ];
 
+        ghApi = nock(gh_api_url);
+        ghApi.get('/user/orgs')
+          .reply(200, [{ login: 'org1' }, { login: 'org2' }]);
+
         lpApi = nock(lp_api_url);
         lpApi.get('/devel/+snaps')
           .query({
-            'ws.op': 'findByURLPrefix',
-            url_prefix: 'https://github.com/anowner/',
+            'ws.op': 'findByURLPrefixes',
+            url_prefixes: [
+              'https://github.com/anowner/',
+              'https://github.com/org1/',
+              'https://github.com/org2/'
+            ],
             owner: `/~${conf.get('LP_API_USERNAME')}`
           })
           .reply(200, {
@@ -461,8 +472,7 @@ describe('The Launchpad API endpoint', () => {
           const fullName = snap.git_repository_url.replace('https://github.com/', '');
           const repoContents = contents[snap.git_repository_url];
 
-          ghApi = nock(gh_api_url)
-            .get(`/repos/${fullName}/contents/snap/snapcraft.yaml`)
+          ghApi.get(`/repos/${fullName}/contents/snap/snapcraft.yaml`)
             .reply(200, repoContents);
           const builds_link = snap.builds_collection_link;
           lpApi.get(builds_link.replace(lp_api_url, ''))
@@ -485,12 +495,12 @@ describe('The Launchpad API endpoint', () => {
         lpApi.get('/devel/~another-user/+snap/test-snap/webhooks')
           .reply(200, { total_size: 0, entries: [] });
         const hmac = createHmac('sha1', conf.get('LP_WEBHOOK_SECRET'));
-        hmac.update('another-user');
+        hmac.update('anowner');
         hmac.update('test-snap');
         lpApi
           .post('/devel/~another-user/+snap/test-snap', {
             'ws.op': 'newWebhook',
-            delivery_url: `${conf.get('BASE_URL')}/another-user/test-snap/` +
+            delivery_url: `${conf.get('BASE_URL')}/anowner/test-snap/` +
                           'webhook/notify',
             event_types: 'snap:build:0.1',
             active: 'true',
@@ -514,8 +524,8 @@ describe('The Launchpad API endpoint', () => {
                 resource_type_link: `${lp_api_url}/devel/#webhook`,
                 self_link: `${lp_api_url}/~test-user/+snap/test-snap/` +
                            '+webhook/1',
-                delivery_url: `${conf.get('BASE_URL')}/` +
-                              'test-user/test-snap/webhook/notify',
+                delivery_url: `${conf.get('BASE_URL')}/org1/test-snap/` +
+                              'webhook/notify',
               }
             ]
           });
@@ -602,15 +612,34 @@ describe('The Launchpad API endpoint', () => {
           resetMemcached();
         });
 
+        it('should store organizations in memcached', async () => {
+          await apiResponse;
+          const cacheId = listOrganizationsCacheId('anowner');
+          const memcachedOrgs = getMemcached().cache[cacheId];
+          expect(memcachedOrgs).toMatch([
+            { login: 'org1' }, { login: 'org2' }
+          ]);
+        });
+
         it('should store snaps in memcached', async () => {
-          const urlPrefix = 'https://github.com/anowner/';
-          const cacheId = getUrlPrefixCacheId(urlPrefix);
+          const urlPrefixes = [
+            'https://github.com/anowner/',
+            'https://github.com/org1/',
+            'https://github.com/org2/'
+          ];
+          const cacheIds = urlPrefixes.map(
+            (urlPrefix) => getUrlPrefixCacheId(urlPrefix)
+          );
 
           await apiResponse;
-          const memcachedSnaps = getMemcached().cache[cacheId];
-          expect(memcachedSnaps.length).toEqual(testSnaps.length);
-          expect(memcachedSnaps[0]).toContain(testSnaps[0]);
-          expect(memcachedSnaps[1]).toContain(testSnaps[1]);
+          const memcachedSnaps = cacheIds.map(
+            (cacheId) => getMemcached().cache[cacheId]
+          );
+          expect(memcachedSnaps[0].length).toBe(1);
+          expect(memcachedSnaps[0][0]).toContain(testSnaps[0]);
+          expect(memcachedSnaps[1].length).toBe(1);
+          expect(memcachedSnaps[1][0]).toContain(testSnaps[1]);
+          expect(memcachedSnaps[2].length).toBe(0);
         });
 
       });
@@ -619,15 +648,24 @@ describe('The Launchpad API endpoint', () => {
 
     context('when snaps don\'t exist', () => {
       let lpApi;
+      let ghApi;
 
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
+        const gh_api_url = conf.get('GITHUB_API_ENDPOINT');
 
+        ghApi = nock(gh_api_url)
+          .get('/user/orgs')
+          .reply(200, [{ login: 'org1' }, { login: 'org2' }]);
         lpApi = nock(lp_api_url)
           .get('/devel/+snaps')
           .query({
-            'ws.op': 'findByURLPrefix',
-            url_prefix: 'https://github.com/anowner/',
+            'ws.op': 'findByURLPrefixes',
+            url_prefixes: [
+              'https://github.com/anowner/',
+              'https://github.com/org1/',
+              'https://github.com/org2/'
+            ],
             owner: `/~${conf.get('LP_API_USERNAME')}`
           })
           .reply(200, {
@@ -639,6 +677,7 @@ describe('The Launchpad API endpoint', () => {
 
       afterEach(() => {
         lpApi.done();
+        ghApi.done();
         nock.cleanAll();
       });
 
@@ -660,15 +699,20 @@ describe('The Launchpad API endpoint', () => {
 
     context('when LP returns error', () => {
       let lpApi;
+      let ghApi;
 
       beforeEach(() => {
         const lp_api_url = conf.get('LP_API_URL');
+        const gh_api_url = conf.get('GITHUB_API_ENDPOINT');
 
+        ghApi = nock(gh_api_url)
+          .get('/user/orgs')
+          .reply(200, []);
         lpApi = nock(lp_api_url)
           .get('/devel/+snaps')
           .query({
-            'ws.op': 'findByURLPrefix',
-            url_prefix: 'https://github.com/anowner/',
+            'ws.op': 'findByURLPrefixes',
+            url_prefixes: 'https://github.com/anowner/',
             owner: `/~${conf.get('LP_API_USERNAME')}`
           })
           .reply(501, 'Something went quite wrong.');
@@ -676,6 +720,7 @@ describe('The Launchpad API endpoint', () => {
 
       afterEach(() => {
         lpApi.done();
+        ghApi.done();
         nock.cleanAll();
       });
 
@@ -694,7 +739,6 @@ describe('The Launchpad API endpoint', () => {
 
 
     context('when snaps are memcached', () => {
-      const urlPrefix = 'https://github.com/anowner/';
       let testSnaps;
       let lpApi;
 
@@ -707,7 +751,7 @@ describe('The Launchpad API endpoint', () => {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~another-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~another-user`,
-            git_repository_url: 'https://github.com/another-user/test-snap',
+            git_repository_url: 'https://github.com/anowner/test-snap',
             builds_collection_link: `${lp_api_base}/~another-user/+snap/` +
                                     'test-snap/builds',
             store_name: 'snap1'
@@ -716,19 +760,24 @@ describe('The Launchpad API endpoint', () => {
             resource_type_link: `${lp_api_base}/#snap`,
             self_link: `${lp_api_base}/~test-user/+snap/test-snap`,
             owner_link: `${lp_api_base}/~test-user`,
-            git_repository_url: 'https://github.com/test-user/test-snap',
+            git_repository_url: 'https://github.com/org1/test-snap',
             builds_collection_link: `${lp_api_base}/~test-user/+snap/` +
                                     'test-snap/builds'
           }
         ];
 
         const contents = {
-          'https://github.com/another-user/test-snap': { name: 'snap1' },
-          'https://github.com/test-user/test-snap': { name: 'snap2' }
+          'https://github.com/anowner/test-snap': { name: 'snap1' },
+          'https://github.com/org1/test-snap': { name: 'snap2' }
         };
 
         setupInMemoryMemcached({
-          [getUrlPrefixCacheId(urlPrefix)]: testSnaps
+          [listOrganizationsCacheId('anowner')]: [
+            { login: 'org1' }, { login: 'org2' }
+          ],
+          [getUrlPrefixCacheId('https://github.com/anowner/')]: [testSnaps[0]],
+          [getUrlPrefixCacheId('https://github.com/org1/')]: [testSnaps[1]],
+          [getUrlPrefixCacheId('https://github.com/org2/')]: []
         });
 
         lpApi = nock(lp_api_url);

--- a/test/unit/src/common/components/repositories-list/t_repositories-list.js
+++ b/test/unit/src/common/components/repositories-list/t_repositories-list.js
@@ -77,7 +77,7 @@ describe('<RepositoriesList />', function() {
       expect(wrapper.children().length).toBe(5);
     });
 
-    xit('should display snap rows in alphabetical order', function() {
+    it('should display snap rows in alphabetical order', function() {
       expect(wrapper.childAt(0).props().fullName).toBe('earnubs/bsi-test-i');
     });
 


### PR DESCRIPTION
This shows organisation repositories for which the user has admin
permissions in the add-repositories dialog, and shows organisation
repositories that the user can write to on the my-repositories page.
Various aspects of the UI will need to be tidied up in future PRs, but
this at least gets us started.

We now request the `read:org` scope from GitHub, which allows us to tell
which organisations a user is in.

I also included a change to sort repository list rows alphabetically,
since given the rest of this change I was seeing odd results without
that.

Fixes #620; fixes #648.