### PR TITLE
Don't try to use removed store routes

### DIFF
--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -2,7 +2,6 @@ import github from './github';
 import githubAuth from './github-auth';
 import launchpad from './launchpad';
 import login from './login';
-import store from './store';
 import universal from './universal';
 import webhook from './webhook';
 import subscribe from './subscribe';
@@ -12,7 +11,6 @@ export {
   github,
   launchpad,
   login,
-  store,
   subscribe,
   webhook,
   universal

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -61,7 +61,6 @@ app.use(generateToken);
 app.use('/', routes.login);
 app.use('/api', routes.github);
 app.use('/api', routes.launchpad);
-app.use('/api', routes.store);
 app.use('/api', routes.subscribe);
 app.use('/', routes.webhook);
 app.use(routes.githubAuth);


### PR DESCRIPTION
@katiefenn noticed that the app is broken because the routes removed in #272 were still being referenced :cry: 

This PR removes those references. Ideally we'd have test coverage of these - I think we should land this first, then look at increasing coverage as a tech debt item?