### PR TITLE
Warning when renaming published snap

### DIFF
--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -86,10 +86,12 @@ export class RepositoriesListView extends Component {
     }
 
     let latestBuild = null;
+    let isPublished = false;
     const currentSnapBuilds = snapBuilds[fullName];
 
     if (currentSnapBuilds && currentSnapBuilds.success && currentSnapBuilds.builds.length) {
       latestBuild = currentSnapBuilds.builds[0];
+      isPublished = currentSnapBuilds.builds.some((build) => build.isPublished);
     }
 
     const registerNameStatus = snap.registerNameStatus || {};
@@ -99,6 +101,7 @@ export class RepositoriesListView extends Component {
         key={ `repo_${fullName}` }
         snap={ snap }
         latestBuild={ latestBuild }
+        isPublished={ isPublished }
         fullName={ fullName }
         authStore={ authStore }
         registerNameStatus={ registerNameStatus }

--- a/src/common/components/repository-row/dropdowns/register-name-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/register-name-dropdown.js
@@ -49,6 +49,7 @@ const Caption = (props) => {
     onSignAgreementChange,
     snapName,
     snapcraftData,
+    isPublished,
     onRegisterSubmit,
     onSnapNameChange
   } = props;
@@ -103,6 +104,9 @@ const Caption = (props) => {
       <div>
         If you change the registered name:
         <ul>
+          { isPublished &&
+            <li>Devices with the snap already installed will no longer receive updates.</li>
+          }
           { snapcraftData.name === registeredName &&
             <li>Builds will stop until you update the snapcraft.yaml to match.</li>
           }
@@ -112,6 +116,7 @@ const Caption = (props) => {
           <label>New name:
             {' ' /* force space between inline elements */}
             <input
+              spellCheck={false}
               autoFocus={true}
               className={ styles.snapNameInput }
               type='text'
@@ -181,6 +186,7 @@ Caption.propTypes = {
   registeredName: PropTypes.string,
   snapName: PropTypes.string,
   snapcraftData: PropTypes.object,
+  isPublished: PropTypes.bool,
   authStore: PropTypes.shape({
     authenticated: PropTypes.bool,
     hasDischarge: PropTypes.bool,
@@ -268,6 +274,7 @@ const RegisterNameDropdown = (props) => {
             registeredName={props.registeredName}
             snapName={props.snapName}
             snapcraftData={props.snapcraftData}
+            isPublished={props.isPublished}
             authStore={props.authStore}
             registerNameStatus={props.registerNameStatus}
             onRegisterSubmit={props.onRegisterSubmit}
@@ -297,6 +304,7 @@ RegisterNameDropdown.propTypes = {
   registeredName: PropTypes.string,
   registerNameStatus: PropTypes.object,
   snapcraftData: PropTypes.object,
+  isPublished: PropTypes.bool,
   onSnapNameChange: PropTypes.func.isRequired,
   onSignAgreementChange: PropTypes.func.isRequired,
   onRegisterSubmit: PropTypes.func.isRequired,

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -243,6 +243,7 @@ export class RepositoryRowView extends Component {
     const {
       snap,
       latestBuild,
+      isPublished,
       fullName,
       authStore,
       registerNameStatus
@@ -301,6 +302,7 @@ export class RepositoryRowView extends Component {
           <RegisterNameDropdown
             registeredName={registeredName}
             snapcraftData={snap.snapcraftData}
+            isPublished={isPublished}
             snapName={this.state.snapName}
             authStore={authStore}
             registerNameStatus={registerNameStatus}
@@ -391,6 +393,7 @@ export class RepositoryRowView extends Component {
       content = (
         <form onSubmit={this.onRegisterSubmit.bind(this, snap.gitRepoUrl)}>
           <input
+            spellCheck={false}
             autoFocus={true}
             type='text'
             className={ styles.snapNameInput }
@@ -470,6 +473,7 @@ RepositoryRowView.propTypes = {
     dateStarted: PropTypes.string,
     statusMessage: PropTypes.string
   }),
+  isPublished: PropTypes.bool,
   fullName: PropTypes.string,
   authStore: PropTypes.shape({
     authenticated: PropTypes.bool,

--- a/src/common/helpers/snap-builds.js
+++ b/src/common/helpers/snap-builds.js
@@ -62,7 +62,7 @@ export function snapBuildFromAPI(entry) {
 
     colour: BuildStatusMapping[entry.buildstate],
     statusMessage: entry.buildstate,
-
+    isPublished: entry.store_upload_status === 'Uploaded',
     dateCreated: entry.datecreated,
     dateStarted: entry.date_started,
     dateBuilt: entry.datebuilt,

--- a/test/unit/src/common/helpers/t_snap-builds.js
+++ b/test/unit/src/common/helpers/t_snap-builds.js
@@ -34,7 +34,8 @@ describe('snapBuildFromAPI helper', () => {
     'archive_link': 'https://api.launchpad.net/devel/ubuntu/+archive/primary',
     'arch_tag': 'amd64',
     'upload_log_url': null,
-    'store_upload_revision': 15
+    'store_upload_revision': 15,
+    'store_upload_status': 'Uploaded'
   };
 
   let snapBuild;
@@ -54,6 +55,7 @@ describe('snapBuildFromAPI helper', () => {
 
         'colour',
         'statusMessage',
+        'isPublished',
 
         'dateCreated',
         'dateStarted',
@@ -79,6 +81,10 @@ describe('snapBuildFromAPI helper', () => {
 
     it('should take statusMessage from buildstate field', () => {
       expect(snapBuild.statusMessage).toEqual(SNAP_BUILD_ENTRY.buildstate);
+    });
+
+    it('should set isPublished to true for Uploaded build', () => {
+      expect(snapBuild.isPublished).toBe(true);
     });
 
     it('should take dateCreated from datecreated field', () => {


### PR DESCRIPTION
Fixes #670

Passes published status (based on build store upload status) to name register dropdown to warn when renaming already published snap.

