### PR TITLE
Properly propagate store authenticated initial state

### DIFF
--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -23,9 +23,11 @@ const SNAP_NAME_NOT_REGISTERED_ERROR_CODE = 'snap-name-not-registered';
 export class RepositoriesListView extends Component {
 
   fetchAuthData(authStore) {
-    if (authStore.authenticated === null) {
+    // check if authenticated and hasShortNamespace haven't been set yet,
+    // so are null or undefined
+    if (authStore.authenticated == null) {
       this.props.dispatch(checkSignedIntoStore());
-    } else if (authStore.hasShortNamespace === null) {
+    } else if (authStore.hasShortNamespace == null) {
       this.props.dispatch(getAccountInfo(authStore.userName));
     }
   }

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -25,9 +25,11 @@ export class RepositoriesListView extends Component {
   fetchAuthData(authStore) {
     // check if authenticated and hasShortNamespace haven't been set yet,
     // so are null or undefined
-    if (authStore.authenticated == null) {
+    if (authStore.authenticated === null ||
+        typeof authStore.authenticated === 'undefined') {
       this.props.dispatch(checkSignedIntoStore());
-    } else if (authStore.hasShortNamespace == null) {
+    } else if (authStore.hasShortNamespace === null ||
+               typeof authStore.hasShortNamespace === 'undefined') {
       this.props.dispatch(getAccountInfo(authStore.userName));
     }
   }

--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -26,10 +26,10 @@ export class RepositoriesListView extends Component {
     // check if authenticated and hasShortNamespace haven't been set yet,
     // so are null or undefined
     if (authStore.authenticated === null ||
-        typeof authStore.authenticated === 'undefined') {
+        authStore.authenticated === undefined) {
       this.props.dispatch(checkSignedIntoStore());
     } else if (authStore.hasShortNamespace === null ||
-               typeof authStore.hasShortNamespace === 'undefined') {
+               authStore.hasShortNamespace === undefined) {
       this.props.dispatch(getAccountInfo(authStore.userName));
     }
   }

--- a/src/server/handlers/universal.js
+++ b/src/server/handlers/universal.js
@@ -34,7 +34,7 @@ export const handleMatch = (req, res, error, redirectLocation, renderProps) => {
 
     const initialState = {
       auth: { authenticated: false },
-      authStore: {}
+      authStore: { authenticated: null }
     };
 
     if (req.session.githubAuthenticated) {


### PR DESCRIPTION
Even though we store macaroons in browser storage app did not properly check if user is already signed in after full page reload.

It was caused by `authenticated` flag being undefined in initial state rather then being `null` (as app code expected).