### PR TITLE
API to refresh user orgs

### DIFF
--- a/src/common/actions/organizations.js
+++ b/src/common/actions/organizations.js
@@ -1,0 +1,18 @@
+import { CALL_API } from '../middleware/call-api';
+
+export const ORGANIZATIONS_REQUEST = 'ORGANIZATIONS_REQUEST';
+export const ORGANIZATIONS_SUCCESS = 'ORGANIZATIONS_SUCCESS';
+export const ORGANIZATIONS_FAILURE = 'ORGANIZATIONS_FAILURE';
+
+export function fetchUserOrganizations(owner) {
+  return {
+    [CALL_API]: {
+      types: [ORGANIZATIONS_REQUEST, ORGANIZATIONS_SUCCESS, ORGANIZATIONS_FAILURE],
+      path: `/api/github/orgs?owner=${owner}`,
+      options: {
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin'
+      }
+    }
+  };
+}

--- a/src/common/components/select-repositories-page/index.js
+++ b/src/common/components/select-repositories-page/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import { fetchBuilds } from '../../actions/snap-builds';
 import { fetchUserRepositoriesAndSnaps } from '../../actions/repositories';
+import { fetchUserOrganizations } from '../../actions/organizations';
 import SelectRepositoryList from '../select-repository-list';
 import { HeadingThree } from '../vanilla/heading';
 import FirstTimeHeading from '../first-time-heading';
@@ -17,6 +18,7 @@ class SelectRepositoriesPage extends Component {
     const owner = this.props.user.login;
 
     if (authenticated) {
+      this.props.dispatch(fetchUserOrganizations(owner));
       this.props.dispatch(fetchUserRepositoriesAndSnaps(owner));
     }
 

--- a/src/common/reducers/user.js
+++ b/src/common/reducers/user.js
@@ -1,9 +1,15 @@
 // initialised with server side rendered state
 
 export const UPDATE_USER = 'UPDATE_USER';
+import { ORGANIZATIONS_SUCCESS } from '../actions/organizations';
 
 export function user(state = null, action) {
   switch(action.type) {
+    case ORGANIZATIONS_SUCCESS:
+      return {
+        ...state,
+        orgs: action.payload.response.orgs
+      };
     // set individual user properties, useful for debugging
     case UPDATE_USER:
       return {

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -110,6 +110,29 @@ export const internalListOrganizations = async (owner, token) => {
   }
 };
 
+export const refreshOrganizations = async (req, res) => {
+  if (!req.session || !req.session.token) {
+    return res.status(401).send(RESPONSE_AUTHENTICATION_FAILED);
+  }
+
+  const owner = req.query.owner;
+
+  // Make sure organization information is fetched again, since
+  // permissions may have changed
+  const orgsCacheID = listOrganizationsCacheId(owner);
+  await getMemcached().del(orgsCacheID);
+
+  const orgs = await internalListOrganizations(owner, req.session.token);
+
+  // update orgs in session
+  req.session.user.orgs = orgs;
+
+  return res.status(200).send({
+    status: 'success',
+    orgs
+  });
+};
+
 // memcached cache id helper
 export const getSnapcraftYamlCacheId = (repositoryUrl) => `snapcraft_data:${repositoryUrl}`;
 

--- a/src/server/handlers/github.js
+++ b/src/server/handlers/github.js
@@ -125,7 +125,9 @@ export const refreshOrganizations = async (req, res) => {
   const orgs = await internalListOrganizations(owner, req.session.token);
 
   // update orgs in session
-  req.session.user.orgs = orgs;
+  if (req.session.user) {
+    req.session.user.orgs = orgs;
+  }
 
   return res.status(200).send({
     status: 'success',

--- a/src/server/routes/github.js
+++ b/src/server/routes/github.js
@@ -20,6 +20,7 @@ router.use('/github/user', json());
 router.get('/github/user', getUser);
 
 router.use('/github/orgs', json());
+router.get('/github/orgs', verifyToken);
 router.get('/github/orgs', refreshOrganizations);
 
 router.use('/github/repos', json());

--- a/src/server/routes/github.js
+++ b/src/server/routes/github.js
@@ -5,7 +5,8 @@ import { verifyToken } from '../middleware/csrf-token';
 import {
   getUser,
   createWebhook,
-  listRepositories
+  listRepositories,
+  refreshOrganizations
 } from '../handlers/github';
 import { getSnapcraftYaml } from '../handlers/launchpad';
 
@@ -17,6 +18,9 @@ router.post('/github/webhook', createWebhook);
 
 router.use('/github/user', json());
 router.get('/github/user', getUser);
+
+router.use('/github/orgs', json());
+router.get('/github/orgs', refreshOrganizations);
 
 router.use('/github/repos', json());
 router.get('/github/repos', listRepositories);

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -283,6 +283,115 @@ describe('The GitHub API endpoint', () => {
     });
   });
 
+  describe('get user orgs route', () => {
+
+    context('when user is not logged in', () => {
+      const oldToken = session.token;
+
+      before(() => {
+        delete session.token;
+      });
+
+      after(() => {
+        session.token = oldToken;
+      });
+
+      it('should return a 401 Unauthorized response', (done) => {
+        supertest(app)
+          .get('/github/orgs')
+          .expect(401, done);
+      });
+
+      it('should return a "error" status', (done) => {
+        supertest(app)
+          .get('/github/orgs')
+          .expect(hasStatus('error'))
+          .end(done);
+      });
+
+      it('should return a body with a "github-authentication-failed" message', (done) => {
+        supertest(app)
+          .get('/github/orgs')
+          .expect(hasPayloadCode('github-authentication-failed'))
+          .end(done);
+      });
+    });
+
+    context('when user is logged in', () => {
+
+      context('when GitHub returns an error', () => {
+        const errorCode = 404;
+        const errorMessage = 'Test error message';
+
+        beforeEach(() => {
+          scope = nock(conf.get('GITHUB_API_ENDPOINT'))
+            .get('/user/orgs')
+            .reply(errorCode, { message: errorMessage });
+        });
+
+        afterEach(() => {
+          scope.done();
+          nock.cleanAll();
+        });
+
+        it('should return 200', async () => {
+          await supertest(app).get('/github/orgs').expect(200);
+        });
+
+        it('should return a "error" status', async () => {
+          await supertest(app).get('/github/orgs').expect(hasStatus('success'));
+        });
+
+        it('should return a body with empty orgs', async () => {
+          const res = await supertest(app).get('/github/orgs');
+
+          expect(res.body.orgs).toEqual([]);
+        });
+      });
+
+      context('when GitHub returns orgs', () => {
+        const orgs = [{ login: 'org1' }, { login: 'org2' }];
+
+        beforeEach(() => {
+          scope = nock(conf.get('GITHUB_API_ENDPOINT'))
+            .get('/user/orgs')
+            .reply(200, orgs);
+        });
+
+        afterEach(() => {
+          scope.done();
+          nock.cleanAll();
+        });
+
+        it('should return with 200', async () => {
+          await supertest(app).get('/github/orgs').expect(200);
+        });
+
+        it('should return a "success" status', async () => {
+          await supertest(app).get('/github/orgs').expect(hasStatus('success'));
+        });
+
+        it('should return orgs', async () => {
+          const res = await supertest(app).get('/github/orgs');
+
+          expect(res.body.orgs).toEqual(orgs);
+        });
+
+        it('should return update orgs in session', async () => {
+          session.user = {
+            orgs: [{ login: 'oldOrg' }]
+          };
+          await supertest(app).get('/github/orgs');
+
+          expect(session.user.orgs).toEqual(orgs);
+
+          delete session.user;
+        });
+
+      });
+    });
+  });
+
   describe('list repositories route', () => {
 
     context('when user is not logged in', () => {

--- a/test/routes/src/server/routes/t_github.js
+++ b/test/routes/src/server/routes/t_github.js
@@ -299,12 +299,14 @@ describe('The GitHub API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .get('/github/orgs')
+          .set('X-CSRF-Token', 'blah')
           .expect(401, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
           .get('/github/orgs')
+          .set('X-CSRF-Token', 'blah')
           .expect(hasStatus('error'))
           .end(done);
       });
@@ -312,6 +314,7 @@ describe('The GitHub API endpoint', () => {
       it('should return a body with a "github-authentication-failed" message', (done) => {
         supertest(app)
           .get('/github/orgs')
+          .set('X-CSRF-Token', 'blah')
           .expect(hasPayloadCode('github-authentication-failed'))
           .end(done);
       });
@@ -335,15 +338,23 @@ describe('The GitHub API endpoint', () => {
         });
 
         it('should return 200', async () => {
-          await supertest(app).get('/github/orgs').expect(200);
+          await supertest(app)
+            .get('/github/orgs')
+            .set('X-CSRF-Token', 'blah')
+            .expect(200);
         });
 
         it('should return a "error" status', async () => {
-          await supertest(app).get('/github/orgs').expect(hasStatus('success'));
+          await supertest(app)
+            .get('/github/orgs')
+            .set('X-CSRF-Token', 'blah')
+            .expect(hasStatus('success'));
         });
 
         it('should return a body with empty orgs', async () => {
-          const res = await supertest(app).get('/github/orgs');
+          const res = await supertest(app)
+            .get('/github/orgs')
+            .set('X-CSRF-Token', 'blah');
 
           expect(res.body.orgs).toEqual([]);
         });
@@ -364,15 +375,23 @@ describe('The GitHub API endpoint', () => {
         });
 
         it('should return with 200', async () => {
-          await supertest(app).get('/github/orgs').expect(200);
+          await supertest(app)
+            .get('/github/orgs')
+            .set('X-CSRF-Token', 'blah')
+            .expect(200);
         });
 
         it('should return a "success" status', async () => {
-          await supertest(app).get('/github/orgs').expect(hasStatus('success'));
+          await supertest(app)
+            .get('/github/orgs')
+            .set('X-CSRF-Token', 'blah')
+            .expect(hasStatus('success'));
         });
 
         it('should return orgs', async () => {
-          const res = await supertest(app).get('/github/orgs');
+          const res = await supertest(app)
+            .get('/github/orgs')
+            .set('X-CSRF-Token', 'blah');
 
           expect(res.body.orgs).toEqual(orgs);
         });
@@ -381,7 +400,9 @@ describe('The GitHub API endpoint', () => {
           session.user = {
             orgs: [{ login: 'oldOrg' }]
           };
-          await supertest(app).get('/github/orgs');
+          await supertest(app)
+            .get('/github/orgs')
+            .set('X-CSRF-Token', 'blah');
 
           expect(session.user.orgs).toEqual(orgs);
 

--- a/test/unit/src/common/actions/t_organizations.js
+++ b/test/unit/src/common/actions/t_organizations.js
@@ -1,0 +1,26 @@
+import expect from 'expect';
+
+import {
+  fetchUserOrganizations
+} from '../../../../../src/common/actions/organizations';
+import * as ActionTypes from '../../../../../src/common/actions/organizations';
+import { CALL_API } from '../../../../../src/common/middleware/call-api';
+
+describe('organizations actions', () => {
+  describe('fetchUserOrganizations', () => {
+    const owner = 'anowner';
+
+    it('should supply request, success and failure actions when invoking CALL_API', () => {
+      expect(fetchUserOrganizations(owner)[CALL_API].types).toEqual([
+        ActionTypes.ORGANIZATIONS_REQUEST,
+        ActionTypes.ORGANIZATIONS_SUCCESS,
+        ActionTypes.ORGANIZATIONS_FAILURE
+      ]);
+    });
+
+    it('should supply a request path containing the owner', () => {
+      expect(fetchUserOrganizations(owner)[CALL_API].path).toInclude(owner);
+    });
+
+  });
+});

--- a/test/unit/src/common/reducers/t_user.js
+++ b/test/unit/src/common/reducers/t_user.js
@@ -1,12 +1,34 @@
 import expect from 'expect';
 
 import { user, UPDATE_USER } from '../../../../../src/common/reducers/user';
+import { ORGANIZATIONS_SUCCESS } from '../../../../../src/common/actions/organizations';
 
 describe('user reducers', () => {
   const initialState = null;
 
   it('should return the initial state', () => {
     expect(user(undefined, {})).toEqual(initialState);
+  });
+
+  context('ORGANIZATIONS_SUCCESS', () => {
+    const state = {
+      orgs: [{ login: 'oldOrg' }]
+    };
+
+    const action = {
+      type: ORGANIZATIONS_SUCCESS,
+      payload: {
+        response: {
+          orgs: [{ login: 'org1' }, { login: 'org2' }]
+        }
+      }
+    };
+
+    it('should update orgs for user', () => {
+      expect(user(state, action)).toInclude({
+        orgs: action.payload.response.orgs
+      });
+    });
   });
 
   context('UPDATE_USER', () => {


### PR DESCRIPTION
Part of #680

API to refresh list of user orgs (in cache, session and redux store) in case access was changed on GitHub side.