### PR TITLE
676: Added csrf tokens to remaining API calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "npm run test:setup-db && nyc npm run test:unit && npm run test:routes && npm run lint",
     "test:setup-db": "rm -f test.sqlite3 && NODE_ENV=test npm run migrate:latest",
     "test:unit": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*",
+    "test:unit:watch": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --watch --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*", 
     "test:unit:inspect": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --inspect --debug-brk --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/unit/t_*.js ./test/unit/**/*",
     "test:routes": "BABEL_DISABLE_CACHE=1 HTTP_PROXY= HTTPS_PROXY= TZ=US/Pacific mocha --env=environments/test.env --recursive --require babel-core/register --require babel-polyfill --compilers js:babel-register ./test/setup.js ./test/routes/**/*",
     "migrate:latest": "knex migrate:latest",

--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -109,12 +109,9 @@ function validateDefaults({ endpoint, csrfToken }) {
 }
 
 function validateSettings(settings) {
-  const { path, options, types } = settings;
+  const { path, types } = settings;
   if (typeof path !== 'string') {
     throw new Error('Specify a string path.');
-  }
-  if (!options) {
-    throw new Error('Specify settings for API request');
   }
   if (Array.isArray(types) && !types.every(type => typeof type === 'string')) {
     throw new Error('Expected action types to be strings.');
@@ -123,6 +120,10 @@ function validateSettings(settings) {
 
 function withCsrfToken(csrfToken, options) {
   if (csrfToken) {
+    if(typeof options === 'undefined'){
+      options = {};
+    }
+
     if (!options.headers) {
       options.headers = {};
     }

--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -120,7 +120,7 @@ function validateSettings(settings) {
 
 function withCsrfToken(csrfToken, options) {
   if (csrfToken) {
-    if(typeof options === 'undefined'){
+    if(typeof options === 'undefined') {
       options = {};
     }
 

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -10,51 +10,49 @@ export const snapBuildsInitialStatus = {
 };
 
 export function snapBuilds(state = {}, action) {
-  const { payload } = action;
-
   const initialStatus = snapBuildsInitialStatus;
 
   switch(action.type) {
     case ActionTypes.FETCH_BUILDS:
       return {
         ...state,
-        [payload.id]: {
+        [action.payload.id]: {
           ...initialStatus,
-          ...state[payload.id],
+          ...state[action.payload.id],
           isFetching: true
         }
       };
     case ActionTypes.FETCH_SNAP_SUCCESS:
       return {
         ...state,
-        [payload.id]: {
-          ...state[payload.id],
+        [action.payload.id]: {
+          ...state[action.payload.id],
           isFetching: false,
           // TODO
           // in refactoring this should go to entities,
           // or maybe shouldn't be needed at all
-          snap: payload.snap
+          snap: action.payload.response.payload.snap
         }
       };
     case ActionTypes.FETCH_BUILDS_SUCCESS:
       return {
         ...state,
-        [payload.id]: {
-          ...state[payload.id],
+        [action.payload.id]: {
+          ...state[action.payload.id],
           isFetching: false,
           success: true,
-          builds: payload.builds.map(snapBuildFromAPI),
+          builds: action.payload.response.payload.builds.map(snapBuildFromAPI),
           error: null
         }
       };
     case ActionTypes.FETCH_BUILDS_ERROR:
       return {
         ...state,
-        [payload.id]: {
-          ...state[payload.id],
+        [action.payload.id]: {
+          ...state[action.payload.id],
           isFetching: false,
           success: false,
-          error: payload.error
+          error: action.payload.response.payload.error
         }
       };
     default:

--- a/src/server/routes/launchpad.js
+++ b/src/server/routes/launchpad.js
@@ -20,16 +20,18 @@ router.post('/launchpad/snaps', newSnap);
 router.get('/launchpad/snaps', findSnap);
 
 router.use('/launchpad/snaps/list', json());
+router.use('/launchpad/snaps/list', verifyToken);
 router.get('/launchpad/snaps/list', findSnaps);
-
 
 router.use('/launchpad/snaps/authorize', json());
 router.post('/launchpad/snaps/authorize', authorizeSnap);
 
 router.use('/launchpad/builds', json());
+router.use('/launchpad/builds', verifyToken);
 router.get('/launchpad/builds', getSnapBuilds);
 
 router.use('/launchpad/snaps/request-builds', json());
+router.use('/launchpad/snaps/request-builds', verifyToken);
 router.post('/launchpad/snaps/request-builds', requestSnapBuilds);
 
 // XXX cjwatson 2017-02-28: This would be more RESTful if we defined an API

--- a/test/routes/src/server/routes/t_launchpad.js
+++ b/test/routes/src/server/routes/t_launchpad.js
@@ -409,6 +409,7 @@ describe('The Launchpad API endpoint', () => {
     beforeEach(async () => {
       apiResponse = supertest(app)
         .get('/launchpad/snaps/list')
+        .set('X-CSRF-Token', 'blah')
         .query({ owner: 'anowner' });
       await db.model('GitHubUser').query('truncate').fetch();
       await db.model('GitHubUser')
@@ -1459,6 +1460,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 200 OK response', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(200, done);
       });
@@ -1466,6 +1468,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "success" status', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(hasStatus('success'))
           .end(done);
@@ -1474,6 +1477,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return body with "snap-builds-found" message', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(hasMessage('snap-builds-found'))
           .end(done);
@@ -1482,6 +1486,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return builds list in payload', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .end((err, res) => {
             const build = res.body.payload.builds[0];
@@ -1527,6 +1532,7 @@ describe('The Launchpad API endpoint', () => {
 
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(200, (err) => {
             lp.done();
@@ -1546,6 +1552,7 @@ describe('The Launchpad API endpoint', () => {
 
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url, size: 42, start: 7 })
           .expect(200, (err) => {
             lp.done();
@@ -1583,6 +1590,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 response', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(404, done);
       });
@@ -1590,6 +1598,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(hasStatus('error'))
           .end(done);
@@ -1598,6 +1607,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return body with error message', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(hasMessage('lp-error', 'Not found'))
           .end(done);
@@ -1621,6 +1631,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 response', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(404, done);
       });
@@ -1628,6 +1639,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(hasStatus('error'))
           .end(done);
@@ -1636,6 +1648,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return body with error message', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .query({ snap: lp_snap_url })
           .expect(hasMessage('lp-error', 'Not found'))
           .end(done);
@@ -1648,12 +1661,14 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 response', (done) => {
         supertest(app)
           .get('/launchpad/builds')
+          .set('X-CSRF-Token', 'blah')
           .expect(404, done);
       });
 
       it('should return a "error" status', (done) => {
         supertest(app)
         .get('/launchpad/builds')
+        .set('X-CSRF-Token', 'blah')
         .expect(hasStatus('error'))
         .end(done);
       });
@@ -1661,6 +1676,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return body with error message', (done) => {
         supertest(app)
         .get('/launchpad/builds')
+        .set('X-CSRF-Token', 'blah')
         .expect(hasMessage('missing-snap-link'))
         .end(done);
       });
@@ -1739,6 +1755,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns a 201 Created response', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(201)
             .end((err) => {
@@ -1750,6 +1767,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns a "success" status', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasStatus('success'))
             .end((err) => {
@@ -1761,6 +1779,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns body with a "snap-builds-requested" message', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasMessage('snap-builds-requested'))
             .end((err) => {
@@ -1772,6 +1791,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns requested builds list in payload', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect((res) => {
               const buildUrls = res.body.payload.builds.map((entry) => {
@@ -1791,6 +1811,7 @@ describe('The Launchpad API endpoint', () => {
         it('leaves builds_requested unmodified if it is unset', async () => {
           await supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' });
           const dbUser = await db.model('GitHubUser')
             .where({ login: 'anowner' })
@@ -1805,6 +1826,7 @@ describe('The Launchpad API endpoint', () => {
           await dbUser.save({ builds_requested: 2 });
           await supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' });
           await dbUser.refresh();
           expect(dbUser.get('builds_requested')).toEqual(4);
@@ -1835,6 +1857,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns a 201 Created response', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(201)
             .end((err) => {
@@ -1846,6 +1869,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns a "success" status', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasStatus('success'))
             .end((err) => {
@@ -1857,6 +1881,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns body with a "snap-builds-requested" message', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect(hasMessage('snap-builds-requested'))
             .end((err) => {
@@ -1868,6 +1893,7 @@ describe('The Launchpad API endpoint', () => {
         it('returns requested builds list in payload', (done) => {
           supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' })
             .expect((res) => {
               const buildUrls = res.body.payload.builds.map((entry) => {
@@ -1887,6 +1913,7 @@ describe('The Launchpad API endpoint', () => {
         it('leaves builds_requested unmodified if it is unset', async () => {
           await supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' });
           const dbUser = await db.model('GitHubUser')
             .where({ login: 'anowner' })
@@ -1901,6 +1928,7 @@ describe('The Launchpad API endpoint', () => {
           await dbUser.save({ builds_requested: 2 });
           await supertest(app)
             .post('/launchpad/snaps/request-builds')
+            .set('X-CSRF-Token', 'blah')
             .send({ repository_url: 'https://github.com/anowner/aname' });
           await dbUser.refresh();
           expect(dbUser.get('builds_requested')).toEqual(4);
@@ -1922,6 +1950,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 401 Unauthorized response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(401, done);
       });
@@ -1929,6 +1958,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -1938,6 +1968,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-no-admin-permissions'))
           .end(done);
@@ -1958,6 +1989,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a 404 Not Found response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(404, done);
       });
@@ -1965,6 +1997,7 @@ describe('The Launchpad API endpoint', () => {
       it('should return a "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -1974,6 +2007,7 @@ describe('The Launchpad API endpoint', () => {
          'message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('github-snapcraft-yaml-not-found'))
           .end(done);
@@ -2006,6 +2040,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns a 404 response', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(404, done);
       });
@@ -2013,6 +2048,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns an "error" status', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasStatus('error'))
           .end(done);
@@ -2021,6 +2057,7 @@ describe('The Launchpad API endpoint', () => {
       it('returns body with a "snap-not-found" message', (done) => {
         supertest(app)
           .post('/launchpad/snaps/request-builds')
+          .set('X-CSRF-Token', 'blah')
           .send({ repository_url: 'https://github.com/anowner/aname' })
           .expect(hasMessage('snap-not-found'))
           .end(done);

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -16,6 +16,7 @@ import {
 } from '../../../../../src/common/actions/snap-builds';
 import { conf } from '../../../../../src/common/helpers/config';
 import { makeLocalForageStub } from '../../../../helpers';
+import callApi from '../../../../../src/common/middleware/call-api';
 
 const localForageStub = makeLocalForageStub();
 const getAccountInfo = proxyquire.noCallThru().load(
@@ -44,7 +45,7 @@ const {
 } = registerNameModule;
 const ActionTypes = registerNameModule;
 
-const middlewares = [ thunk ];
+const middlewares = [ thunk, callApi({ endpoint: conf.get('BASE_URL') }) ];
 const mockStore = configureMockStore(middlewares);
 
 describe('register name actions', () => {

--- a/test/unit/src/common/actions/t_snap-builds.js
+++ b/test/unit/src/common/actions/t_snap-builds.js
@@ -1,297 +1,114 @@
 import expect from 'expect';
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-import nock from 'nock';
-import { isFSA } from 'flux-standard-action';
-
-import { conf } from '../../../../../src/server/helpers/config';
 
 import {
   fetchSnap,
   fetchBuilds,
-  requestBuilds,
-  fetchBuildsSuccess,
-  fetchBuildsError
+  requestBuilds
 } from '../../../../../src/common/actions/snap-builds';
 import * as ActionTypes from '../../../../../src/common/actions/snap-builds';
-
-const middlewares = [ thunk ];
-const mockStore = configureMockStore(middlewares);
+import { CALL_API } from '../../../../../src/common/middleware/call-api';
 
 describe('snap builds actions', () => {
-  let store;
   let action;
 
   const repo = 'dummy/repo';
   const repositoryUrl = `https://github.com/${repo}`;
 
-  beforeEach(() => {
-    store = mockStore({});
-  });
-
-  context('fetchBuildsSuccess', () => {
-    let builds = [ { build: 'test1' }, { build: 'test2' }];
-
-    beforeEach(() => {
-      action = fetchBuildsSuccess(repo, builds);
-    });
-
-    it('should create an action to store snap builds', () => {
-      const expectedAction = {
-        type: ActionTypes.FETCH_BUILDS_SUCCESS,
-        payload: {
-          id: repo,
-          builds
-        }
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('should create a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
-  });
-
-  context('fetchBuildsError', () => {
-    let error = 'Something went wrong!';
-
-    beforeEach(() => {
-      action = fetchBuildsError(repo, error);
-    });
-
-    it('should create an action to store request error on failure', () => {
-      const expectedAction = {
-        type: ActionTypes.FETCH_BUILDS_ERROR,
-        error: true,
-        payload: {
-          id: repo,
-          error
-        }
-      };
-
-      store.dispatch(action);
-      expect(store.getActions()).toInclude(expectedAction);
-    });
-
-    it('should create a valid flux standard action', () => {
-      expect(isFSA(action)).toBe(true);
-    });
-  });
-
   context('fetchBuilds', () => {
-    let api;
+    const snapUrl = 'https://api.launchpad.net/devel/~foo/+snap/bar';
+    let action;
 
     beforeEach(() => {
-      api = nock(conf.get('BASE_URL'));
+      action = fetchBuilds(repositoryUrl, snapUrl);
     });
 
-    afterEach(() => {
-      api.done();
-      nock.cleanAll();
-    });
-
-    it('should store builds on fetch success', async () => {
-      const snapUrl = 'https://api.launchpad.net/devel/~foo/+snap/bar';
-
-      api.get('/api/launchpad/builds')
-        .query({ snap: snapUrl })
-        .reply(200, {
-          status: 'success',
-          payload: {
-            code: 'snap-builds-found',
-            builds: []
-          }
-        });
-
-      await store.dispatch(fetchBuilds(repositoryUrl, snapUrl));
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.FETCH_BUILDS_SUCCESS
+    it('should supply a path', () => {
+      expect(action[CALL_API].path).toEqual(
+        `/api/launchpad/builds?snap=${encodeURIComponent(snapUrl)}`
       );
     });
 
-    it('should store error on Launchpad request failure', async () => {
-      const barUrl = 'https://api.launchpad.net/devel/~foo/+snap/bad';
-
-      api.get('/api/launchpad/builds')
-        .query({ snap: barUrl })
-        .reply(404, {
-          status: 'error',
-          payload: {
-            code: 'lp-error',
-            message: 'Something went wrong'
-          }
-        });
-
-      await store.dispatch(fetchBuilds(repositoryUrl, barUrl));
-      expect(store.getActions()).toHaveActionOfType(
+    it('should supply request, success and failure action types', () => {
+      expect(action[CALL_API].types).toEqual([
+        ActionTypes.FETCH_BUILDS,
+        ActionTypes.FETCH_BUILDS_SUCCESS,
         ActionTypes.FETCH_BUILDS_ERROR
-      );
+      ]);
     });
 
+    it('should set the credentials option to same-origin', () => {
+      expect(action[CALL_API].options.credentials).toEqual('same-origin');
+    });
+
+    it('should supply a payload containing the repo full-name', () => {
+      expect(action.payload.id).toEqual(repo);
+    });
   });
 
   context('fetchSnap', () => {
-    let api;
-
     beforeEach(() => {
-      api = nock(conf.get('BASE_URL'));
+      action = fetchSnap(repositoryUrl);
     });
 
-    afterEach(() => {
-      api.done();
-      nock.cleanAll();
+    it('should supply a path', () => {
+      expect(action[CALL_API].path).toEqual(
+        `/api/launchpad/snaps?repository_url=${encodeURIComponent(repositoryUrl)}`
+      );
     });
 
-    it('should dispatch FETCH_SNAP_SUCCESS with snap info on ' +
-       'success', async () => {
-      const repo = 'foo/bar';
-      const repositoryUrl = `https://github.com/${repo}`;
-      const snapUrl = 'https://api.launchpad.net/devel/~foo/+snap/bar';
-
-      api.get('/api/launchpad/snaps')
-        .query({
-          repository_url: repositoryUrl // should be called with valid GH url
-        })
-        .reply(200, {
-          status: 'success',
-          payload: {
-            code: 'snap-found',
-            snap: {
-              selfLink: snapUrl
-            }
-          }
-        });
-
-      await store.dispatch(fetchSnap(repositoryUrl));
-      expect(store.getActions()).toInclude({
-        type: ActionTypes.FETCH_SNAP_SUCCESS,
-        payload: {
-          id: repo,
-          snap: { selfLink: snapUrl }
-        }
-      });
+    it('should supply request, success and failure action types', () => {
+      expect(action[CALL_API].types).toEqual([
+        ActionTypes.FETCH_BUILDS,
+        ActionTypes.FETCH_SNAP_SUCCESS
+      ]);
     });
 
-    context('on builds call failure', () => {
-      const barUrl = 'https://api.launchpad.net/devel/~foo/+snap/bad';
-
-      beforeEach(() => {
-        api.get('/api/launchpad/builds')
-        .query({ snap: barUrl })
-        .reply(404, {
-          status: 'error',
-          payload: {
-            code: 'lp-error',
-            message: 'Bad snap URL'
-          }
-        });
-      });
-
-      it('should dispatch error action', async () => {
-        await store.dispatch(fetchBuilds(repositoryUrl, barUrl));
-        expect(store.getActions()).toHaveActionOfType(
-          ActionTypes.FETCH_BUILDS_ERROR
-        );
-      });
-
-      it('should pass error message from repsponse to action', async () => {
-        await store.dispatch(fetchBuilds(repositoryUrl, barUrl));
-        const action = store.getActions()
-          .filter((a) => a.type === ActionTypes.FETCH_BUILDS_ERROR)[0];
-        expect(action.payload.error.message).toBe('Bad snap URL');
-      });
-
+    it('should supply a payload containing the repo full-name', () => {
+      expect(action.payload.id).toEqual(repo);
     });
-
-    context('on snaps call failure', () => {
-      const badRepo = 'foo/bad';
-      const repositoryUrl = `https://github.com/${badRepo}`;
-
-      beforeEach(() => {
-        api.get('/api/launchpad/snaps')
-          .query({
-            repository_url: repositoryUrl
-          })
-          .reply(404, {
-            status: 'error',
-            payload: {
-              code: 'lp-error',
-              message: 'Bad repo URL'
-            }
-          });
-      });
-
-      it('should dispatch error action', async () => {
-        await store.dispatch(fetchSnap(repositoryUrl));
-        expect(store.getActions()).toHaveActionOfType(
-          ActionTypes.FETCH_BUILDS_ERROR
-        );
-      });
-
-      it('should pass error message from repsponse to action', async () => {
-        await store.dispatch(fetchSnap(repositoryUrl));
-        const action = store.getActions()
-          .filter((a) => a.type === ActionTypes.FETCH_BUILDS_ERROR)[0];
-        expect(action.payload.error.message).toBe('Bad repo URL');
-      });
-
-    });
-
   });
 
   context('requestBuilds', () => {
-    let api;
-    const repo = 'foo/bar';
-    const repositoryUrl = `https://github.com/${repo}`;
+    let action;
 
     beforeEach(() => {
-      api = nock(conf.get('BASE_URL'));
+      action = requestBuilds(repositoryUrl);
     });
 
-    afterEach(() => {
-      api.done();
-      nock.cleanAll();
-    });
-
-    it('should store builds on request success', async () => {
-      api
-        .post('/api/launchpad/snaps/request-builds', {
-          repository_url: repositoryUrl
-        })
-        .reply(201, {
-          status: 'success',
-          payload: {
-            code: 'snap-builds-requested',
-            builds: []
-          }
-        });
-
-      await store.dispatch(requestBuilds(repositoryUrl));
-      expect(store.getActions()).toHaveActionOfType(
-        ActionTypes.FETCH_BUILDS_SUCCESS
+    it('should supply a path', () => {
+      expect(action[CALL_API].path).toEqual(
+        '/api/launchpad/snaps/request-builds'
       );
     });
 
-    it('should store error on Launchpad request failure', async () => {
-      api
-        .post('/api/launchpad/snaps/request-builds', {
-          repository_url: repositoryUrl
-        })
-        .reply(404, {
-          status: 'error',
-          payload: {
-            code: 'lp-error',
-            message: 'Something went wrong'
-          }
-        });
-
-      await store.dispatch(requestBuilds(repositoryUrl));
-      expect(store.getActions()).toHaveActionOfType(
+    it('should supply request, success and failure action types', () => {
+      expect(action[CALL_API].types).toEqual([
+        ActionTypes.FETCH_BUILDS,
+        ActionTypes.FETCH_BUILDS_SUCCESS,
         ActionTypes.FETCH_BUILDS_ERROR
+      ]);
+    });
+
+    it('should set the credentials option to same-origin', () => {
+      expect(action[CALL_API].options.credentials).toEqual('same-origin');
+    });
+
+    it('should set the HTTP request method option to POST', () => {
+      expect(action[CALL_API].options.method).toEqual('POST');
+    });
+
+    it('should set the Content-Type request header to "application/json"', () => {
+      expect(action[CALL_API].options.headers['Content-Type']).toEqual('application/json');
+    });
+
+    it('should supply a request body containing the repo name', () => {
+      expect(action[CALL_API].options.body).toEqual(
+        JSON.stringify({ repository_url: repositoryUrl })
       );
+    });
+
+    it('should supply a payload containing the repo full-name', () => {
+      expect(action.payload.id).toEqual(repo);
     });
   });
-
 });

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -101,7 +101,11 @@ describe('snapBuilds reducers', () => {
       type: ActionTypes.FETCH_SNAP_SUCCESS,
       payload: {
         id,
-        snap: SNAP
+        response: {
+          payload: {
+            snap: SNAP
+          }
+        }
       }
     };
 
@@ -128,7 +132,11 @@ describe('snapBuilds reducers', () => {
       type: ActionTypes.FETCH_BUILDS_SUCCESS,
       payload: {
         id,
-        builds: SNAP_BUILDS
+        response: {
+          payload: {
+            builds: SNAP_BUILDS
+          }
+        }
       }
     };
 
@@ -164,7 +172,11 @@ describe('snapBuilds reducers', () => {
       type: ActionTypes.FETCH_BUILDS_ERROR,
       payload: {
         id,
-        error: 'Something went wrong!',
+        response: {
+          payload: {
+            error: 'Something went wrong!'
+          }
+        }
       },
       error: true
     };
@@ -174,7 +186,7 @@ describe('snapBuilds reducers', () => {
         ...state[id],
         isFetching: false,
         success: false,
-        error: action.payload.error
+        error: action.payload.response.payload.error
       });
     });
   });


### PR DESCRIPTION
- Replaced calls to fetch in snap-builds actions with CALL_API
  middleware
- Changed CALL_API to not require options anymore (they're options!)
- Added CSRF token checks to snap-builds endpoints
- Fixed tests to work with changes to API calls
- Added new task for watching unit tests