### PR TITLE
Remove confusing advice from repo page

### DIFF
--- a/src/common/containers/builds.js
+++ b/src/common/containers/builds.js
@@ -16,13 +16,15 @@ import withSnapBuilds from './with-snap-builds';
 
 import styles from './container.css';
 
-class Builds extends Component {
+export class Builds extends Component {
   render() {
     const { user, repository } = this.props;
-    const { isFetching, success, error, snap } = this.props.snapBuilds;
+    const { isFetching, success, error, snap, builds } = this.props.snapBuilds;
 
     // only show spinner when data is loading for the first time
     const isLoading = isFetching && !success;
+
+    const isPublished = builds.some((build) => build.isPublished);
 
     return (
       <div className={ styles.container }>
@@ -45,7 +47,7 @@ class Builds extends Component {
         { error &&
           <Message status='error'>{ error.message || error }</Message>
         }
-        { snap && snap.storeName &&
+        { snap && snap.storeName && isPublished &&
           <HelpBox>
             <HelpInstallSnap
               headline='To test this snap on your PC or cloud instance:'
@@ -75,6 +77,11 @@ Builds.propTypes = {
       selfLink: PropTypes.string.isRequired,
       storeName: PropTypes.string.isRequired
     }),
+    builds: PropTypes.arrayOf(
+      PropTypes.shape({
+        isPublished: PropTypes.bool
+      })
+    ),
     success: PropTypes.bool,
     error: PropTypes.object
   })

--- a/test/unit/src/common/containers/t_builds.js
+++ b/test/unit/src/common/containers/t_builds.js
@@ -1,0 +1,64 @@
+import { shallow } from 'enzyme';
+import expect from 'expect';
+import React from 'react';
+import { Link } from 'react-router';
+
+import { HelpInstallSnap } from '../../../../../src/common/components/help';
+import { Builds } from '../../../../../src/common/containers/builds';
+
+describe('The Builds container', function() {
+  const baseProps = {
+    repository: {
+      owner: 'anowner',
+      name: 'aname',
+      fullName: 'anowner/aname',
+      url: 'https://github.com/anowner/aname'
+    },
+    snapBuilds: {
+      snap: {
+        selfLink: 'https://api.launchpad.net/devel/~anowner/+snap/aname',
+        storeName: 'test-snap'
+      },
+      builds: []
+    }
+  };
+
+  it('omits link to "My repos" if not signed in', function() {
+    const element = shallow(<Builds { ...baseProps } />);
+    expect(element.find(Link).length).toBe(0);
+  });
+
+  it('shows link to "My repos" if signed in', function() {
+    const props = { ...baseProps, user: { login: 'test-user' } };
+    const element = shallow(<Builds { ...props } />);
+    expect(element.find(Link).length).toBe(1);
+    expect(element.find(Link).prop('to')).toBe('/user/test-user');
+  });
+
+  it('omits snap testing instructions if snap has no published ' +
+     'builds', function() {
+    const props = {
+      ...baseProps,
+      snapBuilds: {
+        ...baseProps.snapBuilds,
+        builds: [ { isPublished: false } ]
+      }
+    };
+    const element = shallow(<Builds { ...props } />);
+    expect(element.find(HelpInstallSnap).length).toBe(0);
+  });
+
+  it('shows snap testing instructions if snap has published ' +
+     'builds', function() {
+    const props = {
+      ...baseProps,
+      snapBuilds: {
+        ...baseProps.snapBuilds,
+        builds: [ { isPublished: false }, { isPublished: true } ]
+      }
+    };
+    const element = shallow(<Builds { ...props } />);
+    expect(element.find(HelpInstallSnap).length).toBe(1);
+    expect(element.find(HelpInstallSnap).prop('name')).toBe('test-snap');
+  });
+});


### PR DESCRIPTION
If there are no published builds yet, don't show the "To test this snap"
instructions.  Fixes #528.