### PR TITLE
Fix store expiry check

### DIFF
--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -28,11 +28,10 @@ export const SIGN_AGREEMENT_SUCCESS = 'SIGN_AGREEMENT_SUCCESS';
 export const SIGN_OUT_OF_STORE_ERROR = 'SIGN_OUT_OF_STORE_ERROR';
 
 export function extractExpiresCaveat(macaroon) {
-  const storeLocation = url.parse(conf.get('STORE_API_URL')).host;
   for (const caveat of getCaveats(macaroon)) {
     if (caveat.verificationKeyId === '') {
       const parts = caveat.caveatId.split('|');
-      if (parts[0] === storeLocation && parts[1] === 'expires') {
+      if (parts[0] === macaroon.location && parts[1] === 'expires') {
         return moment.utc(parts[2]);
       }
     }


### PR DESCRIPTION
We switched to the forked store recently, which means that the host part
of STORE_API_URL is `dashboard.snapcraft.io`, but it turns out that the
forked store still issues macaroons whose location is
`myapps.developer.ubuntu.com`, presumably out of concerns for
compatibility.  When extracting the `expires` caveat, we therefore need
to extract one that matches the macaroon's location, rather than
assuming that the location is going to match the host that we thought we
were contacting.

Fixes #719.