### PR TITLE
Name ownership reducer

### DIFF
--- a/src/common/components/repositories-list/index.js
+++ b/src/common/components/repositories-list/index.js
@@ -77,7 +77,7 @@ export class RepositoriesListView extends Component {
 
   renderRow(id, index) {
     const snap = this.props.entities.snaps[id];
-    const { hasNoConfiguredSnaps, hasNoRegisteredNames, snapBuilds, authStore } = this.props;
+    const { hasNoConfiguredSnaps, hasNoRegisteredNames, snapBuilds, authStore, nameOwnership } = this.props;
     const { fullName } = parseGitHubRepoUrl(snap.gitRepoUrl);
     const isFirstInList = index === 0;
 
@@ -108,6 +108,7 @@ export class RepositoriesListView extends Component {
         isPublished={ isPublished }
         fullName={ fullName }
         authStore={ authStore }
+        nameOwnership={ nameOwnership }
         registerNameStatus={ registerNameStatus }
         registerNameIsOpen={ registerNameIsOpen }
         configureIsOpen={ configureIsOpen }
@@ -156,6 +157,7 @@ RepositoriesListView.propTypes = {
   entities: PropTypes.shape({
     snaps: PropTypes.object
   }),
+  nameOwnership: PropTypes.object,
   dispatch: PropTypes.func,
   hasSnaps: PropTypes.bool,
   hasNoConfiguredSnaps: PropTypes.bool,
@@ -170,7 +172,8 @@ function mapStateToProps(state) {
     authStore,
     entities,
     snaps,
-    snapBuilds
+    snapBuilds,
+    nameOwnership
   } = state;
 
   return {
@@ -179,6 +182,7 @@ function mapStateToProps(state) {
     entities,
     snaps,
     snapBuilds,
+    nameOwnership,
     hasSnaps: hasSnaps(state),
     hasNoRegisteredNames: hasNoRegisteredNames(state),
     hasNoConfiguredSnaps: hasNoConfiguredSnaps(state)

--- a/src/common/components/repository-row/dropdowns/name-mismatch-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/name-mismatch-dropdown.js
@@ -14,14 +14,19 @@ const NameMismatchDropdown = (props) => {
   const { snapcraftData, storeName } = props.snap;
 
   let helpText;
+  let nameOwnershipStatus;
 
-  if (snapcraftData.nameOwnershipStatus === NAME_OWNERSHIP_REGISTERED_BY_OTHER_USER) {
+  if (props.nameOwnership[snapcraftData.name]) {
+    nameOwnershipStatus = props.nameOwnership[snapcraftData.name].nameOwnershipStatus;
+  }
+
+  if (nameOwnershipStatus === NAME_OWNERSHIP_REGISTERED_BY_OTHER_USER) {
     helpText = getNameRegisteredByOtherUserHelpText(props.snap);
   // TODO cover name registered for another repo #299
-  // } else if (snapcraftData.nameOwnershipStatus === NAME_OWNERSHIP_ALREADY_OWNED) {
+  // } else if (nameOwnershipStatus === NAME_OWNERSHIP_ALREADY_OWNED) {
   //   ...
   // }
-  } else if (snapcraftData.nameOwnershipStatus) {
+  } else if (nameOwnershipStatus) {
     helpText = getNameMismatchHelpText(props.snap, props.onOpenRegisterNameClick);
   }
 
@@ -89,6 +94,7 @@ NameMismatchDropdown.propTypes = {
       name: PropTypes.string
     })
   }),
+  nameOwnership: PropTypes.object,
   onOpenRegisterNameClick: PropTypes.func,
 };
 

--- a/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
@@ -38,6 +38,9 @@ const RemoveRepoDropdown = (props) => {
 };
 
 RemoveRepoDropdown.propTypes = {
+  authStore: PropTypes.shape({
+    authenticated: PropTypes.bool
+  }).isRequired,
   message: PropTypes.string.isRequired,
   onRemoveClick: PropTypes.func.isRequired,
   onCancelClick: PropTypes.func.isRequired

--- a/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
@@ -38,9 +38,6 @@ const RemoveRepoDropdown = (props) => {
 };
 
 RemoveRepoDropdown.propTypes = {
-  authStore: PropTypes.shape({
-    authenticated: PropTypes.bool
-  }).isRequired,
   message: PropTypes.string.isRequired,
   onRemoveClick: PropTypes.func.isRequired,
   onCancelClick: PropTypes.func.isRequired

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -202,7 +202,7 @@ export class RepositoryRowView extends Component {
 
     const nextSnapcraftData = nextProps.snap.snapcraftData;
     const currentSnapcraftData = this.props.snap.snapcraftData;
-    const snapcraftNameOwnership = nextProps.nameOwnership[nextSnapcraftData.name];
+    const snapcraftNameOwnership = nextSnapcraftData && nextProps.nameOwnership[nextSnapcraftData.name];
 
     // name ownership status is available when we have it or is already fetching
     const isNameOwnershipAvailable = (snapcraftNameOwnership &&
@@ -490,7 +490,7 @@ RepositoryRowView.propTypes = {
     success: PropTypes.bool,
     error: PropTypes.object
   }),
-  nameOwnership: PropTypes.object,
+  nameOwnership: PropTypes.object.isRequired,
   registerNameIsOpen: PropTypes.bool,
   configureIsOpen: PropTypes.bool,
   authActions: PropTypes.object,

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -202,19 +202,24 @@ export class RepositoryRowView extends Component {
 
     const nextSnapcraftData = nextProps.snap.snapcraftData;
     const currentSnapcraftData = this.props.snap.snapcraftData;
+    const snapcraftNameOwnership = nextProps.nameOwnership[nextSnapcraftData.name];
+
+    // name ownership status is available when we have it or is already fetching
+    const isNameOwnershipAvailable = (snapcraftNameOwnership &&
+      (snapcraftNameOwnership.nameOwnershipStatus || snapcraftNameOwnership.isFetching)
+    );
 
     // if there is a name mismatch we want to check who owns the name in the store
     if (snapNameIsMismatched(nextProps.snap)
         // we can only do this if user is authenticated in the store
         && nextProps.authStore.authenticated
         && (
-          // and we need to do this only if we don't know the status yet
-          !nextSnapcraftData.nameOwnershipStatus
-          // or if the snapcraft data name changed
-          || nextSnapcraftData.name !== currentSnapcraftData.name
+          // and if the snapcraft data name changed
+          nextSnapcraftData.name !== currentSnapcraftData.name
+          // or we don't know the status yet
+          || !isNameOwnershipAvailable
         )
-        // and if we are not fetching this data already
-        && !nextSnapcraftData.isFetching) {
+      ) {
       this.props.nameActions.checkNameOwnership(nextProps.snap.gitRepoUrl, nextSnapcraftData.name);
     }
   }
@@ -246,7 +251,8 @@ export class RepositoryRowView extends Component {
       isPublished,
       fullName,
       authStore,
-      registerNameStatus
+      registerNameStatus,
+      nameOwnership
     } = this.props;
 
     const showUnconfiguredDropdown = !snapIsConfigured(snap) && this.state.unconfiguredDropdownExpanded;
@@ -288,6 +294,7 @@ export class RepositoryRowView extends Component {
         { showNameMismatchDropdown &&
           <NameMismatchDropdown
             snap={snap}
+            nameOwnership={nameOwnership}
             onOpenRegisterNameClick={this.onUnregisteredClick.bind(this)}
           />
         }
@@ -483,6 +490,7 @@ RepositoryRowView.propTypes = {
     success: PropTypes.bool,
     error: PropTypes.object
   }),
+  nameOwnership: PropTypes.object,
   registerNameIsOpen: PropTypes.bool,
   configureIsOpen: PropTypes.bool,
   authActions: PropTypes.object,

--- a/src/common/reducers/entities/snap.js
+++ b/src/common/reducers/entities/snap.js
@@ -10,32 +10,6 @@ export default function snap(state={}, action) {
   };
 
   switch(action.type) {
-    // case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_REQUEST:
-    //   return {
-    //     ...state,
-    //     snapcraftData: {
-    //       ...state.snapcraftData,
-    //       isFetching: true
-    //     }
-    //   };
-    // case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_SUCCESS:
-    //   return {
-    //     ...state,
-    //     snapcraftData: {
-    //       ...state.snapcraftData,
-    //       isFetching: false,
-    //       nameOwnershipStatus: action.payload.status
-    //     }
-    //   };
-    // case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_ERROR:
-    //   return {
-    //     ...state,
-    //     snapcraftData: {
-    //       ...state.snapcraftData,
-    //       isFetching: false,
-    //       nameOwnershipStatus: null
-    //     }
-    //   };
     case RegisterNameActionTypes.REGISTER_NAME:
       return {
         ...state,

--- a/src/common/reducers/entities/snap.js
+++ b/src/common/reducers/entities/snap.js
@@ -10,32 +10,32 @@ export default function snap(state={}, action) {
   };
 
   switch(action.type) {
-    case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_REQUEST:
-      return {
-        ...state,
-        snapcraftData: {
-          ...state.snapcraftData,
-          isFetching: true
-        }
-      };
-    case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_SUCCESS:
-      return {
-        ...state,
-        snapcraftData: {
-          ...state.snapcraftData,
-          isFetching: false,
-          nameOwnershipStatus: action.payload.status
-        }
-      };
-    case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_ERROR:
-      return {
-        ...state,
-        snapcraftData: {
-          ...state.snapcraftData,
-          isFetching: false,
-          nameOwnershipStatus: null
-        }
-      };
+    // case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_REQUEST:
+    //   return {
+    //     ...state,
+    //     snapcraftData: {
+    //       ...state.snapcraftData,
+    //       isFetching: true
+    //     }
+    //   };
+    // case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_SUCCESS:
+    //   return {
+    //     ...state,
+    //     snapcraftData: {
+    //       ...state.snapcraftData,
+    //       isFetching: false,
+    //       nameOwnershipStatus: action.payload.status
+    //     }
+    //   };
+    // case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_ERROR:
+    //   return {
+    //     ...state,
+    //     snapcraftData: {
+    //       ...state.snapcraftData,
+    //       isFetching: false,
+    //       nameOwnershipStatus: null
+    //     }
+    //   };
     case RegisterNameActionTypes.REGISTER_NAME:
       return {
         ...state,

--- a/src/common/reducers/index.js
+++ b/src/common/reducers/index.js
@@ -10,6 +10,7 @@ import * as snaps from './snaps';
 import * as user from './user';
 import * as auth from './auth';
 import * as authStore from './auth-store';
+import * as nameOwnership from './name-ownership';
 import { entities } from './entities';
 
 const rootReducer = combineReducers({
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   ...snapBuilds,
   ...snaps,
   ...user,
+  ...nameOwnership,
   entities,
   routing: routerReducer
 });

--- a/src/common/reducers/name-ownership.js
+++ b/src/common/reducers/name-ownership.js
@@ -1,0 +1,36 @@
+import * as RegisterNameActionTypes from '../actions/register-name';
+
+export function nameOwnership(state = {}, action) {
+  const { payload } = action;
+
+  switch(action.type) {
+    case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_REQUEST:
+      return {
+        ...state,
+        [payload.snapName]: {
+          ...state[payload.snapName],
+          isFetching: true
+        }
+      };
+    case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_SUCCESS:
+      return {
+        ...state,
+        [payload.snapName]: {
+          ...state[payload.snapName],
+          isFetching: false,
+          nameOwnershipStatus: payload.status
+        }
+      };
+    case RegisterNameActionTypes.CHECK_NAME_OWNERSHIP_ERROR:
+      return {
+        ...state,
+        [payload.snapName]: {
+          ...state[payload.snapName],
+          isFetching: false,
+          nameOwnershipStatus: null
+        }
+      };
+    default:
+      return state;
+  }
+}

--- a/test/unit/src/common/components/repository-row/t_repository-row.js
+++ b/test/unit/src/common/components/repository-row/t_repository-row.js
@@ -28,6 +28,7 @@ describe('<RepositoryRowView />', () => {
       duration: '0:01:24.425045'
     },
     fullName: 'anowner/aname',
+    nameOwnership: {},
     authStore: {
       authenticated: true,
       userName: 'store-user'

--- a/test/unit/src/common/reducers/entities/t_snap.js
+++ b/test/unit/src/common/reducers/entities/t_snap.js
@@ -2,68 +2,12 @@ import expect from 'expect';
 
 import * as RegisterNameActionTypes from '../../../../../../src/common/actions/register-name';
 import snap from '../../../../../../src/common/reducers/entities/snap.js';
-import * as ActionTypes from '../../../../../../src/common/actions/register-name';
 
 describe('snaps entities', function() {
 
   let state = {
     storeName: 'test-name'
   };
-
-  context('name ownership actions', () => {
-    let state = {
-      snapcraftData: {
-        name: 'test-name'
-      }
-    };
-
-    const requestAction = {
-      type: ActionTypes.CHECK_NAME_OWNERSHIP_REQUEST,
-      payload: {
-        id: 'snapId',
-        snapName: 'test-name',
-      }
-    };
-
-    const successAction = {
-      type: ActionTypes.CHECK_NAME_OWNERSHIP_SUCCESS,
-      payload: {
-        id: 'snapId',
-        snapName: 'test-name',
-        status: 'test-status'
-      }
-    };
-
-    const errorAction = {
-      type: ActionTypes.CHECK_NAME_OWNERSHIP_ERROR,
-      payload: {
-        id: 'snapId',
-        snapName: 'test-name',
-        status: 'test-status'
-      }
-    };
-
-    it('CHECK_NAME_OWNERSHIP_REQUEST should update isFetching state', function() {
-      expect(snap(state, requestAction).snapcraftData.isFetching).toBe(true);
-    });
-
-    it('CHECK_NAME_OWNERSHIP_SUCCESS should update isFetching state', function() {
-      expect(snap(state, successAction).snapcraftData.isFetching).toBe(false);
-    });
-
-    it('CHECK_NAME_OWNERSHIP_SUCCESS should set name ownership status', function() {
-      expect(snap(state, successAction).snapcraftData.nameOwnershipStatus).toBe('test-status');
-    });
-
-    it('CHECK_NAME_OWNERSHIP_ERROR should update isFetching state', function() {
-      expect(snap(state, errorAction).snapcraftData.isFetching).toBe(false);
-    });
-
-    it('CHECK_NAME_OWNERSHIP_ERROR should reset name ownership status', function() {
-      expect(snap(state, errorAction).snapcraftData.nameOwnershipStatus).toBe(null);
-    });
-  
-  });
 
   context('on register name actions', () => {
     const initialStatus = {

--- a/test/unit/src/common/reducers/t_name-ownership.js
+++ b/test/unit/src/common/reducers/t_name-ownership.js
@@ -1,0 +1,60 @@
+import expect from 'expect';
+
+import { nameOwnership } from '../../../../../src/common/reducers/name-ownership';
+import * as ActionTypes from '../../../../../src/common/actions/register-name';
+
+describe('name ownership reducers', () => {
+  const initialState = {};
+  let state = {};
+
+  it('should return the initial state', () => {
+    expect(nameOwnership(undefined, {})).toEqual(initialState);
+  });
+
+  const requestAction = {
+    type: ActionTypes.CHECK_NAME_OWNERSHIP_REQUEST,
+    payload: {
+      id: 'snapId',
+      snapName: 'test-name',
+    }
+  };
+
+  const successAction = {
+    type: ActionTypes.CHECK_NAME_OWNERSHIP_SUCCESS,
+    payload: {
+      id: 'snapId',
+      snapName: 'test-name',
+      status: 'test-status'
+    }
+  };
+
+  const errorAction = {
+    type: ActionTypes.CHECK_NAME_OWNERSHIP_ERROR,
+    payload: {
+      id: 'snapId',
+      snapName: 'test-name',
+      status: 'test-status'
+    }
+  };
+
+  it('CHECK_NAME_OWNERSHIP_REQUEST should update isFetching state', function() {
+    expect(nameOwnership(state, requestAction)['test-name'].isFetching).toBe(true);
+  });
+
+  it('CHECK_NAME_OWNERSHIP_SUCCESS should update isFetching state', function() {
+    expect(nameOwnership(state, successAction)['test-name'].isFetching).toBe(false);
+  });
+
+  it('CHECK_NAME_OWNERSHIP_SUCCESS should set name ownership status', function() {
+    expect(nameOwnership(state, successAction)['test-name'].nameOwnershipStatus).toBe('test-status');
+  });
+
+  it('CHECK_NAME_OWNERSHIP_ERROR should update isFetching state', function() {
+    expect(nameOwnership(state, errorAction)['test-name'].isFetching).toBe(false);
+  });
+
+  it('CHECK_NAME_OWNERSHIP_ERROR should reset name ownership status', function() {
+    expect(nameOwnership(state, errorAction)['test-name'].nameOwnershipStatus).toBe(null);
+  });
+
+});


### PR DESCRIPTION
Part of #646

Currently we only check name ownership for name in snapcraft.yaml - and we keep this status together with snapcraft.yaml data in redux store.

But for #646 we also need to check name ownership for registered names of snaps, so it would be better to have a separate store for keeping name ownership status per name.

This PR refactors current state of the app (name ownership of snapcraft.yaml name) into new name ownership reducer, where in future also register names ownership may be kept.