### PR TITLE
Attribute organization repo activity to registrant

### DIFF
--- a/migrations/20170503223139_repository.js
+++ b/migrations/20170503223139_repository.js
@@ -1,0 +1,20 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.createTable('repository', function(table) {
+      table.increments();
+      table.text('owner').notNullable();
+      table.text('name').notNullable();
+      table.text('snapcraft_name');
+      table.text('store_name');
+      table.integer('registrant_id').references('github_user.id');
+      table.timestamps();
+      table.unique(['owner', 'name']);
+    })
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.all([
+    knex.schema.dropTable('repository')
+  ]);
+};

--- a/src/server/db/models/index.js
+++ b/src/server/db/models/index.js
@@ -1,5 +1,7 @@
 import registerGitHubUser from './github-user';
+import registerRepository from './repository';
 
 export default function register(db) {
   registerGitHubUser(db);
+  registerRepository(db);
 }

--- a/src/server/db/models/repository.js
+++ b/src/server/db/models/repository.js
@@ -1,0 +1,23 @@
+// Ensure that GitHubUser model is registered; we do not need to import any
+// bindings.
+import './github-user';
+
+export default function register(db) {
+  /* Schema:
+   *   id: automatic serial number
+   *   owner: repository owner name
+   *   name: repository name
+   *   snapcraft_name: name in snapcraft.yaml
+   *   store_name: registered store name corresponding to this repository
+   *   registrant: GitHub user who registered this repository in BSI
+   *   created_at: creation date
+   *   updated_at: update date
+   */
+  db.model('Repository', {
+    tableName: 'repository',
+    registrant: function() {
+      return this.belongsTo('GitHubUser', 'registrant_id');
+    },
+    hasTimestamps: true
+  });
+}

--- a/src/server/db/models/repository.js
+++ b/src/server/db/models/repository.js
@@ -19,5 +19,29 @@ export default function register(db) {
       return this.belongsTo('GitHubUser', 'registrant_id');
     },
     hasTimestamps: true
+  }, {
+    // Add or update a repository row with the given information.
+    // `query` must be either a Repository model instance or { owner, name }.
+    addOrUpdate: async (query, columns, options) => {
+      let row;
+      if (query instanceof db.Model) {
+        row = query;
+      } else {
+        row = await db.model('Repository').where(query).fetch(options);
+      }
+      if (row === null) {
+        row = db.model('Repository').forge(query);
+      }
+      const setColumns = Object.assign({}, columns);
+      if (setColumns.registrant) {
+        setColumns.registrant_id = setColumns.registrant.get('id');
+      }
+      delete setColumns.registrant;
+      row.set(setColumns);
+      if (row.hasChanged()) {
+        await row.save({}, options);
+      }
+      return row;
+    }
   });
 }

--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -1,6 +1,8 @@
 import { createHash } from 'crypto';
 
 import yaml from 'js-yaml';
+import keyBy from 'lodash/keyBy';
+import uniq from 'lodash/uniq';
 import zip from 'lodash/zip';
 import { normalize } from 'normalizr';
 
@@ -337,13 +339,29 @@ export const newSnap = async (req, res) => {
 
   // We need admin permissions in order to be able to install a webhook later.
   try {
-    await checkAdminPermissions(req.session, repositoryUrl);
+    const { owner, name } = await checkAdminPermissions(
+      req.session, repositoryUrl
+    );
     await db.transaction(async (trx) => {
+      let dbUser = null;
       if (req.session.user) {
-        await db.model('GitHubUser').incrementMetric(
+        dbUser = await db.model('GitHubUser').incrementMetric(
           { github_id: req.session.user.id }, 'snaps_added', 1,
           { transacting: trx }
         );
+      }
+      const repositoryModel = db.model('Repository');
+      let dbRepository = await repositoryModel
+        .where({ owner, name })
+        .fetch({ transacting: trx });
+      if (dbRepository === null) {
+        dbRepository = repositoryModel.forge({ owner, name });
+      }
+      dbRepository.set({
+        registrant_id: dbUser && dbUser.get('id')
+      });
+      if (dbRepository.hasChanged()) {
+        await dbRepository.save({}, { transacting: trx });
       }
 
       const result = await requestNewSnap(repositoryUrl);
@@ -491,48 +509,46 @@ const internalFindSnaps = async (owner, token) => {
 // historical data.  This may under-report if somebody manages to accumulate
 // more snaps than the Launchpad batch size (75) before triggering this, but
 // that shouldn't happen in practice.
-const initializeMetrics = async (gitHubId, snaps) => {
-  await db.transaction(async (trx) => {
-    const row = await db.model('GitHubUser')
-      .where({ github_id: gitHubId })
-      .fetch({ transacting: trx });
-    if (row) {
-      const rowData = row.serialize();
-      if (rowData.snaps_added === undefined ||
-          rowData.snaps_added === null) {
-        row.set({ snaps_added: snaps.length });
-      }
-      if (rowData.snaps_removed === undefined ||
-          rowData.snaps_removed === null) {
-        row.set({ snaps_removed: 0 });
-      }
-      if (rowData.names_registered === undefined ||
-          rowData.names_registered === null) {
-        const namesRegistered = snaps.filter((snap) => snap.store_name).length;
-        row.set({ names_registered: namesRegistered });
-      }
-      if (rowData.builds_requested === undefined ||
-          rowData.builds_requested === null) {
-        // This is potentially quite an expensive piece of initialization,
-        // but only the first time that a user who's been using the site
-        // since before this code landed comes back, so some one-time
-        // expense is tolerable.
-        try {
-          let buildsRequested = 0;
-          for (const snap of snaps) {
-            const builds = await getLaunchpad().get(
-              snap.builds_collection_link
-            );
-            buildsRequested += builds.total_size;
-          }
-          row.set({ builds_requested: buildsRequested });
-        } catch (error) {
-          logger.error(`Failed to fetch builds from Launchpad: ${error}`);
-        }
-      }
-      await row.save({}, { transacting: trx });
+const initializeMetrics = async (trx, gitHubId, snaps) => {
+  const row = await db.model('GitHubUser')
+    .where({ github_id: gitHubId })
+    .fetch({ transacting: trx });
+  if (row) {
+    const rowData = row.serialize();
+    if (rowData.snaps_added === undefined ||
+        rowData.snaps_added === null) {
+      row.set({ snaps_added: snaps.length });
     }
-  });
+    if (rowData.snaps_removed === undefined ||
+        rowData.snaps_removed === null) {
+      row.set({ snaps_removed: 0 });
+    }
+    if (rowData.names_registered === undefined ||
+        rowData.names_registered === null) {
+      const namesRegistered = snaps.filter((snap) => snap.store_name).length;
+      row.set({ names_registered: namesRegistered });
+    }
+    if (rowData.builds_requested === undefined ||
+        rowData.builds_requested === null) {
+      // This is potentially quite an expensive piece of initialization, but
+      // only the first time that a user who's been using the site since
+      // before this code landed comes back, so some one-time expense is
+      // tolerable.
+      try {
+        let buildsRequested = 0;
+        for (const snap of snaps) {
+          const builds = await getLaunchpad().get(
+            snap.builds_collection_link
+          );
+          buildsRequested += builds.total_size;
+        }
+        row.set({ builds_requested: buildsRequested });
+      } catch (error) {
+        logger.error(`Failed to fetch builds from Launchpad: ${error}`);
+      }
+    }
+    await row.save({}, { transacting: trx });
+  }
 };
 
 export const findSnaps = async (req, res) => {
@@ -545,9 +561,46 @@ export const findSnaps = async (req, res) => {
       );
       return { ...snap, snapcraft_data: snapcraftData };
     }));
-    if (req.session.user) {
-      await initializeMetrics(req.session.user.id, snaps);
-    }
+    await db.transaction(async (trx) => {
+      if (req.session.user) {
+        const ownedSnaps = snaps.filter((snap) => {
+          const snapOwner = parseGitHubRepoUrl(snap.git_repository_url).owner;
+          return snapOwner === owner;
+        });
+        await initializeMetrics(trx, req.session.user.id, ownedSnaps);
+      }
+      // Keep the database up to date with the response, for the sake of
+      // metrics.
+      const owners = uniq(snaps.map((snap) => {
+        return parseGitHubRepoUrl(snap.git_repository_url).owner;
+      }));
+      const dbRepositories = await db.model('Repository')
+        .where('owner', 'in', owners)
+        .fetchAll({ transacting: trx });
+      const dbRepositoriesByFullName = keyBy(dbRepositories.models, (repo) => {
+        return `${repo.get('owner')}/${repo.get('name')}`;
+      });
+      for (const snap of snaps) {
+        const { owner, name, fullName } = parseGitHubRepoUrl(
+          snap.git_repository_url
+        );
+        let dbRepository;
+        if (fullName in dbRepositoriesByFullName) {
+          dbRepository = dbRepositoriesByFullName[fullName];
+        } else {
+          dbRepository = db.model('Repository').forge({ owner, name });
+        }
+        dbRepository.set({
+          snapcraft_name: (
+            (snap.snapcraft_data && snap.snapcraft_data.name) || null
+          ),
+          store_name: snap.store_name || null
+        });
+        if (dbRepository.hasChanged()) {
+          await dbRepository.save({}, { transacting: trx });
+        }
+      }
+    });
     return res.status(200).send({
       status: 'success',
       code: 'snaps-found',
@@ -612,18 +665,36 @@ export const authorizeSnap = async (req, res) => {
   const macaroon = req.body.macaroon;
 
   try {
-    await checkAdminPermissions(req.session, repositoryUrl);
+    const { owner, name } = await checkAdminPermissions(
+      req.session, repositoryUrl
+    );
     const result = await internalFindSnap(repositoryUrl);
     // Registration happened a short while ago; we increment the metric here
     // in order to support having the client call `register-name` on the
     // store directly rather than going via our backend.  As such, we don't
     // need to roll this back if authorization fails.
     await db.transaction(async (trx) => {
+      let dbUser = null;
       if (req.session && req.session.user) {
-        await db.model('GitHubUser').incrementMetric(
+        dbUser = await db.model('GitHubUser').incrementMetric(
           { github_id: req.session.user.id }, 'names_registered', 1,
           { transacting: trx }
         );
+      }
+      const repositoryModel = db.model('Repository');
+      let dbRepository = await repositoryModel
+        .where({ owner, name })
+        .fetch({ transacting: trx });
+      if (dbRepository === null) {
+        dbRepository = repositoryModel.forge({
+          owner,
+          name,
+          registrant_id: dbUser && dbUser.get('id')
+        });
+      }
+      dbRepository.set({ store_name: snapName });
+      if (dbRepository.hasChanged()) {
+        await dbRepository.save({}, { transacting: trx });
       }
     });
     const snapUrl = result.self_link;
@@ -686,7 +757,7 @@ export const getSnapBuilds = async (req, res) => {
   }
 };
 
-export const internalRequestSnapBuilds = async (snap, owner) => {
+export const internalRequestSnapBuilds = async (snap, owner, name) => {
   // Request builds, then make sure that auto_build is enabled so that
   // future push events will cause the webhook to dispatch builds.  Doing
   // things in this order ensures that Launchpad's internal
@@ -706,13 +777,15 @@ export const internalRequestSnapBuilds = async (snap, owner) => {
   // requesting builds fails.
   try {
     await db.transaction(async (trx) => {
-      // XXX cjwatson 2017-03-17: This will go wrong once we support
-      // organizations, since we have no way to know which developer to
-      // credit for the builds.  At the moment, the best we can do is to
-      // credit the owner of the repository.
+      const dbRepository = await db.model('Repository')
+        .where({ owner, name })
+        .fetch({ withRelated: ['registrant'], transacting: trx });
+      const userQuery = (
+        (dbRepository && dbRepository.related('registrant')) ||
+        { login: owner }
+      );
       await db.model('GitHubUser').incrementMetric(
-        { login: owner }, 'builds_requested', builds.length,
-        { transacting: trx }
+        userQuery, 'builds_requested', builds.length, { transacting: trx }
       );
     });
   } catch (error) {
@@ -723,11 +796,11 @@ export const internalRequestSnapBuilds = async (snap, owner) => {
 
 export const requestSnapBuilds = async (req, res) => {
   try {
-    const { owner } = await checkAdminPermissions(
+    const { owner, name } = await checkAdminPermissions(
       req.session, req.body.repository_url
     );
     const snap = await internalFindSnap(req.body.repository_url);
-    const builds = await internalRequestSnapBuilds(snap, owner);
+    const builds = await internalRequestSnapBuilds(snap, owner, name);
     return res.status(201).send({
       status: 'success',
       payload: {
@@ -742,7 +815,7 @@ export const requestSnapBuilds = async (req, res) => {
 
 export const deleteSnap = async (req, res) => {
   try {
-    const { owner } = await checkAdminPermissions(
+    const { owner, name } = await checkAdminPermissions(
       req.session, req.body.repository_url
     );
     const snap = await internalFindSnap(req.body.repository_url);
@@ -753,6 +826,12 @@ export const deleteSnap = async (req, res) => {
           { transacting: trx }
         );
       }
+      // Model.destroy doesn't support DELETE FROM ... WHERE ..., so we have
+      // to drop down to the Knex level.
+      await db.knex('Repository')
+        .transacting(trx)
+        .where({ owner, name })
+        .del();
       await snap.lp_delete();
 
       const urlPrefix = getRepoUrlPrefix(owner);


### PR DESCRIPTION
Keep track of who registered each repository with build.snapcraft.io in
a new Repository table, and attribute `builds_requested` and
`builds_released` activity to that user.  Catch up with existing
repositories via the `/api/launchpad/snaps/list` handler.

This isn't necessarily perfect since the publisher can be reassigned in
the store without us noticing, but this is tolerable since it's only for
metrics.

The `Repository.snapcraft_name` and `Repository.store_name` columns
aren't immediately needed for this, but will be useful for future work
such as #706.

Fixes #621.