### PR TITLE
Simulate a missing snap/snapcraft.yaml

### DIFF
--- a/mocks/service/github/index.js
+++ b/mocks/service/github/index.js
@@ -24,6 +24,10 @@ router.get(
   '/repos/:owner/:name/contents/snapcraft.yaml',
   responses.okaySnapcraftYamlFound
 );
+router.get(
+  '/repos/:owner/:name/contents/snap/snapcraft.yaml',
+  responses.errorSnapcraftYamlNotFound
+);
 
 router.get('/user/repos', responses.okayReposFound);
 router.get('/user/orgs', responses.okayOrgsFound);


### PR DESCRIPTION
The mock GitHub service fails to respond sensibly to a request for `snap/snapcraft.yaml` when it can just 404 instead. This makes the fake simulate a `snapcraft.yaml` but a missing `snap/snapcraft.yaml`.