### PR TITLE
Get registered names from account info response

### DIFF
--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -8,7 +8,7 @@ import url from 'url';
 import { checkStatus, getError } from '../helpers/api';
 import { conf } from '../helpers/config';
 import { getCaveats } from '../helpers/macaroons';
-import { getPackageUploadRequestMacaroon } from './register-name';
+import { STORE_SERIES, getPackageUploadRequestMacaroon } from './register-name';
 
 const BASE_URL = conf.get('BASE_URL');
 
@@ -228,7 +228,14 @@ async function fetchAccountInfo(root, discharge) {
     headers: { 'Accept': 'application/json' }
   });
   if (response.status >= 200 && response.status < 300) {
-    return { signedAgreement: true, hasShortNamespace: true };
+    const json = await response.json();
+    let registeredNames = null;
+
+    if (json.snaps && json.snaps[STORE_SERIES]) {
+      registeredNames = Object.keys(json.snaps[STORE_SERIES]);
+    }
+
+    return { signedAgreement: true, hasShortNamespace: true, registeredNames };
   } else {
     const json = await response.json();
     const payload = json.error_list ? json.error_list[0] : json;

--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -227,8 +227,8 @@ async function fetchAccountInfo(root, discharge) {
   const response = await fetch(accountUrl, {
     headers: { 'Accept': 'application/json' }
   });
+  const json = await response.json();
   if (response.status >= 200 && response.status < 300) {
-    const json = await response.json();
     let registeredNames = null;
 
     if (json.snaps && json.snaps[STORE_SERIES]) {
@@ -237,7 +237,6 @@ async function fetchAccountInfo(root, discharge) {
 
     return { signedAgreement: true, hasShortNamespace: true, registeredNames };
   } else {
-    const json = await response.json();
     const payload = json.error_list ? json.error_list[0] : json;
     if (response.status === 403 && payload.code === 'user-not-ready') {
       const data = { signedAgreement: null, hasShortNamespace: null };

--- a/src/common/actions/register-name.js
+++ b/src/common/actions/register-name.js
@@ -17,8 +17,8 @@ export const REGISTER_NAME_CLEAR = 'REGISTER_NAME_CLEAR';
 
 // XXX cjwatson 2017-02-08: Hardcoded for now, but should eventually be
 // configurable.
-const STORE_SERIES = '16';
-const STORE_CHANNELS = ['edge'];
+export const STORE_SERIES = '16';
+export const STORE_CHANNELS = ['edge'];
 
 export async function getPackageUploadRequestMacaroon() {
   let packageUploadRequest;

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -201,14 +201,23 @@ export class RepositoryRowView extends Component {
       });
     }
 
-    const nextSnapcraftData = nextProps.snap.snapcraftData;
+    // only attempt checking name ownership if user is authenticated
+    // and we are not fetching any auth data (because fetched account info will
+    // contain names already registered by given user)
+    if (this.props.authStore.authenticated &&
+        !nextProps.authStore.isFetching && !this.props.authStore.isFetching) {
+      const nextSnapcraftData = nextProps.snap.snapcraftData;
 
-    if (snapNameIsMismatched(nextProps.snap)) {
-      this.checkNameOwnership(nextProps.nameOwnership, nextSnapcraftData.name);
-    }
+      // if register name doesn't match snapcraft.yaml name verfify who
+      // owns name in snapcraft.yaml
+      if (snapNameIsMismatched(nextProps.snap)) {
+        this.checkNameOwnership(nextProps.nameOwnership, nextSnapcraftData.name);
+      }
 
-    if (nextProps.snap.storeName) {
-      this.checkNameOwnership(nextProps.nameOwnership, nextProps.snap.storeName);
+      // if snap has a registered name, verify who owns it
+      if (nextProps.snap.storeName) {
+        this.checkNameOwnership(nextProps.nameOwnership, nextProps.snap.storeName);
+      }
     }
   }
 
@@ -220,7 +229,7 @@ export class RepositoryRowView extends Component {
       (nameOwnership.status || nameOwnership.isFetching)
     );
 
-    if (this.props.authStore.authenticated && !isNameOwnershipAvailable) {
+    if (!isNameOwnershipAvailable) {
       this.props.checkNameOwnership(name);
     }
   }
@@ -484,6 +493,7 @@ RepositoryRowView.propTypes = {
   isPublished: PropTypes.bool,
   fullName: PropTypes.string,
   authStore: PropTypes.shape({
+    isFetching: PropTypes.bool,
     authenticated: PropTypes.bool,
     userName: PropTypes.string
   }),

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -204,8 +204,7 @@ export class RepositoryRowView extends Component {
     // only attempt checking name ownership if user is authenticated
     // and we are not fetching any auth data (because fetched account info will
     // contain names already registered by given user)
-    if (this.props.authStore.authenticated &&
-        !nextProps.authStore.isFetching && !this.props.authStore.isFetching) {
+    if (this.isAuthReady(nextProps)) {
       const nextSnapcraftData = nextProps.snap.snapcraftData;
 
       // if register name doesn't match snapcraft.yaml name verfify who
@@ -219,6 +218,11 @@ export class RepositoryRowView extends Component {
         this.checkNameOwnership(nextProps.nameOwnership, nextProps.snap.storeName);
       }
     }
+  }
+
+  isAuthReady(nextProps) {
+    return (this.props.authStore.authenticated &&
+        !nextProps.authStore.isFetching && !this.props.authStore.isFetching);
   }
 
   checkNameOwnership(nameOwnershipStore, name) {

--- a/src/common/reducers/name-ownership.js
+++ b/src/common/reducers/name-ownership.js
@@ -1,4 +1,6 @@
 import * as ActionTypes from '../actions/name-ownership';
+import { NAME_OWNERSHIP_ALREADY_OWNED } from '../actions/name-ownership';
+import { GET_ACCOUNT_INFO_SUCCESS } from '../actions/auth-store';
 
 export function nameOwnership(state = {}, action) {
   const { payload } = action;
@@ -30,6 +32,20 @@ export function nameOwnership(state = {}, action) {
           status: null
         }
       };
+    case GET_ACCOUNT_INFO_SUCCESS:
+      if (payload.registeredNames) {
+        return {
+          ...state,
+          ...payload.registeredNames.reduce((ownership, name) => {
+            ownership[name] = {
+              isFetching: false,
+              status: NAME_OWNERSHIP_ALREADY_OWNED
+            };
+            return ownership;
+          }, {})
+        };
+      }
+      return state;
     default:
       return state;
   }

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -12,12 +12,12 @@ import { conf } from '../../../../../src/common/helpers/config';
 import { makeLocalForageStub } from '../../../../helpers';
 
 const localForageStub = makeLocalForageStub();
-const getPackageUploadRequestMacaroon = proxyquire.noCallThru().load(
+const registerNameModule = proxyquire.noCallThru().load(
   '../../../../../src/common/actions/register-name',
   { 'localforage': localForageStub }
-).getPackageUploadRequestMacaroon;
+);
+const { getPackageUploadRequestMacaroon, STORE_SERIES } = registerNameModule;
 
-const STORE_SERIES = '16';
 const authStoreModule = proxyquire.noCallThru().load(
   '../../../../../src/common/actions/auth-store',
   {

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -16,13 +16,16 @@ const getPackageUploadRequestMacaroon = proxyquire.noCallThru().load(
   '../../../../../src/common/actions/register-name',
   { 'localforage': localForageStub }
 ).getPackageUploadRequestMacaroon;
+
+const STORE_SERIES = '16';
 const authStoreModule = proxyquire.noCallThru().load(
   '../../../../../src/common/actions/auth-store',
   {
     'localforage': localForageStub,
-    './register-name': { getPackageUploadRequestMacaroon }
+    './register-name': { getPackageUploadRequestMacaroon, STORE_SERIES }
   }
 );
+
 const {
   checkSignedIntoStore,
   extractExpiresCaveat,
@@ -524,7 +527,35 @@ describe('store authentication actions', () => {
           .reply(200, {});
         const expectedAction = {
           type: ActionTypes.GET_ACCOUNT_INFO_SUCCESS,
-          payload: { signedAgreement: true, hasShortNamespace: true }
+          payload: {
+            signedAgreement: true,
+            hasShortNamespace: true,
+            registeredNames: null
+          }
+        };
+        await store.dispatch(getAccountInfo('test-user'));
+        expect(store.getActions()).toInclude(expectedAction);
+      });
+
+      it('stores success action if getting account information succeeds ' +
+         'and returns a list of registered names', async () => {
+        api.get('/store/account')
+          .query(true)
+          .reply(200, {
+            snaps: {
+              [STORE_SERIES]: {
+                'test-name-1': {},
+                'test-name-2': {}
+              }
+            }
+          });
+        const expectedAction = {
+          type: ActionTypes.GET_ACCOUNT_INFO_SUCCESS,
+          payload: {
+            signedAgreement: true,
+            hasShortNamespace: true,
+            registeredNames: ['test-name-1', 'test-name-2']
+          }
         };
         await store.dispatch(getAccountInfo('test-user'));
         expect(store.getActions()).toInclude(expectedAction);
@@ -601,7 +632,11 @@ describe('store authentication actions', () => {
               .reply(200, {});
             const expectedAction = {
               type: ActionTypes.GET_ACCOUNT_INFO_SUCCESS,
-              payload: { signedAgreement: true, hasShortNamespace: true }
+              payload: {
+                signedAgreement: true,
+                hasShortNamespace: true,
+                registeredNames: null
+              }
             };
             await store.dispatch(getAccountInfo('test-user'));
             expect(store.getActions()).toInclude(expectedAction);

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -360,7 +360,11 @@ describe('register name actions', () => {
 
                 const expectedAccountAction = {
                   type: GET_ACCOUNT_INFO_SUCCESS,
-                  payload: { signedAgreement: true, hasShortNamespace: true }
+                  payload: {
+                    signedAgreement: true,
+                    hasShortNamespace: true,
+                    registeredNames: null
+                  }
                 };
                 await store.dispatch(registerName(repository, 'test-snap', {
                   signAgreement: 'test-user'
@@ -378,7 +382,11 @@ describe('register name actions', () => {
 
                 const expectedAccountAction = {
                   type: GET_ACCOUNT_INFO_SUCCESS,
-                  payload: { signedAgreement: true, hasShortNamespace: true }
+                  payload: {
+                    signedAgreement: true,
+                    hasShortNamespace: true,
+                    registeredNames: null
+                  }
                 };
                 await store.dispatch(registerName(repository, 'test-snap', {
                   signAgreement: 'test-user'


### PR DESCRIPTION
As suggested by @cjwatson `/store/account` API response (that we already make after user signs in) already contains list of names registered by given user.

So we can pre-populate list of names owned by given user with this information before we attempt to verify ownership of any other name.