### PR TITLE
Don't attempt do reload name ownership if previous failed

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -229,8 +229,9 @@ export class RepositoryRowView extends Component {
     const nameOwnership = nameOwnershipStore[name];
 
     // don't fetch if we have the data or it's already fetching
+    // also in case of error don't fetch again (to avoid fetching loop...)
     const isNameOwnershipAvailable = (nameOwnership &&
-      (nameOwnership.status || nameOwnership.isFetching)
+      (nameOwnership.status || nameOwnership.isFetching || nameOwnership.error)
     );
 
     if (!isNameOwnershipAvailable) {

--- a/src/common/reducers/name-ownership.js
+++ b/src/common/reducers/name-ownership.js
@@ -20,7 +20,8 @@ export function nameOwnership(state = {}, action) {
         [payload.name]: {
           ...state[payload.name],
           isFetching: false,
-          status: payload.status
+          status: payload.status,
+          error: null
         }
       };
     case ActionTypes.CHECK_NAME_OWNERSHIP_ERROR:
@@ -29,7 +30,8 @@ export function nameOwnership(state = {}, action) {
         [payload.name]: {
           ...state[payload.name],
           isFetching: false,
-          status: null
+          status: null,
+          error: payload.error
         }
       };
     case GET_ACCOUNT_INFO_SUCCESS:

--- a/test/unit/src/common/reducers/t_name-ownership.js
+++ b/test/unit/src/common/reducers/t_name-ownership.js
@@ -30,7 +30,8 @@ describe('name ownership reducers', () => {
     type: ActionTypes.CHECK_NAME_OWNERSHIP_ERROR,
     payload: {
       name: 'test-name',
-      status: 'test-status'
+      status: 'test-status',
+      error: 'Something is wrong'
     }
   };
 
@@ -54,4 +55,7 @@ describe('name ownership reducers', () => {
     expect(nameOwnership(state, errorAction)['test-name'].status).toBe(null);
   });
 
+  it('CHECK_NAME_OWNERSHIP_ERROR should store error object', function() {
+    expect(nameOwnership(state, errorAction)['test-name'].error).toEqual('Something is wrong');
+  });
 });


### PR DESCRIPTION
Found when debugging issues with #738.

If name ownership failed (returned an error) for any reason we were attempting to (immediately) fetch it again. This was resulting in loops of /register-name API calls failing in the same way.

We don't have any means to debounce such repeated calls or postpone reloading the data in case of error, so the best way to deal with that would be not to try again if error was returned.

Name ownership will be refreshed next time user reloads whole page or signs in again.