### PR TITLE
Prevent other users from removing registered snap

### DIFF
--- a/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
@@ -6,14 +6,37 @@ import { WarningIcon } from '../icons';
 
 import styles from './dropdowns.css';
 
+const getRemoveWarningMessage = (latestBuild, registeredName) => {
+  let warningText;
+  if (latestBuild) {
+    warningText = (
+      'Removing this repo will delete all its builds and build logs.'
+    );
+  } else {
+    warningText = (
+      'Are you sure you want to remove this repo from the list?'
+    );
+  }
+  if (registeredName !== null) {
+    warningText += ' The name will remain registered.';
+  }
+  // XXX cjwatson 2017-02-28: Once we can get hold of published states for
+  // builds, we should also implement this design requirement:
+  //   Separately, if any build has been published, the text should end
+  //   with:
+  //     Published builds will remain published.
+
+  return warningText;
+};
+
 const RemoveRepoDropdown = (props) => {
-  const { message, onCancelClick, onRemoveClick } = props;
+  const { latestBuild, registeredName, onCancelClick, onRemoveClick } = props;
 
   return (
     <Dropdown>
       <Row>
         <Data col="100">
-          <WarningIcon /> { message }
+          <WarningIcon /> { getRemoveWarningMessage(latestBuild, registeredName) }
         </Data>
       </Row>
       <Row>
@@ -38,7 +61,8 @@ const RemoveRepoDropdown = (props) => {
 };
 
 RemoveRepoDropdown.propTypes = {
-  message: PropTypes.string.isRequired,
+  latestBuild: PropTypes.object,
+  registeredName: PropTypes.string,
   onRemoveClick: PropTypes.func.isRequired,
   onCancelClick: PropTypes.func.isRequired
 };

--- a/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
@@ -30,31 +30,66 @@ const getRemoveWarningMessage = (latestBuild, registeredName) => {
 };
 
 const RemoveRepoDropdown = (props) => {
-  const { latestBuild, registeredName, onCancelClick, onRemoveClick } = props;
+  const {
+    isAuthenticated,
+    isOwnerOfRegisteredName,
+    latestBuild,
+    registeredName,
+    onCancelClick,
+    onSignInClick,
+    onRemoveClick
+  } = props;
+
+  let message = (
+    <span>
+      <WarningIcon /> { getRemoveWarningMessage(latestBuild, registeredName) }
+    </span>
+  );
+
+  let actionButton = (
+    <Button
+      appearance="negative"
+      onClick={ onRemoveClick }
+    >
+      Remove
+    </Button>
+  );
+
+  if (registeredName) {
+    if (isAuthenticated) {
+      if (!isOwnerOfRegisteredName) {
+        message = `To remove this repo, contact the person who registered the name ${registeredName}.`;
+        actionButton = null;
+      }
+    } else {
+      message = `You can remove this repo only if you registered the name ${registeredName}.`;
+
+      actionButton = (
+        <Button
+          appearance="positive"
+          onClick={ onSignInClick }
+        >
+          Sign in
+        </Button>
+      );
+    }
+  }
 
   return (
     <Dropdown>
       <Row>
         <Data col="100">
-          <WarningIcon /> { getRemoveWarningMessage(latestBuild, registeredName) }
+          { message }
         </Data>
       </Row>
-      <Row>
-        <div className={ styles.buttonRow }>
-          <a
-            onClick={ onCancelClick }
-            className={ styles.cancel }
-          >
-            Cancel
-          </a>
-          <Button
-            appearance="negative"
-            onClick={ onRemoveClick }
-          >
-            Remove
-          </Button>
-        </div>
-      </Row>
+      { actionButton &&
+        <Row>
+          <div className={ styles.buttonRow }>
+            <a onClick={ onCancelClick } className={ styles.cancel }>Cancel</a>
+            { actionButton }
+          </div>
+        </Row>
+      }
     </Dropdown>
   );
 
@@ -63,7 +98,10 @@ const RemoveRepoDropdown = (props) => {
 RemoveRepoDropdown.propTypes = {
   latestBuild: PropTypes.object,
   registeredName: PropTypes.string,
+  isOwnerOfRegisteredName: PropTypes.bool,
+  isAuthenticated: PropTypes.bool,
   onRemoveClick: PropTypes.func.isRequired,
+  onSignInClick: PropTypes.func.isRequired,
   onCancelClick: PropTypes.func.isRequired
 };
 

--- a/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
+++ b/src/common/components/repository-row/dropdowns/remove-repo-dropdown.js
@@ -6,9 +6,9 @@ import { WarningIcon } from '../icons';
 
 import styles from './dropdowns.css';
 
-const getRemoveWarningMessage = (latestBuild, registeredName) => {
+const getRemoveWarningMessage = (isBuilt, registeredName) => {
   let warningText;
-  if (latestBuild) {
+  if (isBuilt) {
     warningText = (
       'Removing this repo will delete all its builds and build logs.'
     );
@@ -33,7 +33,7 @@ const RemoveRepoDropdown = (props) => {
   const {
     isAuthenticated,
     isOwnerOfRegisteredName,
-    latestBuild,
+    isBuilt,
     registeredName,
     onCancelClick,
     onSignInClick,
@@ -42,7 +42,7 @@ const RemoveRepoDropdown = (props) => {
 
   let message = (
     <span>
-      <WarningIcon /> { getRemoveWarningMessage(latestBuild, registeredName) }
+      <WarningIcon /> { getRemoveWarningMessage(isBuilt, registeredName) }
     </span>
   );
 
@@ -96,8 +96,8 @@ const RemoveRepoDropdown = (props) => {
 };
 
 RemoveRepoDropdown.propTypes = {
-  latestBuild: PropTypes.object,
   registeredName: PropTypes.string,
+  isBuilt: PropTypes.bool,
   isOwnerOfRegisteredName: PropTypes.bool,
   isAuthenticated: PropTypes.bool,
   onRemoveClick: PropTypes.func.isRequired,

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -281,7 +281,7 @@ export class RepositoryRowView extends Component {
 
     const registeredName = snap.storeName;
 
-    const hasBuilt = !!(latestBuild && snap.snapcraftData);
+    const isBuilt = !!(latestBuild && snap.snapcraftData);
 
     const isActive = (
       showNameMismatchDropdown ||
@@ -298,10 +298,10 @@ export class RepositoryRowView extends Component {
       <Row isActive={isActive}>
 
         {/* cells */}
-        { this.renderRepoName(fullName, hasBuilt) }
+        { this.renderRepoName(fullName, isBuilt) }
         { this.renderConfiguredStatus(snap) }
         { this.renderSnapName(registeredName, showRegisterNameInput, snap) }
-        { this.renderBuildStatus(fullName, hasBuilt, latestBuild) }
+        { this.renderBuildStatus(fullName, isBuilt, latestBuild) }
         { this.renderDelete() }
 
         {/* dropdowns */}
@@ -336,7 +336,7 @@ export class RepositoryRowView extends Component {
         }
         { showRemoveDropdown &&
           <RemoveRepoDropdown
-            latestBuild={latestBuild}
+            isBuilt={isBuilt}
             registeredName={registeredName}
             isOwnerOfRegisteredName={isOwnerOfRegisteredName}
             isAuthenticated={authStore.authenticated}
@@ -418,10 +418,10 @@ export class RepositoryRowView extends Component {
     );
   }
 
-  renderBuildStatus(fullName, hasBuilt, latestBuild) {
+  renderBuildStatus(fullName, isBuilt, latestBuild) {
     return (
-      <DataLink col="30" to={ hasBuilt ? `/user/${fullName}` : null }>
-        { hasBuilt
+      <DataLink col="30" to={ isBuilt ? `/user/${fullName}` : null }>
+        { isBuilt
           ? (
             <BuildStatus
               colour={ latestBuild.colour }

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -20,7 +20,7 @@ import {
 } from './icons';
 import * as authStoreActionCreators from '../../actions/auth-store';
 import * as registerNameActionCreators from '../../actions/register-name';
-import { checkNameOwnership } from '../../actions/name-ownership';
+import { NAME_OWNERSHIP_ALREADY_OWNED, checkNameOwnership } from '../../actions/name-ownership';
 import * as snapActionCreators from '../../actions/snaps';
 
 import { parseGitHubRepoUrl } from '../../helpers/github-url';
@@ -290,10 +290,9 @@ export class RepositoryRowView extends Component {
       showUnregisteredDropdown ||
       showRemoveDropdown
     );
-    // XXX cjwatson 2017-02-28: The specification calls for the remove icon
-    // to be shown only when hovering over or tapping in an empty part of
-    // the row.  My attempts to do this so far have resulted in the remove
-    // icon playing hide-and-seek.
+
+    let isOwnerOfRegisteredName = (registeredName && nameOwnership[registeredName] &&
+      nameOwnership[registeredName].status === NAME_OWNERSHIP_ALREADY_OWNED);
 
     return (
       <Row isActive={isActive}>
@@ -339,7 +338,10 @@ export class RepositoryRowView extends Component {
           <RemoveRepoDropdown
             latestBuild={latestBuild}
             registeredName={registeredName}
+            isOwnerOfRegisteredName={isOwnerOfRegisteredName}
+            isAuthenticated={authStore.authenticated}
             onRemoveClick={this.onRemoveClick.bind(this, snap.gitRepoUrl)}
+            onSignInClick={this.onSignInClick.bind(this)}
             onCancelClick={this.onToggleRemoveClick.bind(this)}
           />
         }

--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -337,36 +337,14 @@ export class RepositoryRowView extends Component {
         }
         { showRemoveDropdown &&
           <RemoveRepoDropdown
-            message={this.getRemoveWarningMessage(latestBuild, registeredName)}
+            latestBuild={latestBuild}
+            registeredName={registeredName}
             onRemoveClick={this.onRemoveClick.bind(this, snap.gitRepoUrl)}
             onCancelClick={this.onToggleRemoveClick.bind(this)}
           />
         }
       </Row>
     );
-  }
-
-  getRemoveWarningMessage(latestBuild, registeredName) {
-    let warningText;
-    if (latestBuild) {
-      warningText = (
-        'Removing this repo will delete all its builds and build logs.'
-      );
-    } else {
-      warningText = (
-        'Are you sure you want to remove this repo from the list?'
-      );
-    }
-    if (registeredName !== null) {
-      warningText += ' The name will remain registered.';
-    }
-    // XXX cjwatson 2017-02-28: Once we can get hold of published states for
-    // builds, we should also implement this design requirement:
-    //   Separately, if any build has been published, the text should end
-    //   with:
-    //     Published builds will remain published.
-
-    return warningText;
   }
 
   renderRepoName(fullName, isLinked) {

--- a/test/unit/src/common/components/repository-row/dropdowns/t_remove-repo-dropdown.js
+++ b/test/unit/src/common/components/repository-row/dropdowns/t_remove-repo-dropdown.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import expect from 'expect';
+import { shallow } from 'enzyme';
+
+import RemoveRepoDropdown from '../../../../../../../src/common/components/repository-row/dropdowns/remove-repo-dropdown';
+
+describe('<RemoveRepoDropdown />', () => {
+  const props = {
+    isBuild: false,
+    registeredName: null,
+    isOwnerOfRegisteredName: false,
+    isAuthenticated: false,
+    onRemoveClick: () => {},
+    onSignInClick: () => {},
+    onCancelClick: () => {}
+  };
+
+  let view;
+
+  beforeEach(function() {
+    view = shallow(<RemoveRepoDropdown { ...props }/>);
+  });
+
+  context('when name is not registered', function() {
+    beforeEach(() => {
+      view.setProps({ registeredName: null });
+    });
+
+    it('should render proper warning message', () => {
+      expect(view.html()).toContain('Are you sure you want to remove this repo from the list?');
+    });
+
+    it('should render Remove button', () => {
+      expect(view.find('Button').prop('children')).toEqual('Remove');
+    });
+
+    context('when repo was ever built', () => {
+      beforeEach(() => {
+        view.setProps({ isBuilt: true });
+      });
+
+      it('should render proper warning message', () => {
+        expect(view.html()).toContain('Removing this repo will delete all its builds and build logs.');
+      });
+    });
+  });
+
+  context('when name is registered', function() {
+    beforeEach(function() {
+      view.setProps({ registeredName: 'test-registered-name' });
+    });
+
+    context('when user is not signed in', () => {
+      beforeEach(function() {
+        view.setProps({ isAuthenticated: false });
+      });
+
+      it('should render proper warning message', () => {
+        expect(view.html()).toContain('You can remove this repo only if you registered the name');
+      });
+
+      it('should render Sign in button', () => {
+        expect(view.find('Button').prop('children')).toEqual('Sign in');
+      });
+    });
+
+    context('when user is signed in', () => {
+      beforeEach(function() {
+        view.setProps({ isAuthenticated: true });
+      });
+
+      context('when user owns registered name', () => {
+        beforeEach(function() {
+          view.setProps({ isOwnerOfRegisteredName: true });
+        });
+
+        it('should render proper warning message', () => {
+          expect(view.html()).toContain('Are you sure you want to remove this repo from the list?');
+        });
+
+        it('should render Remove button', () => {
+          expect(view.find('Button').prop('children')).toEqual('Remove');
+        });
+      });
+
+      context('when user does not own registered name', () => {
+        beforeEach(function() {
+          view.setProps({ isOwnerOfRegisteredName: false });
+        });
+
+        it('should render proper warning message', () => {
+          expect(view.html()).toContain('To remove this repo, contact the person who registered the name');
+        });
+
+        it('should render Remove button', () => {
+          expect(view.find('Button').length).toEqual(0);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #646

Final UI part of #646. If repo has registered name user needs to sign in before removing it.
Only user who registered the name is able to remove given repo.

<img width="1061" alt="screen shot 2017-05-11 at 14 26 36" src="https://cloud.githubusercontent.com/assets/83575/25949017/55c41e48-3656-11e7-8d88-e5071204edb1.png">
<img width="1059" alt="screen shot 2017-05-11 at 14 27 32" src="https://cloud.githubusercontent.com/assets/83575/25949018/55c593ae-3656-11e7-86be-1807529c3689.png">
