### PR TITLE
Work around ols-jenkaas build-charm failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,9 @@ git-build: EXTRA_CHARM_BUILD_ARGS = --force
 git-build: build $(GIT_CHARMREPODIR)
 	rsync -a -m --ignore-times --delete --exclude-from build-exclude.txt  $(CHARMDIR)/ $(CHARMREPODIR)/
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git add .
-	# XXX cjwatson 2017-05-12: This is clearly the wrong place for this,
-	# but works around an ols-jenkaas bug.
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.name 'Ubuntu One Auto Copilot'
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.email otto-copilot@canonical.com
-	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
+	# XXX cjwatson 2017-05-12: Setting EMAIL here is clearly the wrong
+	# place for this, but works around an ols-jenkaas bug.
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) EMAIL=otto-copilot@canonical.com git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git push origin $(BUILDBRANCH)
 
 .PHONY: version-info build deploy clean check-git-build-vars git-build

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ git-build: EXTRA_CHARM_BUILD_ARGS = --force
 git-build: build $(GIT_CHARMREPODIR)
 	rsync -a -m --ignore-times --delete --exclude-from build-exclude.txt  $(CHARMDIR)/ $(CHARMREPODIR)/
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git add .
+	# XXX cjwatson 2017-05-12: This is clearly the wrong place for this,
+	# but works around an ols-jenkaas bug.
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.name 'Ubuntu One Auto Copilot'
+	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git config user.email otto-copilot@canonical.com
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git commit -am "Build of $(NAME) from $(GIT_HEAD_HASH)"
 	cd $(CHARMREPODIR) && GIT_DIR=$(GIT_CHARMREPODIR) git push origin $(BUILDBRANCH)
 


### PR DESCRIPTION
ols-jenkaas is set up such that code running in the containers doesn't
currently have a git identity configured, so the build-charm jobs
sometimes fail depending on whether git manages to auto-detect some
semblance of a reasonable identity.  Work around this by forcing the
correct identity, although this is hardcoding production configuration
that ought to live elsewhere.