### PR TITLE
Fix Repository row deletion with PostgreSQL

### DIFF
--- a/src/server/handlers/launchpad.js
+++ b/src/server/handlers/launchpad.js
@@ -802,12 +802,12 @@ export const deleteSnap = async (req, res) => {
           { transacting: trx }
         );
       }
-      // Model.destroy doesn't support DELETE FROM ... WHERE ..., so we have
-      // to drop down to the Knex level.
-      await db.knex('Repository')
-        .transacting(trx)
+      const dbRepository = await db.model('Repository')
         .where({ owner, name })
-        .del();
+        .fetch({ transacting: trx });
+      if (dbRepository) {
+        await dbRepository.destroy({ transacting: trx });
+      }
       await snap.lp_delete();
 
       const urlPrefix = getRepoUrlPrefix(owner);


### PR DESCRIPTION
The manual Knex deletion code we were using previously apparently
compiles to something that isn't quite syntactically valid for
PostgreSQL, so fall back to a slower Bookshelf-based fetch/destroy pair
instead.