### PR TITLE
Fix error handling in callApi middleware

### DIFF
--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -7,7 +7,7 @@ export const CALL_API = 'CALL_API';
 // Performs the call and promises when such actions are dispatched. This
 // has been implemented using promises because of suspected problems with
 // sourcemapping async / await code.
-export default defaults => () => next => action => {
+export default (defaults) => () => (next) => (action) => {
   // If action does not invoke CALL_API,
   // ignore it
   const settings = action[CALL_API];
@@ -42,35 +42,24 @@ export default defaults => () => next => action => {
               }
 
               if (successType) {
-                return next(createAction({
+                next(createAction({
                   type: successType,
                   payload: {
                     response: result
                   }
                 }));
-              } else {
-                return Promise.resolve(result);
               }
+
+              // resolve promise with response JSON
+              return result;
             });
-        })
-        .catch((error) => {
-          if (failureType) {
-            return  next(createAction({
-              type: failureType,
-              payload: {
-                error: error
-              },
-              error: true
-            }));
-          } else {
-            error.action = action;
-            return Promise.reject(error);
-          }
         });
     })
     .catch((error) => {
       if (failureType) {
-        return next(createAction({
+        // if type of failure action is defined in settings
+        // catch the error and pass it in failure action payload
+        next(createAction({
           type: failureType,
           payload: {
             error: error
@@ -78,8 +67,8 @@ export default defaults => () => next => action => {
           error: true
         }));
       } else {
-        error.action = action;
-        return Promise.reject(error);
+        // otherwise, reject the promise with error
+        throw error;
       }
     });
 };

--- a/src/common/middleware/call-api.js
+++ b/src/common/middleware/call-api.js
@@ -42,47 +42,45 @@ export default defaults => () => next => action => {
               }
 
               if (successType) {
-                next(createAction({
+                return next(createAction({
                   type: successType,
                   payload: {
                     response: result
                   }
                 }));
+              } else {
+                return Promise.resolve(result);
               }
-
-              return Promise.resolve(result);
             });
         })
         .catch((error) => {
           if (failureType) {
-            next(createAction({
+            return  next(createAction({
               type: failureType,
               payload: {
                 error: error
               },
               error: true
             }));
+          } else {
+            error.action = action;
+            return Promise.reject(error);
           }
-
-          error.action = action;
-
-          return Promise.reject(error);
         });
     })
     .catch((error) => {
       if (failureType) {
-        next(createAction({
+        return next(createAction({
           type: failureType,
           payload: {
             error: error
           },
           error: true
         }));
+      } else {
+        error.action = action;
+        return Promise.reject(error);
       }
-
-      error.action = action;
-
-      return Promise.reject(error);
     });
 };
 

--- a/src/common/reducers/snap-builds.js
+++ b/src/common/reducers/snap-builds.js
@@ -52,7 +52,7 @@ export function snapBuilds(state = {}, action) {
           ...state[action.payload.id],
           isFetching: false,
           success: false,
-          error: action.payload.response.payload.error
+          error: action.payload.error
         }
       };
     default:

--- a/test/unit/src/common/reducers/t_snap-builds.js
+++ b/test/unit/src/common/reducers/t_snap-builds.js
@@ -172,11 +172,7 @@ describe('snapBuilds reducers', () => {
       type: ActionTypes.FETCH_BUILDS_ERROR,
       payload: {
         id,
-        response: {
-          payload: {
-            error: 'Something went wrong!'
-          }
-        }
+        error: 'Something went wrong!'
       },
       error: true
     };
@@ -186,7 +182,7 @@ describe('snapBuilds reducers', () => {
         ...state[id],
         isFetching: false,
         success: false,
-        error: action.payload.response.payload.error
+        error: action.payload.error
       });
     });
   });


### PR DESCRIPTION
Fixes #774 

What seemed to be just a small issue with getting error in reducer turned out to be a bigger issue with our `callApi` middleware.

This middleware currently both dispatches an action of given type and returns a promise (resolved if fetch is successful or rejected in case of an error).
The problem was, that in most cases when we handle API responses and expect reducer to handle the error we didn't expect and catch the rejected promise. Which resulted in uncaught promise rejections almost every time API returned an error (even when we 'expected' it and passed to reducer).

So, as the main part of this PR the call API middleware needed to change a bit so it either dispatches an action (if given a type) or returns a resolved/rejected promise (if action type is not given as setup).