### PR TITLE
Redirect users on sign in based on if they ever added a snap

### DIFF
--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -89,6 +89,7 @@ export const verify = (req, res, next) => {
       orgs
     };
 
+    let hasAddedSnaps = false;
 
     // Save user info to DB
     await db.transaction(async (trx) => {
@@ -108,13 +109,20 @@ export const verify = (req, res, next) => {
         if (dbUser.hasChanged()) {
           await dbUser.save({}, { transacting: trx });
         }
+
+        hasAddedSnaps = dbUser.attributes.snaps_added > 0;
       } catch (error) {
         return next(error);
       }
     });
 
-    // Redirect to logged in URL
-    res.redirect(`/user/${req.session.user.login}`);
+    // if user has added any snaps before go to "My repos"
+    if (hasAddedSnaps) {
+      res.redirect(`/user/${req.session.user.login}`);
+    }
+
+    // otherwise go to "Add repos"
+    res.redirect('/select-repositories');
   });
 };
 

--- a/src/server/handlers/github-auth.js
+++ b/src/server/handlers/github-auth.js
@@ -110,7 +110,7 @@ export const verify = (req, res, next) => {
           await dbUser.save({}, { transacting: trx });
         }
 
-        hasAddedSnaps = dbUser.attributes.snaps_added > 0;
+        hasAddedSnaps = dbUser.get('snaps_added') > 0;
       } catch (error) {
         return next(error);
       }


### PR DESCRIPTION
Fixes #780

Using metrics data (number of added snaps) to redirect users on sign in: to select-repositories if they never added any snap or to dashboard if they have (or did have) any snaps.

As discussed in #780 this will have a consequence that users will not be able to get to clean 'first time' state after they add any repo - unless we remove their data directly from the database.

This PR will allow to fix #675 without workarounds introduced in #782.