### PR TITLE
Fixes #703, changing 'Doesn't match' to 'Name mismatch'.

### DIFF
--- a/src/common/components/repository-row/index.js
+++ b/src/common/components/repository-row/index.js
@@ -366,7 +366,7 @@ export class RepositoryRowView extends Component {
       content = <span>Not configured</span>;
     } else if (snapNameIsMismatched(snap)){
       onClick = this.onNameMismatchClick.bind(this);
-      content = <span><ErrorIcon /> Doesn’t match</span>;
+      content = <span><ErrorIcon /> Name mismatch</span>;
     } else {
       onClick = this.onConfiguredClick.bind(this);
       content = <TickIcon />;


### PR DESCRIPTION
This makes the message more specific without making it longer.